### PR TITLE
ci: use release notes template to avoid shell escape corruption

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Azure Functions Skills v${VERSION}
+
+AI assistant plugins for Azure Functions — one-command setup for GitHub Copilot, Claude Code, and Codex.
+
+### Install with npm
+
+```bash
+npx @agent-loom/azure-functions-skills@${VERSION} setup
+npx @agent-loom/azure-functions-skills@${VERSION} chat
+```
+
+### Install without npm
+
+Download the zip for your AI assistant and extract it into your project root:
+
+| Assistant | Download |
+|-----------|----------|
+| GitHub Copilot | `azure-functions-skills-ghcp-${VERSION}.zip` |
+| Claude Code | `azure-functions-skills-claude-${VERSION}.zip` |
+| Codex | `azure-functions-skills-codex-${VERSION}.zip` |
+
+### What's new
+
+See the auto-generated changelog below.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,26 +44,19 @@ jobs:
           zip -r "../azure-functions-skills-claude-${VERSION}.zip" claude/
           zip -r "../azure-functions-skills-codex-${VERSION}.zip" codex/
 
+      - name: Render release notes
+        run: |
+          export VERSION="${GITHUB_REF_NAME#v}"
+          envsubst '${VERSION}' < .github/RELEASE_NOTES_TEMPLATE.md > release_notes.md
+          echo "--- Rendered release notes ---"
+          cat release_notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          body_path: release_notes.md
           files: |
             azure-functions-skills-ghcp-*.zip
             azure-functions-skills-claude-*.zip
             azure-functions-skills-codex-*.zip
-          body: |
-            ## Install without npm
-
-            Download the zip for your AI assistant and extract it into your project:
-
-            | Assistant | Download | Extract to |
-            |-----------|----------|------------|
-            | **GitHub Copilot** | `azure-functions-skills-ghcp-${{ github.ref_name }}.zip` | Project root |
-            | **Claude Code** | `azure-functions-skills-claude-${{ github.ref_name }}.zip` | Project root |
-            | **Codex** | `azure-functions-skills-codex-${{ github.ref_name }}.zip` | Project root |
-
-            ### Quick install (with npm)
-            ```bash
-            npx @agent-loom/azure-functions-skills setup
-            ```


### PR DESCRIPTION
## Summary

Harden the publish workflow so GitHub Release notes can never again be mangled by shell escape interpretation, and fix the v0.8.0 release body as a side effect.

Closes #6

## What happened in v0.8.0

The v0.8.0 `publish.yml` run ended in failure, so the release was created manually (most likely via a shell that ran something resembling `gh release create --notes "..."`). During that path, backticks were turned into backslashes and then the result was re-interpreted as C-style escapes, producing artifacts like:

~~~
\\ash                                           <- came from ```bash
| GitHub Copilot | \^Gzure-...zip\ |             <- came from `azure-...
~~~

`\b` became a literal backspace that ate the following `b`, and `\a` became BEL (ASCII 7) which prints as `^G`. The v0.8.0 release body has been restored to the intended Markdown via the API as part of this fix.

## Changes

- New `.github/RELEASE_NOTES_TEMPLATE.md` with a `${VERSION}` placeholder. Release notes are now source-controlled and reviewed like any other change.
- `publish.yml`:
  - New "Render release notes" step that uses `envsubst '${VERSION}'` to substitute the version, restricted to only that variable so unrelated text is never touched.
  - `softprops/action-gh-release@v2` now receives `body_path: release_notes.md` instead of an inline `body: |` block.
  - `generate_release_notes: true` is kept, so GitHub's auto-generated changelog is appended below the template.

## Why this prevents recurrence

- The release body is produced by `envsubst` in a controlled GitHub Actions shell step, so no human copy/paste through interactive shells can corrupt it.
- Inline YAML `body: |` is gone, so there is no multi-line string that could be accidentally routed through a shell with escape interpretation.
- Any future changes to the release template go through a PR and get reviewed.

## Verification

- Local simulation: rendering the template with `VERSION=0.9.0` produces the expected Markdown; no placeholders other than `${VERSION}` exist in the file.
- `envsubst '${VERSION}'` is allowlisted, so other dollar-brace sequences (none today, but robust for future edits) will not be substituted.
- Next release (v0.8.1 or v0.9.0) will exercise this end-to-end.

## Out of scope

- Re-running the `publish.yml` workflow for v0.8.0 is not done here; the release body has been corrected in place via API.
- A broader release checklist doc could live under `docs/`; happy to follow up if desired.
