### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE


### PR DESCRIPTION
## Summary

Add the Microsoft-standard MIT `LICENSE` file at the repository root.

Closes #7
Closes #1

## Why

- `package.json` already declares `"license": "MIT"` but the repository has no `LICENSE` file.
- The microsoft-github-policy-service bot flagged this in #1.
- GitHub and npm both expect a top-level `LICENSE` file to render the license badge and surface it in search results.

## Contents

Byte-exact copy of [microsoft/repo-templates/shared/LICENSE](https://github.com/microsoft/repo-templates/blob/main/shared/LICENSE):

- MIT License
- Copyright holder: Microsoft Corporation
- Filename: `LICENSE` (no extension) — the canonical form recognized by GitHub and npm

No other files change.

## Verification

- Once merged, GitHub should auto-detect the license and show an "MIT License" badge on the repo landing page.
- #1 and #7 will auto-close via the `Closes` keywords above.
