### PR TITLE
azure-functions-create: use templates MCP as primary, func as fallback (closes #9)

### DIFF
--- a/docs/prd-docs/f19-mcp-integration.md
+++ b/docs/prd-docs/f19-mcp-integration.md
@@ -1,6 +1,6 @@
-# F19: MCP Integration — Template & Runtime MCP Server
+# F19: MCP Integration — Azure MCP Server
 
-**Status:** 🚧 Partially Implemented (Layer 1 — Templates MCP wired into `azure-functions-create`)
+**Status:** ✅ Implemented (Layer 1 — Azure MCP Server wired into `azure-functions-create`)
 **Draft Spec Section:** N/A (discovered from func-emulate F6/F10)
 **Depends on:** F1 (Skill Graph Metadata), F5 (azure-functions-create)
 
@@ -11,29 +11,28 @@ For AI coding agents to access Azure Functions templates and function metadata, 
 1. **Embed patterns in skill files** — Static; skills need updating whenever templates change
 2. **Search web documentation** — Slow, inaccurate, and risks hallucination
 
-func-emulate solved this problem through **MCP (Model Context Protocol) servers**: exposing template catalogs, project scaffolding, and SKU profiles as MCP tools that AI agents can access programmatically.
+The solution is **MCP (Model Context Protocol) servers**: exposing template catalogs, project scaffolding, and runtime metadata as MCP tools that AI agents can access programmatically.
 
-The `azure-functions-templates-mcp-server` (by Manvir Kaur) already exists, providing 68+ templates across 4 languages via MCP. `azure-functions-skills` needs to design integration with this server so all skills can reference it.
+The official [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) now includes Azure Functions tools natively, providing 68+ templates across 6 languages (C#, Java, JavaScript, Python, TypeScript, PowerShell). `azure-functions-skills` integrates with these tools so all skills can reference them.
 
 ## Feature
 
-Integration design with MCP servers. Enables skills to leverage MCP tools for template search, code generation, and SKU compatibility checks.
+Integration design with the Azure MCP Server. Enables skills to leverage MCP tools for template search, code generation, and Azure resource management.
 
 ## Two Integration Layers
 
-### Layer 1: Templates MCP (existing external server)
+### Layer 1: Azure MCP Server — Azure Functions tools (implemented)
 
-Incorporating the Azure Functions Templates MCP Server into the skill ecosystem.
+The Azure MCP Server includes Azure Functions tools for template discovery and project scaffolding.
 
-**Available MCP Tools:**
+**Available Azure Functions MCP Tools:**
 
 | Tool | Description | Consuming Skills |
 |------|------------|-----------------|
-| `get_languages_list` | List of supported languages (runtime versions, template count) | azure-functions-create, azure-functions-help |
-| `get_project_template` | Project initialization files (host.json, package.json, etc.) | azure-functions-create |
-| `get_azure_functions_templates_list` | Template list by language (descriptions, categories) | azure-functions-create, azure-functions-help |
-| `get_azure_functions_template` | Full template source code + required app settings | azure-functions-create |
-| `get_sku_profile` | SKU profile (host/bundle versions) — *future* | azure-functions-hosting, azure-functions-audit |
+| `functions language list` | Discover supported languages, runtime versions, and prerequisites | azure-functions-create, azure-functions-help |
+| `functions project get` | Project initialization files (host.json, package.json, etc.) | azure-functions-create |
+| `functions list or get template` | List templates (omit template name) or get full template code (include template name) | azure-functions-create, azure-functions-help |
+| `function app list or get` | List or get details of existing Azure Functions apps | azure-functions-deploy, azure-functions-discovery |
 
 **Automatic MCP configuration generation:**
 
@@ -43,10 +42,10 @@ During `azure-functions-setup` (F3) workspace configuration, MCP settings are pl
 // .vscode/mcp.json (GitHub Copilot)
 {
   "servers": {
-    "azure-functions-templates": {
+    "azure": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "manvir-templates-mcp-server"]
+      "args": ["-y", "@azure/mcp@latest", "server", "start"]
     }
   }
 }
@@ -56,9 +55,9 @@ During `azure-functions-setup` (F3) workspace configuration, MCP settings are pl
 // .claude/settings.json (Claude Code)
 {
   "mcpServers": {
-    "azure-functions-templates": {
+    "azure": {
       "command": "npx",
-      "args": ["-y", "manvir-templates-mcp-server"]
+      "args": ["-y", "@azure/mcp@latest", "server", "start"]
     }
   }
 }
@@ -79,22 +78,21 @@ This layer can be implemented by wrapping the `/admin/functions` API from `func 
 
 ## Skill × MCP Integration Matrix
 
-How each skill utilizes MCP tools:
+How each skill utilizes Azure MCP tools:
 
-| Skill | MCP Tool | Purpose |
+| Skill | Azure MCP Tool | Purpose |
 |-------|----------|---------|
-| **azure-functions-create** (F5) | `get_languages_list`, `get_azure_functions_templates_list`, `get_azure_functions_template`, `get_project_template` | Template search, code generation, project scaffolding |
-| **azure-functions-help** (F2) | `get_languages_list`, `get_azure_functions_templates_list` | Display available template lists |
-| **azure-functions-hosting** (F8) | `get_sku_profile` | Retrieve SKU-specific constraint information |
-| **azure-functions-audit** (F18) | `get_sku_profile` | SKU compatibility checks |
-| **azure-functions-discovery** (F4) | `get_sku_profile` | Detailed information for detected SKU |
+| **azure-functions-create** (F5) | `functions language list`, `functions list or get template`, `functions project get` | Template search, code generation, project scaffolding |
+| **azure-functions-help** (F2) | `functions language list`, `functions list or get template` | Display available template lists |
+| **azure-functions-deploy** (F7) | `function app list or get` | Discover existing function apps |
+| **azure-functions-discovery** (F4) | `function app list or get` | Detailed information for detected apps |
 
 ## MCP Availability Detection
 
-Skills detect whether MCP tools are available and fall back to embedded patterns if not:
+Skills detect whether Azure MCP tools are available and fall back to embedded patterns if not:
 
 ```
-MCP tools available?
+Azure MCP tools available?
 ├── Yes → Retrieve templates via MCP (latest, accurate)
 └── No → Use embedded patterns/examples within the skill (static but reliable)
 ```

--- a/docs/prd-docs/f19-mcp-integration.md
+++ b/docs/prd-docs/f19-mcp-integration.md
@@ -1,7 +1,7 @@
 # F19: MCP Integration — Template & Runtime MCP Server
 
-**Status:** 📋 Proposed  
-**Draft Spec Section:** N/A (discovered from func-emulate F6/F10)  
+**Status:** 🚧 Partially Implemented (Layer 1 — Templates MCP wired into `azure-functions-create`)
+**Draft Spec Section:** N/A (discovered from func-emulate F6/F10)
 **Depends on:** F1 (Skill Graph Metadata), F5 (azure-functions-create)
 
 ## Problem
@@ -31,9 +31,9 @@ Incorporating the Azure Functions Templates MCP Server into the skill ecosystem.
 |------|------------|-----------------|
 | `get_languages_list` | List of supported languages (runtime versions, template count) | azure-functions-create, azure-functions-help |
 | `get_project_template` | Project initialization files (host.json, package.json, etc.) | azure-functions-create |
-| `get_templates_list` | Template list by language (descriptions, categories) | azure-functions-create, azure-functions-help |
-| `get_template` | Full template source code + required app settings | azure-functions-create |
-| `get_sku_profile` | SKU profile (host/bundle versions) | azure-functions-hosting, azure-functions-audit |
+| `get_azure_functions_templates_list` | Template list by language (descriptions, categories) | azure-functions-create, azure-functions-help |
+| `get_azure_functions_template` | Full template source code + required app settings | azure-functions-create |
+| `get_sku_profile` | SKU profile (host/bundle versions) — *future* | azure-functions-hosting, azure-functions-audit |
 
 **Automatic MCP configuration generation:**
 
@@ -46,7 +46,7 @@ During `azure-functions-setup` (F3) workspace configuration, MCP settings are pl
     "azure-functions-templates": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "azure-functions-templates-mcp-server"]
+      "args": ["-y", "manvir-templates-mcp-server"]
     }
   }
 }
@@ -58,7 +58,7 @@ During `azure-functions-setup` (F3) workspace configuration, MCP settings are pl
   "mcpServers": {
     "azure-functions-templates": {
       "command": "npx",
-      "args": ["-y", "azure-functions-templates-mcp-server"]
+      "args": ["-y", "manvir-templates-mcp-server"]
     }
   }
 }
@@ -83,8 +83,8 @@ How each skill utilizes MCP tools:
 
 | Skill | MCP Tool | Purpose |
 |-------|----------|---------|
-| **azure-functions-create** (F5) | `get_languages_list`, `get_templates_list`, `get_template`, `get_project_template` | Template search, code generation, project scaffolding |
-| **azure-functions-help** (F2) | `get_languages_list`, `get_templates_list` | Display available template lists |
+| **azure-functions-create** (F5) | `get_languages_list`, `get_azure_functions_templates_list`, `get_azure_functions_template`, `get_project_template` | Template search, code generation, project scaffolding |
+| **azure-functions-help** (F2) | `get_languages_list`, `get_azure_functions_templates_list` | Display available template lists |
 | **azure-functions-hosting** (F8) | `get_sku_profile` | Retrieve SKU-specific constraint information |
 | **azure-functions-audit** (F18) | `get_sku_profile` | SKU compatibility checks |
 | **azure-functions-discovery** (F4) | `get_sku_profile` | Detailed information for detected SKU |

--- a/docs/prd-docs/f5-azure-functions-create.md
+++ b/docs/prd-docs/f5-azure-functions-create.md
@@ -37,7 +37,7 @@ The skill instructs the agent to **never write function code from scratch** when
 
 ### Path B — Composition Algorithm Fallback (explicit)
 
-When the Azure MCP tools are not detected, the skill falls back to the **composition algorithm** from `plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md`. This provides a comprehensive, step-by-step process for scaffolding projects using `azd init -t` with base templates and integration recipes (Cosmos DB, Event Hubs, Durable Functions, etc.), including proper UAMI configuration and IaC composition. Minimal per-language HTTP trigger snippets remain available in `references/language-snippets.md` as a last-resort fallback.
+When the Azure MCP tools are not detected, the skill falls back to the **manifest-based composition algorithm** from `composition.md`. This fetches the template manifest from `cdn.functions.azure.com` (or GitHub fallback), filters by language/resource/IaC, downloads templates, and composes them — including IaC merge, RBAC roles, and UAMI configuration. This ensures the agent can still produce production-ready projects without MCP. Minimal per-language HTTP trigger snippets remain available in `references/language-snippets.md` as a last-resort fallback when the manifest is also unavailable.
 
 ## Workflow
 
@@ -55,7 +55,7 @@ When the Azure MCP tools are not detected, the skill falls back to the **composi
 
 4. Generate project files
    → Path A: functions project get + functions list or get template (Azure MCP)
-   → Path B: composition algorithm (azd init -t + recipes)
+   → Path B: manifest-based composition (CDN fetch + template download + compose)
 
 5. Post-creation suggestions (from graph metadata)
    → "Next: azure-functions-deploy to deploy, or azure-functions-observability to set up monitoring"

--- a/docs/prd-docs/f5-azure-functions-create.md
+++ b/docs/prd-docs/f5-azure-functions-create.md
@@ -35,9 +35,9 @@ When the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mc
 
 The skill instructs the agent to **never write function code from scratch** when these tools are available.
 
-### Path B — `func` CLI Fallback (explicit)
+### Path B — Composition Algorithm Fallback (explicit)
 
-When the Azure MCP tools are not detected, the skill falls back to `func init` + `func new` and shows an explicit bilingual notice to the user that guides them toward enabling the Azure MCP Server. Minimal per-language code examples live in `references/language-snippets.md` (loaded via the `references/` mechanism added in #8), keeping the main `SKILL.md` lean.
+When the Azure MCP tools are not detected, the skill falls back to the **composition algorithm** from `plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md`. This provides a comprehensive, step-by-step process for scaffolding projects using `azd init -t` with base templates and integration recipes (Cosmos DB, Event Hubs, Durable Functions, etc.), including proper UAMI configuration and IaC composition. Minimal per-language HTTP trigger snippets remain available in `references/language-snippets.md` as a last-resort fallback.
 
 ## Workflow
 
@@ -55,7 +55,7 @@ When the Azure MCP tools are not detected, the skill falls back to `func init` +
 
 4. Generate project files
    → Path A: functions project get + functions list or get template (Azure MCP)
-   → Path B: func init + func new (CLI)
+   → Path B: composition algorithm (azd init -t + recipes)
 
 5. Post-creation suggestions (from graph metadata)
    → "Next: azure-functions-deploy to deploy, or azure-functions-observability to set up monitoring"

--- a/docs/prd-docs/f5-azure-functions-create.md
+++ b/docs/prd-docs/f5-azure-functions-create.md
@@ -1,8 +1,8 @@
 # F5: azure-functions-create — Project Scaffolding
 
-**Status:** 📋 Proposed  
-**Draft Spec Section:** 5.1, 6, 8  
-**Depends on:** F1 (Skill Graph Metadata), F3 (azure-functions-setup recommended first)
+**Status:** ✅ Implemented (MCP-primary with `func` fallback)
+**Draft Spec Section:** 5.1, 6, 8
+**Depends on:** F1 (Skill Graph Metadata), F3 (azure-functions-setup recommended first), F19 (MCP Integration)
 
 ## Problem
 
@@ -17,6 +17,27 @@ After setting up the environment, the developer's next question is "how do I cre
 3. **Project structure** — `host.json`, language-specific config, `.gitignore`, entry point
 4. **Programming model** — v2 (Python/Node) vs. traditional, isolated worker (.NET)
 5. **Post-creation next steps** — directed transitions to `azure-functions-deploy`, `azure-functions-observability`, `azure-functions-hosting`
+
+## Execution Paths (MCP-Primary)
+
+The skill is designed with a clear primary / fallback split so it works across the full matrix of agent capabilities:
+
+### Path A — MCP Primary (preferred)
+
+When the [`azure-functions-templates` MCP server](https://www.npmjs.com/package/manvir-templates-mcp-server) (Manvir Kaur) is wired into the agent, use it as the authoritative source of truth. This server ships 68+ officially maintained templates across C#, Java, Python, TypeScript and exposes four composable tools:
+
+| Step | MCP Tool | Purpose |
+|------|----------|---------|
+| Discover languages | `get_languages_list` | Supported languages + runtime versions + template counts |
+| Browse templates | `get_azure_functions_templates_list` | Language-specific template catalog with descriptions and categories |
+| Initialize project | `get_project_template` | Returns `host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, etc. |
+| Add function | `get_azure_functions_template` | Full function source code + required app settings + additional packages |
+
+The skill instructs the agent to **never write function code from scratch** when these tools are available.
+
+### Path B — `func` CLI Fallback (explicit)
+
+When the MCP server is not detected, the skill falls back to `func init` + `func new` and shows an explicit bilingual notice to the user that guides them toward enabling the MCP. Minimal per-language code examples live in `references/language-snippets.md` (loaded via the `references/` mechanism added in #8), keeping the main `SKILL.md` lean.
 
 ## Workflow
 
@@ -33,7 +54,8 @@ After setting up the environment, the developer's next question is "how do I cre
    → HTTP trigger (default) | Timer | Blob | Queue | Cosmos DB | Event Hub | ...
 
 4. Generate project files
-   → host.json, local.settings.json, language files, .gitignore
+   → Path A: get_project_template + get_azure_functions_template (MCP)
+   → Path B: func init + func new (CLI)
 
 5. Post-creation suggestions (from graph metadata)
    → "Next: azure-functions-deploy to deploy, or azure-functions-observability to set up monitoring"

--- a/docs/prd-docs/f5-azure-functions-create.md
+++ b/docs/prd-docs/f5-azure-functions-create.md
@@ -24,20 +24,20 @@ The skill is designed with a clear primary / fallback split so it works across t
 
 ### Path A — MCP Primary (preferred)
 
-When the [`azure-functions-templates` MCP server](https://www.npmjs.com/package/manvir-templates-mcp-server) (Manvir Kaur) is wired into the agent, use it as the authoritative source of truth. This server ships 68+ officially maintained templates across C#, Java, Python, TypeScript and exposes four composable tools:
+When the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) is wired into the agent, use it as the authoritative source of truth. This server ships 68+ officially maintained templates across C#, Java, JavaScript, Python, TypeScript, and PowerShell, and exposes three composable tools:
 
-| Step | MCP Tool | Purpose |
+| Step | Azure MCP Tool | Purpose |
 |------|----------|---------|
-| Discover languages | `get_languages_list` | Supported languages + runtime versions + template counts |
-| Browse templates | `get_azure_functions_templates_list` | Language-specific template catalog with descriptions and categories |
-| Initialize project | `get_project_template` | Returns `host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, etc. |
-| Add function | `get_azure_functions_template` | Full function source code + required app settings + additional packages |
+| Discover languages | `functions language list` | Supported languages + runtime versions + prerequisites |
+| Browse templates | `functions list or get template` (omit template name) | Language-specific template catalog with descriptions |
+| Initialize project | `functions project get` | Returns `host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, etc. |
+| Add function | `functions list or get template` (with template name) | Full function source code + required app settings + additional packages |
 
 The skill instructs the agent to **never write function code from scratch** when these tools are available.
 
 ### Path B — `func` CLI Fallback (explicit)
 
-When the MCP server is not detected, the skill falls back to `func init` + `func new` and shows an explicit bilingual notice to the user that guides them toward enabling the MCP. Minimal per-language code examples live in `references/language-snippets.md` (loaded via the `references/` mechanism added in #8), keeping the main `SKILL.md` lean.
+When the Azure MCP tools are not detected, the skill falls back to `func init` + `func new` and shows an explicit bilingual notice to the user that guides them toward enabling the Azure MCP Server. Minimal per-language code examples live in `references/language-snippets.md` (loaded via the `references/` mechanism added in #8), keeping the main `SKILL.md` lean.
 
 ## Workflow
 
@@ -54,7 +54,7 @@ When the MCP server is not detected, the skill falls back to `func init` + `func
    → HTTP trigger (default) | Timer | Blob | Queue | Cosmos DB | Event Hub | ...
 
 4. Generate project files
-   → Path A: get_project_template + get_azure_functions_template (MCP)
+   → Path A: functions project get + functions list or get template (Azure MCP)
    → Path B: func init + func new (CLI)
 
 5. Post-creation suggestions (from graph metadata)

--- a/templates/agents/functions-guide.agent.md
+++ b/templates/agents/functions-guide.agent.md
@@ -13,7 +13,7 @@ You are the Azure Functions development guide. Your job is to understand what th
 
 You have access to the following MCP server — use it proactively:
 
-- **azure**: Use Azure MCP tools for template discovery (`functions language list`, `functions project get`, `functions list or get template`), deployment, resource management, and configuration. Always use these tools instead of guessing template code.
+- **azure**: Use Azure MCP tools for template discovery (`functions language list`, `functions project get`, `functions list or get template`), best practices (`get_azure_bestpractices` with `resource: azurefunctions`), deployment, resource management, and configuration. Always use these tools instead of guessing template code.
 
 ## Available Skills
 

--- a/templates/agents/functions-guide.agent.md
+++ b/templates/agents/functions-guide.agent.md
@@ -3,7 +3,6 @@ name: functions-guide
 description: "Azure Functions development guide — routes you to the right skill based on your goals and project context. Use @functions-guide for guided assistance."
 tools:
   - "*"
-  - "azure-functions-templates/*"
 ---
 
 # Azure Functions Guide
@@ -12,10 +11,9 @@ You are the Azure Functions development guide. Your job is to understand what th
 
 ## MCP Tools Available
 
-You have access to the following MCP servers — use them proactively:
+You have access to the following MCP server — use it proactively:
 
-- **azure-functions-templates**: Use `get_languages_list`, `get_templates_list`, `get_template`, and `get_project_template` to help users discover and create functions. Always use these tools instead of guessing template code.
-- **azure**: Use Azure MCP tools for deployment, resource management, and configuration.
+- **azure**: Use Azure MCP tools for template discovery (`functions language list`, `functions project get`, `functions list or get template`), deployment, resource management, and configuration. Always use these tools instead of guessing template code.
 
 ## Available Skills
 

--- a/templates/mcp/servers.yaml
+++ b/templates/mcp/servers.yaml
@@ -2,16 +2,9 @@
 # These are embedded into target-specific MCP config files by the build system.
 
 servers:
-  - id: azure-functions-templates
-    name: "Azure Functions Templates"
-    description: "Template discovery and scaffolding for Azure Functions"
-    type: stdio
-    command: npx
-    args: ["-y", "manvir-templates-mcp-server"]
-
   - id: azure
     name: "Azure MCP"
-    description: "Azure resource management — deploy, configure, monitor Functions apps"
+    description: "Azure resource management and Azure Functions template discovery, scaffolding, deployment, and monitoring"
     type: stdio
     command: npx
     args: ["-y", "@azure/mcp@latest", "server", "start"]

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -90,7 +90,7 @@ Use this path **only when the Azure MCP tools are not available**. When falling 
 
 #### B.1 Fallback algorithm
 
-Follow the **Fallback Path (Azure MCP Unavailable)** algorithm below (sourced from [composition.md](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md)):
+Follow this manifest-based fallback algorithm:
 
 ```
 1. FETCH MANIFEST

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -18,7 +18,11 @@ Check whether the following Azure MCP tools are available in your current tool l
 - `functions project get`
 - `functions list or get template`
 
-These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) and cover 68+ officially maintained templates across C#, Java, JavaScript, Python, TypeScript, and PowerShell.
+These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) and return officially maintained templates across C#, Python, TypeScript, JavaScript, Java and PowerShell.
+
+Also check for the best practices tool:
+
+- `get_azure_bestpractices` with `resource: azurefunctions`
 
 - **If available** → proceed with **Path A (MCP primary)**.
 - **If not available** → proceed with **Path B (composition algorithm fallback)**.
@@ -29,11 +33,21 @@ These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/d
 
 Use the Azure MCP Server as the **authoritative source of truth** for Azure Functions templates. Do **not** write function code from scratch when these tools are available.
 
-#### A.1 Gather requirements
+#### A.1 Gather requirements & best practices
+
+If `get_azure_bestpractices` is available, call it first:
+
+```
+Tool: get_azure_bestpractices
+resource: azurefunctions
+action: code-generation
+```
+
+Apply the returned guidelines (programming models, extension bundles version, authentication levels, project structure, etc.) to every file you generate in the steps below.
 
 Ask the user (or detect from context):
 
-- **Language**: `csharp` | `java` | `javascript` | `python` | `typescript` | `powershell`
+- **Language**: `csharp` | `python` | `typescript` | `javascript` | `java` | `powershell`
 - **Trigger / template**: let the MCP list decide (step A.3)
 - **Project name**: directory name
 - **Runtime version** (optional): e.g. Node.js `22`, Python `3.11`, Java `21`

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -90,7 +90,7 @@ Use this path **only when the Azure MCP tools are not available**. When falling 
 
 #### B.1 Fallback algorithm
 
-Follow the **Fallback Path (Azure MCP Unavailable)** section in [composition.md](plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md):
+Follow the **Fallback Path (Azure MCP Unavailable)** algorithm below (sourced from [composition.md](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md)):
 
 ```
 1. FETCH MANIFEST

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -44,7 +44,7 @@ Call `functions language list`. Returns supported languages with runtime version
 
 #### A.3 Browse available templates
 
-Call `functions list or get template` with only the `Language` parameter (omit `Template name`). This returns the list of available templates for the chosen language with descriptions. Present the templates to the user and let them pick.
+Call `functions list or get template` with only the `language` parameter (omit `template`). This returns the list of available templates for the chosen language with descriptions. Present the templates to the user and let them pick.
 
 #### A.4 Initialize the project
 
@@ -52,20 +52,21 @@ Call `functions project get`:
 
 ```
 Tool: functions project get
-Language: <chosen language, e.g. typescript>
+language: <chosen language, e.g. typescript>
 ```
 
 Returns project-level files (`host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, `tsconfig.json`, etc.). Write these into the target directory.
 
 #### A.5 Add the function
 
-Call `functions list or get template` with both `Language` and `Template name`:
+Call `functions list or get template` with both `language` and `template`:
 
 ```
 Tool: functions list or get template
-Language: <chosen language, e.g. typescript>
-Template name: <chosen template, e.g. HTTP trigger>
-Runtime version: <optional>
+language: <chosen language, e.g. typescript>
+template: <chosen template, e.g. http-trigger-typescript-azd>
+runtime-version: <optional, e.g. 22>
+output: <optional, "New" (default) or "Add" for existing projects>
 ```
 
 Returns the full function source code plus any required app settings and additional package dependencies. Write the returned file(s) into the project and merge any extra settings into `local.settings.json` and any extra packages into the dependency manifest.

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -84,30 +84,54 @@ Then invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<Fu
 
 Use this path **only when the Azure MCP tools are not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
 
-> ℹ️ Azure MCP Server のツールが見つからないため、テンプレート合成アルゴリズムにフォールバックします。Azure MCP を有効化すると 68+ の最新テンプレートから動的に選択できます。設定方法は `azure-functions-setup` を実行してください。
+> ℹ️ Azure MCP Server のツールが見つからないため、テンプレートマニフェストからのフォールバックパスを使用します。Azure MCP を有効化すると動的にテンプレートを発見・合成できます。設定方法は `azure-functions-setup` を実行してください。
 >
-> ℹ️ Azure MCP tools were not found; falling back to the composition algorithm. Enabling the Azure MCP Server unlocks dynamic selection from 68+ up-to-date templates. Run `azure-functions-setup` to configure it.
+> ℹ️ Azure MCP tools were not found; using the manifest-based fallback path. Enabling the Azure MCP Server unlocks dynamic template discovery and composition. Run `azure-functions-setup` to configure it.
 
-#### B.1 Follow the composition algorithm
+#### B.1 Fallback algorithm
 
-Read and follow the composition algorithm at:
+Follow the **Fallback Path (Azure MCP Unavailable)** section in [composition.md](plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md):
 
 ```
-plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md
+1. FETCH MANIFEST
+   GET https://cdn.functions.azure.com/public/templates-manifest/manifest.json
+   If fetch fails → fall back to:
+     https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Template-Manifest/manifest.json
+   If both fail → fall back to known-good Azure-Samples/functions-quickstart-* repos
+   If all fail → report error and ask user to retry later
+
+2. FILTER TEMPLATES
+   Filter by: language, resource, iac
+
+3. CHECK SINGLE-TEMPLATE MATCH
+   If one template covers ALL requirements → use it alone
+
+4. SELECT TEMPLATES
+   - Trigger template (REQUIRED) — base project with IaC
+   - Binding templates (OPTIONAL) — extract patterns only
+
+5. DOWNLOAD TEMPLATES
+   For each template:
+   - If folderPath == "." → ZIP download + unzip
+   - If folderPath != "." → fetch tree + raw github url file downloads
+   - Fallback: git clone --depth 1
+
+6. COMPOSE
+   - Use trigger template as BASE
+   - EXTRACT binding patterns from binding templates
+   - MERGE IaC resources, RBAC roles and settings
+   - ADD user's custom business logic
+
+7. TRIM unused demo code (keep AzureWebJobsStorage)
+
+8. WRITE all files
+
+9. DEPLOY: azd up --no-prompt
 ```
-
-This is the **authoritative process** for composing Azure Functions projects from base templates and integration recipes. It covers:
-
-1. **Base template selection** — `azd init -t <template>` with language-specific templates (Bicep or Terraform)
-2. **Integration recipe** — Cosmos DB, Service Bus, Event Hubs, Timer, Blob, Durable, MCP, etc.
-3. **IaC module composition** — adding Bicep/Terraform modules for the chosen integration
-4. **UAMI (User Assigned Managed Identity)** — correct credential + clientId settings for all bindings
-5. **Source code replacement** — language-specific trigger code from recipe source files
-6. **Validation and deployment** — `azd up` with RBAC propagation handling
 
 #### B.2 Quick code reference
 
-For minimal HTTP trigger snippets per language (last-resort fallback when the composition algorithm is also unavailable), see [references/language-snippets.md](references/language-snippets.md).
+For minimal HTTP trigger snippets per language (last-resort fallback when the manifest is also unavailable), see [references/language-snippets.md](references/language-snippets.md).
 
 #### B.3 Verify
 
@@ -122,7 +146,7 @@ func start
 If `host.json` already exists, do **not** re-initialize. Instead:
 
 - **MCP path**: call `functions list or get template` with the same language as the existing project and specify the desired template name. Write the returned file.
-- **Composition path**: read the relevant recipe from `plugin/skills/azure-prepare/references/services/functions/templates/recipes/{integration}/source/{language}.md` and apply the source code.
+- **Fallback path**: fetch the manifest, filter for the desired template by language and resource, download the template source, and merge the function files into the existing project.
 
 ## After Creation
 

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -99,8 +99,6 @@ Then invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<Fu
 
 Use this path **only when the Azure MCP tools are not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
 
-> ℹ️ Azure MCP Server のツールが見つからないため、テンプレートマニフェストからのフォールバックパスを使用します。Azure MCP を有効化すると動的にテンプレートを発見・合成できます。設定方法は `azure-functions-setup` を実行してください。
->
 > ℹ️ Azure MCP tools were not found; using the manifest-based fallback path. Enabling the Azure MCP Server unlocks dynamic template discovery and composition. Run `azure-functions-setup` to configure it.
 
 #### B.1 Fallback algorithm

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -10,16 +10,15 @@ Ensure `func` (Azure Functions Core Tools v4) is installed. If not, suggest runn
 
 ## Workflow
 
-### Step 1 — Detect the `azure-functions-templates` MCP server
+### Step 1 — Detect Azure MCP tools
 
-Check whether the following MCP tools are available in your current tool list:
+Check whether the following Azure MCP tools are available in your current tool list:
 
-- `get_languages_list`
-- `get_project_template`
-- `get_azure_functions_templates_list`
-- `get_azure_functions_template`
+- `functions language list`
+- `functions project get`
+- `functions list or get template`
 
-These are provided by the [azure-functions-templates MCP server](https://www.npmjs.com/package/manvir-templates-mcp-server) (Manvir Kaur, 68+ officially sourced templates across C#, Java, Python, TypeScript).
+These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) and cover 68+ officially maintained templates across C#, Java, JavaScript, Python, TypeScript, and PowerShell.
 
 - **If available** → proceed with **Path A (MCP primary)**.
 - **If not available** → proceed with **Path B (func CLI fallback)** and show the fallback notice to the user.
@@ -28,46 +27,45 @@ These are provided by the [azure-functions-templates MCP server](https://www.npm
 
 ### Path A — MCP primary (recommended)
 
-Use the MCP server as the **authoritative source of truth** for Azure Functions templates. Do **not** write function code from scratch when these tools are available.
+Use the Azure MCP Server as the **authoritative source of truth** for Azure Functions templates. Do **not** write function code from scratch when these tools are available.
 
 #### A.1 Gather requirements
 
 Ask the user (or detect from context):
 
-- **Language**: `csharp` | `java` | `python` | `typescript`
+- **Language**: `csharp` | `java` | `javascript` | `python` | `typescript` | `powershell`
 - **Trigger / template**: let the MCP list decide (step A.3)
 - **Project name**: directory name
 - **Runtime version** (optional): e.g. Node.js `22`, Python `3.11`, Java `21`
 
 #### A.2 Discover supported languages
 
-Call `get_languages_list`. Returns supported languages with runtime versions, programming models, and template counts. Use this to confirm the user's language choice is supported and to suggest a default runtime version.
+Call `functions language list`. Returns supported languages with runtime versions, programming models, and prerequisites. Use this to confirm the user's language choice is supported and to suggest a default runtime version.
 
 #### A.3 Browse available templates
 
-Call `get_azure_functions_templates_list` with the chosen `language`. Present the returned templates (name, description, category) to the user and let them pick. Categories include Web APIs, Storage, Database, Streaming, Messaging, Durable Functions, AI/ML, Real-time, etc.
+Call `functions list or get template` with only the `Language` parameter (omit `Template name`). This returns the list of available templates for the chosen language with descriptions. Present the templates to the user and let them pick.
 
 #### A.4 Initialize the project
 
-Call `get_project_template`:
+Call `functions project get`:
 
 ```
-Tool: get_project_template
-language: <chosen language>
-runtimeVersion: <optional>
+Tool: functions project get
+Language: <chosen language, e.g. typescript>
 ```
 
 Returns project-level files (`host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, `tsconfig.json`, etc.). Write these into the target directory.
 
 #### A.5 Add the function
 
-Call `get_azure_functions_template`:
+Call `functions list or get template` with both `Language` and `Template name`:
 
 ```
-Tool: get_azure_functions_template
-language: <chosen language>
-template: <chosen template, e.g. HttpTrigger>
-runtimeVersion: <optional>
+Tool: functions list or get template
+Language: <chosen language, e.g. typescript>
+Template name: <chosen template, e.g. HTTP trigger>
+Runtime version: <optional>
 ```
 
 Returns the full function source code plus any required app settings and additional package dependencies. Write the returned file(s) into the project and merge any extra settings into `local.settings.json` and any extra packages into the dependency manifest.
@@ -84,18 +82,18 @@ Then invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<Fu
 
 ### Path B — func CLI fallback
 
-Use this path **only when the MCP server is not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
+Use this path **only when the Azure MCP tools are not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
 
-> ℹ️ `azure-functions-templates` MCP server が見つからないため、Azure Functions Core Tools (`func`) にフォールバックします。MCP を有効化すると 68+ の最新テンプレートから選択できます。設定方法は `azure-functions-setup` を実行してください。
+> ℹ️ Azure MCP Server のツールが見つからないため、Azure Functions Core Tools (`func`) にフォールバックします。Azure MCP を有効化すると 68+ の最新テンプレートから選択できます。設定方法は `azure-functions-setup` を実行してください。
 >
-> ℹ️ The `azure-functions-templates` MCP server was not found; falling back to Azure Functions Core Tools (`func`). Enabling the MCP unlocks selection from 68+ up-to-date templates. Run `azure-functions-setup` to configure it.
+> ℹ️ Azure MCP tools were not found; falling back to Azure Functions Core Tools (`func`). Enabling the Azure MCP Server unlocks selection from 68+ up-to-date templates. Run `azure-functions-setup` to configure it.
 
 #### B.1 Scaffold with Core Tools
 
 ```bash
 # Create project
 func init <project-name> --<language-flag>
-#   --typescript | --python | --dotnet-isolated | --java | --javascript
+#   --typescript | --python | --dotnet-isolated | --java | --javascript | --powershell
 
 # Add a function
 cd <project-name>
@@ -120,7 +118,7 @@ func start
 
 If `host.json` already exists, do **not** re-initialize. Instead:
 
-- **MCP path**: call `get_azure_functions_template` with the same language as the existing project and write the returned file.
+- **MCP path**: call `functions list or get template` with the same language as the existing project and specify the desired template name. Write the returned file.
 - **func path**: `func new --name <FunctionName> --template "<template name>"`
 
 ## After Creation

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -10,88 +10,118 @@ Ensure `func` (Azure Functions Core Tools v4) is installed. If not, suggest runn
 
 ## Workflow
 
-### 1. Gather Requirements
+### Step 1 — Detect the `azure-functions-templates` MCP server
+
+Check whether the following MCP tools are available in your current tool list:
+
+- `get_languages_list`
+- `get_project_template`
+- `get_azure_functions_templates_list`
+- `get_azure_functions_template`
+
+These are provided by the [azure-functions-templates MCP server](https://www.npmjs.com/package/manvir-templates-mcp-server) (Manvir Kaur, 68+ officially sourced templates across C#, Java, Python, TypeScript).
+
+- **If available** → proceed with **Path A (MCP primary)**.
+- **If not available** → proceed with **Path B (func CLI fallback)** and show the fallback notice to the user.
+
+---
+
+### Path A — MCP primary (recommended)
+
+Use the MCP server as the **authoritative source of truth** for Azure Functions templates. Do **not** write function code from scratch when these tools are available.
+
+#### A.1 Gather requirements
 
 Ask the user (or detect from context):
 
-- **Language**: Node.js/TypeScript (default) | Python | .NET (isolated) | Java
-- **Trigger**: HTTP (default) | Timer | Blob | Queue | Cosmos DB | Event Hub
+- **Language**: `csharp` | `java` | `python` | `typescript`
+- **Trigger / template**: let the MCP list decide (step A.3)
 - **Project name**: directory name
+- **Runtime version** (optional): e.g. Node.js `22`, Python `3.11`, Java `21`
 
-### 2. Scaffold with Core Tools
+#### A.2 Discover supported languages
+
+Call `get_languages_list`. Returns supported languages with runtime versions, programming models, and template counts. Use this to confirm the user's language choice is supported and to suggest a default runtime version.
+
+#### A.3 Browse available templates
+
+Call `get_azure_functions_templates_list` with the chosen `language`. Present the returned templates (name, description, category) to the user and let them pick. Categories include Web APIs, Storage, Database, Streaming, Messaging, Durable Functions, AI/ML, Real-time, etc.
+
+#### A.4 Initialize the project
+
+Call `get_project_template`:
+
+```
+Tool: get_project_template
+language: <chosen language>
+runtimeVersion: <optional>
+```
+
+Returns project-level files (`host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, `tsconfig.json`, etc.). Write these into the target directory.
+
+#### A.5 Add the function
+
+Call `get_azure_functions_template`:
+
+```
+Tool: get_azure_functions_template
+language: <chosen language>
+template: <chosen template, e.g. HttpTrigger>
+runtimeVersion: <optional>
+```
+
+Returns the full function source code plus any required app settings and additional package dependencies. Write the returned file(s) into the project and merge any extra settings into `local.settings.json` and any extra packages into the dependency manifest.
+
+#### A.6 Verify
+
+```bash
+func start
+```
+
+Then invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<FunctionName>`).
+
+---
+
+### Path B — func CLI fallback
+
+Use this path **only when the MCP server is not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
+
+> ℹ️ `azure-functions-templates` MCP server が見つからないため、Azure Functions Core Tools (`func`) にフォールバックします。MCP を有効化すると 68+ の最新テンプレートから選択できます。設定方法は `azure-functions-setup` を実行してください。
+>
+> ℹ️ The `azure-functions-templates` MCP server was not found; falling back to Azure Functions Core Tools (`func`). Enabling the MCP unlocks selection from 68+ up-to-date templates. Run `azure-functions-setup` to configure it.
+
+#### B.1 Scaffold with Core Tools
 
 ```bash
 # Create project
-func init <project-name> --typescript
+func init <project-name> --<language-flag>
+#   --typescript | --python | --dotnet-isolated | --java | --javascript
 
 # Add a function
 cd <project-name>
 func new --name <FunctionName> --template "HTTP trigger"
 ```
 
-### 3. Language-Specific Patterns
+Common templates: `HTTP trigger`, `Timer trigger`, `Blob trigger`, `Queue trigger`, `Cosmos DB trigger`, `Event Hub trigger`, `Service Bus trigger`.
 
-#### Node.js / TypeScript (v4 model)
+#### B.2 Fill in the function body
 
-```typescript
-import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+For quick code patterns per language (minimal examples), see [references/language-snippets.md](references/language-snippets.md).
 
-export async function httpTrigger(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-    context.log(`Http function processed request for url "${request.url}"`);
-    const name = request.query.get('name') || await request.text() || 'world';
-    return { body: `Hello, ${name}!` };
-}
-
-app.http('httpTrigger', {
-    methods: ['GET', 'POST'],
-    authLevel: 'function',
-    handler: httpTrigger
-});
-```
-
-#### Python (v2 model)
-
-```python
-import azure.functions as func
-import logging
-
-app = func.FunctionApp()
-
-@app.route(route="hello")
-def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
-    logging.info('Python HTTP trigger function processed a request.')
-    name = req.params.get('name') or 'world'
-    return func.HttpResponse(f"Hello, {name}!")
-```
-
-#### .NET (isolated worker)
-
-```csharp
-[Function("HttpTrigger")]
-public HttpResponseData Run(
-    [HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
-{
-    _logger.LogInformation("C# HTTP trigger function processed a request.");
-    var response = req.CreateResponse(HttpStatusCode.OK);
-    response.WriteString("Hello, world!");
-    return response;
-}
-```
-
-### 4. Verify
+#### B.3 Verify
 
 ```bash
 func start
-# Visit http://localhost:7071/api/<FunctionName>
 ```
 
-### 5. Adding Functions to Existing Projects
+---
 
-If `host.json` already exists, use `func new` to add functions:
+### Adding functions to existing projects
 
-```bash
-func new --name MyTimer --template "Timer trigger"
-```
+If `host.json` already exists, do **not** re-initialize. Instead:
+
+- **MCP path**: call `get_azure_functions_template` with the same language as the existing project and write the returned file.
+- **func path**: `func new --name <FunctionName> --template "<template name>"`
 
 ## After Creation
 

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -21,7 +21,7 @@ Check whether the following Azure MCP tools are available in your current tool l
 These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) and cover 68+ officially maintained templates across C#, Java, JavaScript, Python, TypeScript, and PowerShell.
 
 - **If available** → proceed with **Path A (MCP primary)**.
-- **If not available** → proceed with **Path B (func CLI fallback)** and show the fallback notice to the user.
+- **If not available** → proceed with **Path B (composition algorithm fallback)**.
 
 ---
 
@@ -80,31 +80,34 @@ Then invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<Fu
 
 ---
 
-### Path B — func CLI fallback
+### Path B — Composition algorithm fallback
 
 Use this path **only when the Azure MCP tools are not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
 
-> ℹ️ Azure MCP Server のツールが見つからないため、Azure Functions Core Tools (`func`) にフォールバックします。Azure MCP を有効化すると 68+ の最新テンプレートから選択できます。設定方法は `azure-functions-setup` を実行してください。
+> ℹ️ Azure MCP Server のツールが見つからないため、テンプレート合成アルゴリズムにフォールバックします。Azure MCP を有効化すると 68+ の最新テンプレートから動的に選択できます。設定方法は `azure-functions-setup` を実行してください。
 >
-> ℹ️ Azure MCP tools were not found; falling back to Azure Functions Core Tools (`func`). Enabling the Azure MCP Server unlocks selection from 68+ up-to-date templates. Run `azure-functions-setup` to configure it.
+> ℹ️ Azure MCP tools were not found; falling back to the composition algorithm. Enabling the Azure MCP Server unlocks dynamic selection from 68+ up-to-date templates. Run `azure-functions-setup` to configure it.
 
-#### B.1 Scaffold with Core Tools
+#### B.1 Follow the composition algorithm
 
-```bash
-# Create project
-func init <project-name> --<language-flag>
-#   --typescript | --python | --dotnet-isolated | --java | --javascript | --powershell
+Read and follow the composition algorithm at:
 
-# Add a function
-cd <project-name>
-func new --name <FunctionName> --template "HTTP trigger"
+```
+plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md
 ```
 
-Common templates: `HTTP trigger`, `Timer trigger`, `Blob trigger`, `Queue trigger`, `Cosmos DB trigger`, `Event Hub trigger`, `Service Bus trigger`.
+This is the **authoritative process** for composing Azure Functions projects from base templates and integration recipes. It covers:
 
-#### B.2 Fill in the function body
+1. **Base template selection** — `azd init -t <template>` with language-specific templates (Bicep or Terraform)
+2. **Integration recipe** — Cosmos DB, Service Bus, Event Hubs, Timer, Blob, Durable, MCP, etc.
+3. **IaC module composition** — adding Bicep/Terraform modules for the chosen integration
+4. **UAMI (User Assigned Managed Identity)** — correct credential + clientId settings for all bindings
+5. **Source code replacement** — language-specific trigger code from recipe source files
+6. **Validation and deployment** — `azd up` with RBAC propagation handling
 
-For quick code patterns per language (minimal examples), see [references/language-snippets.md](references/language-snippets.md).
+#### B.2 Quick code reference
+
+For minimal HTTP trigger snippets per language (last-resort fallback when the composition algorithm is also unavailable), see [references/language-snippets.md](references/language-snippets.md).
 
 #### B.3 Verify
 
@@ -119,7 +122,7 @@ func start
 If `host.json` already exists, do **not** re-initialize. Instead:
 
 - **MCP path**: call `functions list or get template` with the same language as the existing project and specify the desired template name. Write the returned file.
-- **func path**: `func new --name <FunctionName> --template "<template name>"`
+- **Composition path**: read the relevant recipe from `plugin/skills/azure-prepare/references/services/functions/templates/recipes/{integration}/source/{language}.md` and apply the source code.
 
 ## After Creation
 

--- a/templates/skills/azure-functions-create/references/language-snippets.md
+++ b/templates/skills/azure-functions-create/references/language-snippets.md
@@ -1,6 +1,6 @@
 # Language Snippets — Azure Functions
 
-Minimal starter patterns for HTTP triggers. Use these only as a last-resort fallback when the `azure-functions-templates` MCP server is unavailable **and** `func new` does not produce the desired shape. Prefer the MCP `get_azure_functions_template` tool whenever possible — it ships maintained, complete templates.
+Minimal starter patterns for HTTP triggers. Use these only as a last-resort fallback when the Azure MCP tools are unavailable **and** `func new` does not produce the desired shape. Prefer the `functions list or get template` Azure MCP tool whenever possible — it returns maintained, complete templates.
 
 ## TypeScript (Node.js v4 model)
 
@@ -71,4 +71,4 @@ public HttpResponseMessage run(
 ## Notes
 
 - HTTP triggers default to `authLevel: 'function'`. Use `'anonymous'` only for explicitly public endpoints.
-- For non-HTTP triggers (Timer, Blob, Queue, Service Bus, Cosmos DB, Event Hub, etc.), always prefer the MCP `get_azure_functions_template` tool — binding configuration is error-prone to write by hand.
+- For non-HTTP triggers (Timer, Blob, Queue, Service Bus, Cosmos DB, Event Hub, etc.), always prefer the `functions list or get template` Azure MCP tool — binding configuration is error-prone to write by hand.

--- a/templates/skills/azure-functions-create/references/language-snippets.md
+++ b/templates/skills/azure-functions-create/references/language-snippets.md
@@ -1,0 +1,74 @@
+# Language Snippets — Azure Functions
+
+Minimal starter patterns for HTTP triggers. Use these only as a last-resort fallback when the `azure-functions-templates` MCP server is unavailable **and** `func new` does not produce the desired shape. Prefer the MCP `get_azure_functions_template` tool whenever possible — it ships maintained, complete templates.
+
+## TypeScript (Node.js v4 model)
+
+```typescript
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+
+export async function httpTrigger(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    context.log(`Http function processed request for url "${request.url}"`);
+    const name = request.query.get('name') || await request.text() || 'world';
+    return { body: `Hello, ${name}!` };
+}
+
+app.http('httpTrigger', {
+    methods: ['GET', 'POST'],
+    authLevel: 'function',
+    handler: httpTrigger
+});
+```
+
+## Python (v2 programming model)
+
+```python
+import azure.functions as func
+import logging
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info('Python HTTP trigger function processed a request.')
+    name = req.params.get('name') or 'world'
+    return func.HttpResponse(f"Hello, {name}!")
+```
+
+## C# (.NET isolated worker)
+
+```csharp
+[Function("HttpTrigger")]
+public HttpResponseData Run(
+    [HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
+{
+    _logger.LogInformation("C# HTTP trigger function processed a request.");
+    var response = req.CreateResponse(HttpStatusCode.OK);
+    response.WriteString("Hello, world!");
+    return response;
+}
+```
+
+## Java (Maven)
+
+```java
+@FunctionName("HttpTrigger")
+public HttpResponseMessage run(
+        @HttpTrigger(
+            name = "req",
+            methods = {HttpMethod.GET, HttpMethod.POST},
+            authLevel = AuthorizationLevel.FUNCTION)
+            HttpRequestMessage<Optional<String>> request,
+        final ExecutionContext context) {
+    context.getLogger().info("Java HTTP trigger processed a request.");
+    final String name = request.getQueryParameters().getOrDefault("name", "world");
+    return request.createResponseBuilder(HttpStatusCode.OK)
+        .body("Hello, " + name + "!")
+        .build();
+}
+```
+
+## Notes
+
+- HTTP triggers default to `authLevel: 'function'`. Use `'anonymous'` only for explicitly public endpoints.
+- For non-HTTP triggers (Timer, Blob, Queue, Service Bus, Cosmos DB, Event Hub, etc.), always prefer the MCP `get_azure_functions_template` tool — binding configuration is error-prone to write by hand.

--- a/templates/skills/azure-functions-create/skill.yaml
+++ b/templates/skills/azure-functions-create/skill.yaml
@@ -6,6 +6,8 @@ targets:
   ghcp: true
   claude: true
   codex: true
+mcp_preferred:
+  - azure-functions-templates
 tags:
   - create
   - scaffold

--- a/templates/skills/azure-functions-create/skill.yaml
+++ b/templates/skills/azure-functions-create/skill.yaml
@@ -7,7 +7,7 @@ targets:
   claude: true
   codex: true
 mcp_preferred:
-  - azure-functions-templates
+  - azure
 tags:
   - create
   - scaffold

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -168,6 +168,7 @@ describe('buildTarget — ghcp', () => {
     expect(body).toMatch(/Path A/);
     expect(body).toMatch(/Path B/);
     expect(body).toContain('fallback');
+    expect(body).toContain('composition.md');
     // References file ships alongside the skill
     const refsPath = join(
       DIST_DIR, 'ghcp', '.github', 'skills', 'azure-functions-create',

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -109,7 +109,7 @@ describe('buildTarget — ghcp', () => {
     expect(existsSync(mcpPath)).toBe(true);
     const mcp = JSON.parse(readFileSync(mcpPath, 'utf-8'));
     expect(mcp.servers).toBeTruthy();
-    expect(mcp.servers['azure-functions-templates']).toBeTruthy();
+    expect(mcp.servers['azure']).toBeTruthy();
   });
 
   it('generates agent definition', () => {
@@ -160,11 +160,10 @@ describe('buildTarget — ghcp', () => {
 
     const skillPath = join(DIST_DIR, 'ghcp', '.github', 'skills', 'azure-functions-create', 'SKILL.md');
     const body = readFileSync(skillPath, 'utf-8');
-    // MCP-primary: mentions the four templates MCP tool names
-    expect(body).toContain('get_languages_list');
-    expect(body).toContain('get_project_template');
-    expect(body).toContain('get_azure_functions_templates_list');
-    expect(body).toContain('get_azure_functions_template');
+    // MCP-primary: mentions the Azure MCP tool names
+    expect(body).toContain('functions language list');
+    expect(body).toContain('functions project get');
+    expect(body).toContain('functions list or get template');
     // Path structure + fallback notice
     expect(body).toMatch(/Path A/);
     expect(body).toMatch(/Path B/);
@@ -230,7 +229,7 @@ describe('buildTarget — ghcp', () => {
     expect(existsSync(mcpPluginPath)).toBe(true);
     const mcp = JSON.parse(readFileSync(mcpPluginPath, 'utf-8'));
     expect(mcp.mcpServers).toBeTruthy();
-    expect(mcp.mcpServers['azure-functions-templates']).toBeTruthy();
+    expect(mcp.mcpServers['azure']).toBeTruthy();
   });
 
   it('generates plugin hooks.json at plugin root', () => {
@@ -342,7 +341,7 @@ describe('buildTarget — codex', () => {
     const configPath = join(DIST_DIR, 'codex', '.codex', 'config.toml');
     expect(existsSync(configPath)).toBe(true);
     const content = readFileSync(configPath, 'utf-8');
-    expect(content).toContain('[mcp_servers.azure-functions-templates]');
+    expect(content).toContain('[mcp_servers.azure]');
     expect(content).toContain('command = "npx"');
   });
 
@@ -422,8 +421,8 @@ describe('Codex plugin manifest', () => {
     const mcpPath = join(DIST_DIR, 'codex', '.mcp.json');
     expect(existsSync(mcpPath)).toBe(true);
     const mcp = JSON.parse(readFileSync(mcpPath, 'utf-8'));
-    expect(mcp['azure-functions-templates']).toBeTruthy();
-    expect(mcp['azure-functions-templates'].command).toBe('npx');
+    expect(mcp['azure']).toBeTruthy();
+    expect(mcp['azure'].command).toBe('npx');
   });
 
   it('generates marketplace.json', () => {

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -151,6 +151,32 @@ describe('buildTarget — ghcp', () => {
     }
   });
 
+  it('azure-functions-create skill is MCP-primary and ships language-snippets reference', () => {
+    const skills = loadSkills(join(TEMPLATES_DIR, 'skills'));
+    const mcpServers = loadMcpServers(join(TEMPLATES_DIR, 'mcp', 'servers.yaml'));
+    const agents = loadAgents(join(TEMPLATES_DIR, 'agents'));
+    const hooks = loadHooks(join(TEMPLATES_DIR, 'hooks'));
+    buildTarget('ghcp', { skills, mcpServers, agents, hooks }, DIST_DIR);
+
+    const skillPath = join(DIST_DIR, 'ghcp', '.github', 'skills', 'azure-functions-create', 'SKILL.md');
+    const body = readFileSync(skillPath, 'utf-8');
+    // MCP-primary: mentions the four templates MCP tool names
+    expect(body).toContain('get_languages_list');
+    expect(body).toContain('get_project_template');
+    expect(body).toContain('get_azure_functions_templates_list');
+    expect(body).toContain('get_azure_functions_template');
+    // Path structure + fallback notice
+    expect(body).toMatch(/Path A/);
+    expect(body).toMatch(/Path B/);
+    expect(body).toContain('fallback');
+    // References file ships alongside the skill
+    const refsPath = join(
+      DIST_DIR, 'ghcp', '.github', 'skills', 'azure-functions-create',
+      'references', 'language-snippets.md',
+    );
+    expect(existsSync(refsPath)).toBe(true);
+  });
+
   it('generates hooks in .github/hooks/', () => {
     const skills = loadSkills(join(TEMPLATES_DIR, 'skills'));
     const mcpServers = loadMcpServers(join(TEMPLATES_DIR, 'mcp', 'servers.yaml'));
@@ -491,8 +517,6 @@ describe('setup module', () => {
     expect(result.welcomeMessage).toContain('Azure Functions');
   });
 });
-
-// ─── references/ subdir support ───
 
 describe('skill references/ subdirectory', () => {
   const FIXTURE_DIR = join(import.meta.dirname, '..', 'dist-test-refs-fixture');

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -164,10 +164,15 @@ describe('buildTarget — ghcp', () => {
     expect(body).toContain('functions language list');
     expect(body).toContain('functions project get');
     expect(body).toContain('functions list or get template');
+    // Best practices tool reference
+    expect(body).toContain('get_azure_bestpractices');
+    expect(body).toContain('azurefunctions');
     // Path structure + fallback notice
     expect(body).toMatch(/Path A/);
     expect(body).toMatch(/Path B/);
     expect(body).toContain('fallback');
+    // Template count should NOT be hardcoded (no "68+")
+    expect(body).not.toMatch(/\d+\+?\s*officially maintained templates/);
     // References file ships alongside the skill
     const refsPath = join(
       DIST_DIR, 'ghcp', '.github', 'skills', 'azure-functions-create',

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -168,7 +168,6 @@ describe('buildTarget — ghcp', () => {
     expect(body).toMatch(/Path A/);
     expect(body).toMatch(/Path B/);
     expect(body).toContain('fallback');
-    expect(body).toContain('composition.md');
     // References file ships alongside the skill
     const refsPath = join(
       DIST_DIR, 'ghcp', '.github', 'skills', 'azure-functions-create',


### PR DESCRIPTION
# Issue #9: azure-functions-create uses Azure MCP as primary, manifest fallback

Closes #9

## Summary

Rewrites `azure-functions-create/SKILL.md` so agents use the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) as the authoritative source for Azure Functions templates, with a manifest-based composition algorithm kept as an explicit fallback.

## Two-path workflow

### Path A — MCP primary (recommended)

Used whenever the Azure MCP `functions` tools are present in the agent's tool list:

| Step | Tool | Parameters |
|------|------|------------|
| A.2 Discover supported languages | `functions language list` | _(none)_ |
| A.3 Browse templates | `functions list or get template` | `language` |
| A.4 Initialize project | `functions project get` | `language` |
| A.5 Add function | `functions list or get template` | `language`, `template`, `runtime-version` (opt), `output` (opt) |

Tool names match the Azure MCP Server's `functions` command router sub-commands (`functions_language_list`, `functions_project_get`, `functions_template_get`). See the [official docs](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions).

### Path B — Manifest-based fallback

Triggered only when the MCP is not detected. Uses a 9-step composition algorithm:

1. Fetch template manifest from `https://cdn.functions.azure.com/public/templates-manifest/manifest.json`
2. Filter by language, resource, IaC
3. Check single-template match
4. Select trigger + binding templates
5. Download templates
6. Compose (merge IaC, RBAC, settings)
7. Trim unused demo code
8. Write files
9. Deploy with `azd up`

Minimal per-language HTTP trigger snippets shipped in `references/language-snippets.md` as a last-resort fallback.

## Local verification

Tested the Azure MCP Server (`@azure/mcp@latest` v3.0.0-beta.4) locally via JSON-RPC stdio:

| Sub-command | Status | Result |
|-------------|--------|--------|
| `functions_language_list` | ✅ | Returns 6 languages (Python, TypeScript, JavaScript, Java, C#, PowerShell) with runtime versions, prerequisites, init/run/build commands |
| `functions_project_get` | ✅ | Returns project scaffolding (file structure, init instructions) per language |
| `functions_template_get` (list) | ✅ | Returns all templates with descriptions (HTTP, Timer, Blob, EventHub, Durable, Cosmos, MCP, etc.) |
| `functions_template_get` (get) | ✅ | Returns full function source code and IaC files for specific templates |

The `functions` tool is a hierarchical command router: agents call the parent `functions` tool with `command` + `parameters` sub-fields. The host platform maps these to platform-specific tool names (e.g., VS Code Copilot → `mcp_azure-functio_get_languages_list`).

## Other changes

- `servers.yaml` — single `azure` entry: `npx -y @azure/mcp@latest server start`
- `skill.yaml` — `mcp_preferred: [azure]`
- `functions-guide.agent.md` — Azure MCP tool references
- `docs/prd-docs/f5-azure-functions-create.md` — MCP-primary execution paths, status → Implemented
- `docs/prd-docs/f19-mcp-integration.md` — Layer 1 Azure MCP Server, status → ✅ Implemented
- `references/language-snippets.md` — last-resort fallback snippets via `references/` mechanism from PR #18
- `tests/build.test.js` — regression tests for MCP-primary structure (62/62 passing)

## Testing

- `npm test` — **62/62 passing**
- `npm run build` succeeds for ghcp, claude, codex
- Local MCP server verification (see table above)
