### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-loom/azure-functions-skills",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AI assistant plugins for Azure Functions — one-command setup for GitHub Copilot, Claude Code, and Codex",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bump version from 0.8.0 to 0.9.0 for the next release.

### Changes since 0.8.0 (PR #15–#19)

- **#15** feat: plugin.json manifest for all targets
- **#16** feat: MCP server declarations via servers.yaml
- **#17** feat: add MIT LICENSE
- **#18** feat: rename content.md to SKILL.md, support references/ subdir
- **#19** feat: azure-functions-create uses Azure MCP as primary, manifest fallback
  - Integrated \get_azure_bestpractices\ tool for Functions-specific guidelines
  - Removed hardcoded template counts
  - Verified all Azure MCP tools locally

### Release steps

1. Merge this PR
2. \git tag v0.9.0 && git push origin v0.9.0\
3. CI auto-publishes to npm + creates GitHub Release with artifacts