### PR TITLE
feat: add azure-functions-diagnostics skill suite

### DIFF
--- a/src/build/build-target.js
+++ b/src/build/build-target.js
@@ -35,6 +35,16 @@ function copySkillReferences(skill, skillDestDir) {
   copyDirRecursive(skill.referencesDir, join(skillDestDir, 'references'));
 }
 
+function copySkillScripts(skill, skillDestDir) {
+  if (!skill.scriptsDir) return;
+  copyDirRecursive(skill.scriptsDir, join(skillDestDir, 'scripts'));
+}
+
+function copySkillAssets(skill, skillDestDir) {
+  copySkillReferences(skill, skillDestDir);
+  copySkillScripts(skill, skillDestDir);
+}
+
 // ─── GHCP ───
 
 function buildGhcp({ skills, mcpServers, agents, hooks }, distDir) {
@@ -62,7 +72,7 @@ function buildGhcp({ skills, mcpServers, agents, hooks }, distDir) {
     const skillDir = join(base, '.github', 'skills', skill.id);
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, 'SKILL.md'), generateGhcpSkillMd(skill));
-    copySkillReferences(skill, skillDir);
+    copySkillAssets(skill, skillDir);
   }
 
   // .github/hooks/welcome-setup.json — SessionStart hook (workspace level)
@@ -84,7 +94,7 @@ function buildGhcp({ skills, mcpServers, agents, hooks }, distDir) {
     const skillDir = join(base, 'skills', skill.id);
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, 'SKILL.md'), generateGhcpSkillMd(skill));
-    copySkillReferences(skill, skillDir);
+    copySkillAssets(skill, skillDir);
   }
 
   // agents/<name>.agent.md — Plugin-level agent
@@ -123,7 +133,7 @@ function buildClaude({ skills, mcpServers, agents, hooks }, distDir) {
     const skillDir = join(base, '.claude', 'skills', skill.id);
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, 'SKILL.md'), generateClaudeSkillMd(skill));
-    copySkillReferences(skill, skillDir);
+    copySkillAssets(skill, skillDir);
   }
 }
 
@@ -143,7 +153,7 @@ function buildCodex({ skills, mcpServers, agents, hooks }, distDir) {
     const skillDir = join(base, '.agents', 'skills', skill.id);
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, 'SKILL.md'), generateCodexSkillMd(skill));
-    copySkillReferences(skill, skillDir);
+    copySkillAssets(skill, skillDir);
   }
 
   // skills/<id>/SKILL.md — plugin-convention skills (for .codex-plugin)
@@ -151,7 +161,7 @@ function buildCodex({ skills, mcpServers, agents, hooks }, distDir) {
     const skillDir = join(base, 'skills', skill.id);
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, 'SKILL.md'), generateCodexSkillMd(skill));
-    copySkillReferences(skill, skillDir);
+    copySkillAssets(skill, skillDir);
   }
 
   // .codex-plugin/plugin.json — plugin manifest

--- a/src/build/loader.js
+++ b/src/build/loader.js
@@ -20,6 +20,10 @@ export function loadSkills(skillsDir) {
     const referencesDir =
       existsSync(refsPath) && statSync(refsPath).isDirectory() ? refsPath : null;
 
+    const scriptsPath = join(base, 'scripts');
+    const scriptsDir =
+      existsSync(scriptsPath) && statSync(scriptsPath).isDirectory() ? scriptsPath : null;
+
     return {
       id: parseYamlValue(skillYaml, 'id'),
       title: parseYamlValue(skillYaml, 'title'),
@@ -28,6 +32,7 @@ export function loadSkills(skillsDir) {
       content,
       graph: parseGraph(graphYaml),
       referencesDir,
+      scriptsDir,
       raw: { skill: skillYaml, graph: graphYaml },
     };
   });

--- a/templates/skills/azure-functions-common/SKILL.md
+++ b/templates/skills/azure-functions-common/SKILL.md
@@ -1,0 +1,22 @@
+# Azure Functions Common References
+
+Use this suite-internal skill as the shared reference pack for Azure Functions skills.
+
+This skill is intentionally workflow-light. Do not load all references up front. Use [routing.md](references/routing.md) to choose only the runtime/language and trigger/binding reference files needed for the current task.
+
+## Scope
+
+Shared references include:
+
+- Language/runtime references in `references/languages/`.
+- Trigger/binding extension references in `references/extensions/`.
+- Routing rules in `references/routing.md`.
+
+Task-specific skills keep their own workflows, scripts, evidence checklists, and output formats. For example, diagnostics owns diagnostic workflow and health evidence rules; this skill only owns reusable Azure Functions reference material.
+
+## Loading rules
+
+- Load exactly one language reference when the runtime is known, plus Durable only when Durable is involved.
+- Load only extension references matching the app's triggers/bindings or the symptom.
+- Load Extension Bundles only for non-.NET apps or extension-version/binding-resolution symptoms.
+- Prefer official documentation, official repositories, official samples, and package/container registries before broader web sources.

--- a/templates/skills/azure-functions-common/graph.yaml
+++ b/templates/skills/azure-functions-common/graph.yaml
@@ -1,0 +1,7 @@
+id: azure-functions-common
+title: Azure Functions Common References
+suggestions:
+  on_success: []
+  on_failure: []
+entry_conditions:
+  - shared_reference_required

--- a/templates/skills/azure-functions-common/references/extensions/azure-tables.md
+++ b/templates/skills/azure-functions-common/references/extensions/azure-tables.md
@@ -1,0 +1,26 @@
+# Azure Functions Diagnostics Reference — Azure Tables
+
+Use this file when investigating Table input/output bindings, connection, SDK type binding behavior, or table data access issues.
+
+## Bindings
+
+- `table`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Tables extension and SDK code paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and indexing behavior |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/tables` and shared paths `sdk/core`, `sdk/identity`, and `sdk/extensions`.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Table bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |

--- a/templates/skills/azure-functions-common/references/extensions/cosmos-db.md
+++ b/templates/skills/azure-functions-common/references/extensions/cosmos-db.md
@@ -1,0 +1,33 @@
+# Azure Functions Diagnostics Reference — Cosmos DB
+
+Use this file when investigating Cosmos DB trigger/input-output binding, leases, change feed, connection, throughput, or scale behavior.
+
+## Bindings
+
+- `cosmosDBTrigger`
+- `cosmosDB`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-webjobs-sdk-extensions | https://github.com/Azure/azure-webjobs-sdk-extensions | Cosmos DB extension implementation |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and scale behavior |
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Newer SDK integration paths when relevant |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/cosmosdb` when the issue involves SDK integration.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Cosmos DB bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2 |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |
+
+## Investigation guidance
+
+- Include Cosmos DB in message-trigger investigations when the symptom involves change feed processing, leases, throughput, or trigger latency.
+- For scale symptoms, inspect `azure-webjobs-sdk-extensions` under `src/WebJobs.Extensions.CosmosDB` and host scale behavior.

--- a/templates/skills/azure-functions-common/references/extensions/dapr.md
+++ b/templates/skills/azure-functions-common/references/extensions/dapr.md
@@ -1,0 +1,32 @@
+# Azure Functions Diagnostics Reference — Dapr
+
+Use this file when investigating Dapr bindings, Dapr service invocation, Dapr pub/sub, Dapr state, Dapr secret, or topic trigger behavior in Azure Functions.
+
+## Bindings
+
+- `daprBinding`
+- `daprBindingTrigger`
+- `daprInvoke`
+- `daprPublish`
+- `daprSecret`
+- `daprServiceInvocationTrigger`
+- `daprState`
+- `daprTopicTrigger`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Extension and SDK integration paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Dapr extension bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-dapr |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+
+## Investigation notes
+
+- If package versions are resolved through extension bundles, also check the extension bundle reference.

--- a/templates/skills/azure-functions-common/references/extensions/durable-functions.md
+++ b/templates/skills/azure-functions-common/references/extensions/durable-functions.md
@@ -1,0 +1,33 @@
+# Azure Functions Diagnostics Reference — Durable Functions Extension
+
+Use this file when investigating Durable Functions triggers/bindings, orchestrations, activities, entities, durable clients, task hubs, or storage providers.
+
+## Bindings
+
+- `activityTrigger`
+- `orchestrationTrigger`
+- `entityTrigger`
+- `durableClient`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-durable-extension | https://github.com/Azure/azure-functions-durable-extension | Durable Functions extension |
+| durabletask | https://github.com/Azure/durabletask | Durable Task Framework and Azure Storage provider |
+| durabletask-mssql | https://github.com/microsoft/durabletask-mssql | SQL Server storage provider |
+| durabletask-netherite | https://github.com/microsoft/durabletask-netherite | Netherite/Event Hubs storage provider |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Durable Functions overview | https://learn.microsoft.com/en-us/azure/azure-functions/durable-functions/durable-functions-overview |
+| Durable Task overview | https://learn.microsoft.com/en-us/azure/durable-task/common/what-is-durable-task |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+
+## Investigation guidance
+
+- Search public GitHub issues in `Azure/azure-functions-durable-extension`, `Azure/durabletask`, and `Azure/azure-functions-host` first.
+- Add language-specific Durable repos when the app language is known.
+- Add provider repos when SQL Server or Netherite is configured.

--- a/templates/skills/azure-functions-common/references/extensions/event-grid.md
+++ b/templates/skills/azure-functions-common/references/extensions/event-grid.md
@@ -1,0 +1,31 @@
+# Azure Functions Diagnostics Reference — Event Grid
+
+Use this file when investigating Event Grid trigger/output binding, validation, delivery, retry, or event schema issues.
+
+## Bindings
+
+- `eventGridTrigger`
+- `eventGrid`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Event Grid extension and SDK code paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and indexing behavior |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/eventgrid` and shared paths `sdk/core`, `sdk/identity`, and `sdk/extensions`.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Event Grid bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation notes
+
+- Include HTTP/host behavior when Event Grid validation or endpoint delivery is involved.

--- a/templates/skills/azure-functions-common/references/extensions/event-hubs.md
+++ b/templates/skills/azure-functions-common/references/extensions/event-hubs.md
@@ -1,0 +1,32 @@
+# Azure Functions Diagnostics Reference — Event Hubs
+
+Use this file when investigating Event Hubs trigger/output binding, checkpoints, partition ownership, connection, throughput, or scale behavior.
+
+## Bindings
+
+- `eventHubTrigger`
+- `eventHub`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Event Hubs extension and SDK code paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and scale behavior |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/eventhub` and shared paths `sdk/core`, `sdk/identity`, and `sdk/extensions`.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Event Hubs bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |
+
+## Investigation guidance
+
+- Include Event Hubs in message-trigger investigations when the symptom involves checkpoints, partition ownership, throughput, or trigger latency.
+- For scale symptoms, inspect `azure-sdk-for-net` under `sdk/eventhub` and host scale behavior.

--- a/templates/skills/azure-functions-common/references/extensions/extension-bundles.md
+++ b/templates/skills/azure-functions-common/references/extensions/extension-bundles.md
@@ -1,0 +1,24 @@
+# Azure Functions Diagnostics Reference — Extension Bundles
+
+Use this file when investigating extension version resolution for non-.NET Azure Functions apps or when a binding issue may be caused by the extension bundle version.
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-extension-bundles | https://github.com/Azure/azure-functions-extension-bundles | Extension bundle packaging and package list |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host extension loading behavior |
+
+## Public references
+
+| Topic | URL |
+|------|-----|
+| Extension bundle repository | https://github.com/Azure/azure-functions-extension-bundles |
+| Extension bundle v4 package list | https://github.com/Azure/azure-functions-extension-bundles/blob/main/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json |
+| App settings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+
+## Investigation guidance
+
+- Use this reference for non-.NET apps where extensions are loaded from bundles instead of explicit package references.
+- Include extension bundle metadata when investigating deployment, extension loading, binding resolution, or non-.NET package-version symptoms.

--- a/templates/skills/azure-functions-common/references/extensions/fabric.md
+++ b/templates/skills/azure-functions-common/references/extensions/fabric.md
@@ -1,0 +1,28 @@
+# Azure Functions Diagnostics Reference — Fabric
+
+Use this file when investigating Fabric-related Azure Functions bindings or user data function context behavior.
+
+## Bindings
+
+- `FabricItem`
+- `UdfProperty`
+- `UserDataFunctionContext`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Extension and SDK integration paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation notes
+
+- No public Functions-specific Fabric binding page was found in reviewed source material or Microsoft Learn sources.
+- If package versions are resolved through extension bundles, also check the extension bundle reference.

--- a/templates/skills/azure-functions-common/references/extensions/http.md
+++ b/templates/skills/azure-functions-common/references/extensions/http.md
@@ -1,0 +1,28 @@
+# Azure Functions Diagnostics Reference — HTTP
+
+Use this file when investigating HTTP trigger/input-output behavior, routing, authorization level behavior, request/response handling, or host-level HTTP symptoms.
+
+## Bindings
+
+- `httpTrigger`
+- `http`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host HTTP pipeline, routing, indexing, authorization integration |
+| azure-webjobs-sdk | https://github.com/Azure/azure-webjobs-sdk | Core binding framework |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| HTTP trigger and bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation notes
+
+- HTTP issues often cross host, language worker, and language SDK boundaries.
+- Include the relevant language file when the issue involves request body parsing, response serialization, streaming, or middleware.

--- a/templates/skills/azure-functions-common/references/extensions/kafka.md
+++ b/templates/skills/azure-functions-common/references/extensions/kafka.md
@@ -1,0 +1,29 @@
+# Azure Functions Diagnostics Reference — Kafka
+
+Use this file when investigating Kafka trigger/output binding, broker connectivity, consumer group behavior, offset behavior, or extension-specific failures.
+
+## Bindings
+
+- `kafkaTrigger`
+- `kafka`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-kafka-extension | https://github.com/Azure/azure-functions-kafka-extension | Kafka extension implementation |
+| confluent-kafka-dotnet | https://github.com/confluentinc/confluent-kafka-dotnet | Kafka .NET client dependency |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and scale behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Kafka bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-kafka |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |
+
+## Investigation guidance
+
+- Treat Kafka extension investigations as a dedicated path because symptoms often involve broker configuration, consumer group behavior, and the Confluent client dependency.
+- Include Kafka extension code when investigating scale behavior.

--- a/templates/skills/azure-functions-common/references/extensions/mcp.md
+++ b/templates/skills/azure-functions-common/references/extensions/mcp.md
@@ -1,0 +1,28 @@
+# Azure Functions Diagnostics Reference — MCP
+
+Use this file when investigating Model Context Protocol-related Azure Functions bindings.
+
+## Bindings
+
+- `mcpToolTrigger`
+- `mcpToolProperty`
+- `mcpResourceTrigger`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Extension and SDK integration paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation notes
+
+- No public Functions-specific MCP binding page was found in reviewed source material or Microsoft Learn sources.
+- Exclude internal MCP service references from external diagnostics documentation.

--- a/templates/skills/azure-functions-common/references/extensions/mysql.md
+++ b/templates/skills/azure-functions-common/references/extensions/mysql.md
@@ -1,0 +1,27 @@
+# Azure Functions Diagnostics Reference — MySQL
+
+Use this file when investigating MySQL input/output binding or MySQL trigger behavior.
+
+## Bindings
+
+- `MySql`
+- `MySqlTrigger`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Extension and SDK integration paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| MySQL bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-azure-mysql |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |
+
+## Investigation notes
+
+- If the issue involves package resolution from a non-.NET app, also check the extension bundle reference.

--- a/templates/skills/azure-functions-common/references/extensions/rabbitmq.md
+++ b/templates/skills/azure-functions-common/references/extensions/rabbitmq.md
@@ -1,0 +1,30 @@
+# Azure Functions Diagnostics Reference — RabbitMQ
+
+Use this file when investigating RabbitMQ trigger/output binding, broker connectivity, queue behavior, authentication, or extension-specific failures.
+
+## Bindings
+
+- `rabbitMQTrigger`
+- `rabbitMQ`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-rabbitmq-extension | https://github.com/Azure/azure-functions-rabbitmq-extension | RabbitMQ extension implementation |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| RabbitMQ bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-rabbitmq |
+| RabbitMQ extension wiki | https://github.com/Azure/azure-functions-rabbitmq-extension/wiki |
+| RabbitMQ getting started | https://www.rabbitmq.com/getstarted.html |
+| .NET RabbitMQ client API guide | https://www.rabbitmq.com/dotnet-api-guide.html |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+
+## Investigation guidance
+
+- Use the public RabbitMQ docs and the extension wiki as primary references for broker behavior and language samples.
+- Treat RabbitMQ extension investigations as a dedicated path because symptoms often involve broker connectivity, queue behavior, and authentication.

--- a/templates/skills/azure-functions-common/references/extensions/redis.md
+++ b/templates/skills/azure-functions-common/references/extensions/redis.md
@@ -1,0 +1,29 @@
+# Azure Functions Diagnostics Reference — Redis
+
+Use this file when investigating Redis triggers, Redis output binding, pub/sub, streams, list trigger behavior, connection, or scale behavior.
+
+## Bindings
+
+- `redisPubSubTrigger`
+- `redisStreamTrigger`
+- `redisListTrigger`
+- `redis`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-redis-extension | https://github.com/Azure/azure-functions-redis-extension | Redis extension implementation |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and scale behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Redis bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cache |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |
+
+## Investigation guidance
+
+- Include `azure-functions-redis-extension` when investigating Redis scale symptoms, trigger latency, pub/sub, stream, or list trigger behavior.

--- a/templates/skills/azure-functions-common/references/extensions/sendgrid.md
+++ b/templates/skills/azure-functions-common/references/extensions/sendgrid.md
@@ -1,0 +1,21 @@
+# Azure Functions Diagnostics Reference — SendGrid
+
+Use this file when investigating SendGrid output binding behavior, package resolution, configuration, or message delivery from Azure Functions.
+
+## Bindings
+
+- `sendGrid`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-webjobs-sdk-extensions | https://github.com/Azure/azure-webjobs-sdk-extensions | SendGrid extension implementation |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| SendGrid binding | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-sendgrid |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |

--- a/templates/skills/azure-functions-common/references/extensions/service-bus.md
+++ b/templates/skills/azure-functions-common/references/extensions/service-bus.md
@@ -1,0 +1,34 @@
+# Azure Functions Diagnostics Reference — Service Bus
+
+Use this file when investigating Service Bus trigger/output binding, sessions, settlement, lock renewal, connection, or scale behavior.
+
+## Bindings
+
+- `serviceBusTrigger`
+- `serviceBus`
+
+## Public repositories
+
+| Repository | URL | Use |
+| ----------- | ----- | ----- |
+| azure-webjobs-sdk | <https://github.com/Azure/azure-webjobs-sdk> | Core binding pipeline, trigger indexing, and name resolution |
+| azure-sdk-for-net | <https://github.com/Azure/azure-sdk-for-net> | Service Bus extension and SDK code paths |
+| azure-functions-host | <https://github.com/Azure/azure-functions-host> | Host/runtime and scale behavior |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/servicebus` and shared paths `sdk/core`, `sdk/identity`, and `sdk/extensions`.
+
+## Public documentation
+
+| Topic | URL |
+| ------ | ----- |
+| Service Bus bindings | <https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus> |
+| Best practices | <https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices> |
+| Manage connections | <https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections> |
+
+## Investigation guidance
+
+- Include Service Bus in message-trigger investigations when the symptom involves delivery, sessions, lock renewal, settlement, retries, or trigger latency.
+- Include `azure-webjobs-sdk` when the symptom involves binding indexing, `%SETTING%` name resolution, binding metadata, or core trigger pipeline behavior.
+- For scale symptoms, inspect `azure-sdk-for-net` under `sdk/servicebus` and host scale behavior.

--- a/templates/skills/azure-functions-common/references/extensions/signalr.md
+++ b/templates/skills/azure-functions-common/references/extensions/signalr.md
@@ -1,0 +1,30 @@
+# Azure Functions Diagnostics Reference — SignalR Service
+
+Use this file when investigating SignalR output binding, trigger, connection info, negotiation, endpoints, or messaging behavior.
+
+## Bindings
+
+- `signalR`
+- `signalRTrigger`
+- `signalRConnectionInfo`
+- `signalREndpoints`
+- `signalRNegotiation`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | SignalR extension and SDK code paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/signalr` and shared paths `sdk/core`, `sdk/identity`, and `sdk/extensions`.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| SignalR Service bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |

--- a/templates/skills/azure-functions-common/references/extensions/sql.md
+++ b/templates/skills/azure-functions-common/references/extensions/sql.md
@@ -1,0 +1,27 @@
+# Azure Functions Diagnostics Reference — SQL
+
+Use this file when investigating Azure SQL input/output binding, SQL trigger, change tracking, connection, or scale behavior.
+
+## Bindings
+
+- `Sql`
+- `SqlTrigger`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-sql-extension | https://github.com/Azure/azure-functions-sql-extension | SQL extension implementation |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and scale behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| SQL bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-azure-sql |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |
+
+## Investigation guidance
+
+- Include `azure-functions-sql-extension` when investigating SQL scale symptoms, trigger latency, or change tracking behavior.

--- a/templates/skills/azure-functions-common/references/extensions/storage-blob.md
+++ b/templates/skills/azure-functions-common/references/extensions/storage-blob.md
@@ -1,0 +1,33 @@
+# Azure Functions Diagnostics Reference — Storage Blob
+
+Use this file when investigating Blob trigger, Blob input/output binding, polling, receipts, connection, or scale behavior.
+
+## Bindings
+
+- `blobTrigger`
+- `blob`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-webjobs-sdk | https://github.com/Azure/azure-webjobs-sdk | Storage extension and binding framework |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and indexing behavior |
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Storage SDK and newer extension code paths |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/storage` when the issue involves Storage SDK or extension internals.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Blob bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob |
+| Recover a storage account | https://learn.microsoft.com/en-us/azure/azure-functions/functions-recover-storage-account |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+
+## Investigation guidance
+
+- Include Blob in message-trigger investigations when the symptom involves event delivery, retries, or trigger latency.
+- For scale symptoms, inspect Storage extension code paths and host scale behavior.

--- a/templates/skills/azure-functions-common/references/extensions/storage-queue.md
+++ b/templates/skills/azure-functions-common/references/extensions/storage-queue.md
@@ -1,0 +1,33 @@
+# Azure Functions Diagnostics Reference — Storage Queue
+
+Use this file when investigating Queue trigger, Queue output binding, poison messages, visibility timeout, connection, or scale behavior.
+
+## Bindings
+
+- `queueTrigger`
+- `queue`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-webjobs-sdk | https://github.com/Azure/azure-webjobs-sdk | Storage Queue extension and binding framework |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime and indexing behavior |
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Storage SDK and newer extension code paths |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/storage` when the issue involves Storage SDK or extension internals.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Queue bindings | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue |
+| Recover a storage account | https://learn.microsoft.com/en-us/azure/azure-functions/functions-recover-storage-account |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+
+## Investigation guidance
+
+- Include Queue in message-trigger investigations when the symptom involves event delivery, retries, poison messages, or trigger latency.
+- For scale symptoms, inspect Storage extension code paths and host scale behavior.

--- a/templates/skills/azure-functions-common/references/extensions/timer.md
+++ b/templates/skills/azure-functions-common/references/extensions/timer.md
@@ -1,0 +1,27 @@
+# Azure Functions Diagnostics Reference — Timer
+
+Use this file when investigating timer trigger schedule, missed execution, singleton, host ID, storage, or schedule monitor issues.
+
+## Bindings
+
+- `timerTrigger`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-webjobs-sdk-extensions | https://github.com/Azure/azure-webjobs-sdk-extensions | Timer extension implementation |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host scheduling, startup, and runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Timer trigger | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation notes
+
+- Timer behavior can depend on host storage and host ID configuration.
+- Check host logs before assuming language-worker behavior.

--- a/templates/skills/azure-functions-common/references/extensions/twilio.md
+++ b/templates/skills/azure-functions-common/references/extensions/twilio.md
@@ -1,0 +1,21 @@
+# Azure Functions Diagnostics Reference — Twilio
+
+Use this file when investigating Twilio SMS output binding behavior, package resolution, configuration, or message delivery from Azure Functions.
+
+## Bindings
+
+- `twilioSms`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-webjobs-sdk-extensions | https://github.com/Azure/azure-webjobs-sdk-extensions | Twilio extension implementation |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Twilio binding | https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-twilio |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |

--- a/templates/skills/azure-functions-common/references/extensions/web-pubsub.md
+++ b/templates/skills/azure-functions-common/references/extensions/web-pubsub.md
@@ -1,0 +1,29 @@
+# Azure Functions Diagnostics Reference — Web PubSub
+
+Use this file when investigating Web PubSub bindings, triggers, connection, request, or messaging behavior.
+
+## Bindings
+
+- `webPubSub`
+- `webPubSubTrigger`
+- `webPubSubConnection`
+- `webPubSubRequest`
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Web PubSub extension and SDK code paths |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior |
+
+## Sparse checkout guidance
+
+For `azure-sdk-for-net`, use `sdk/webpubsub` and shared paths `sdk/core`, `sdk/identity`, and `sdk/extensions`.
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Web PubSub bindings | https://learn.microsoft.com/en-us/azure/web-pubsub/reference-functions-bindings |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Manage connections | https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections |

--- a/templates/skills/azure-functions-common/references/languages/csharp.md
+++ b/templates/skills/azure-functions-common/references/languages/csharp.md
@@ -1,0 +1,43 @@
+# Azure Functions Diagnostics Reference — C# / .NET
+
+Use this file when investigating Azure Functions issues involving C# apps, .NET isolated worker, .NET in-process apps, binding behavior in C#, or .NET runtime/package support.
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-dotnet-worker | https://github.com/Azure/azure-functions-dotnet-worker | .NET isolated worker |
+| azure-functions-vs-build-sdk | https://github.com/Azure/azure-functions-vs-build-sdk | Build SDK and Visual Studio integration |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior that affects .NET apps |
+| azure-webjobs-sdk | https://github.com/Azure/azure-webjobs-sdk | In-process model and binding pipeline |
+| azure-webjobs-sdk-extensions | https://github.com/Azure/azure-webjobs-sdk-extensions | Timer, Cosmos DB, SendGrid, Twilio, and extension behavior |
+| azure-sdk-for-net | https://github.com/Azure/azure-sdk-for-net | Azure SDK-based Functions extensions |
+
+## Sparse checkout guidance
+
+Use this `azure-sdk-for-net` scope when the issue crosses .NET code and extension packages:
+
+```text
+sdk/core, sdk/identity, sdk/extensions, sdk/storage,
+sdk/eventgrid, sdk/eventhub, sdk/servicebus,
+sdk/signalr, sdk/tables, sdk/cosmosdb, sdk/webpubsub
+```
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| .NET isolated process guide | https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide |
+| .NET in-process class library guide | https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library |
+| Migrate from in-process to isolated | https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model |
+| Performance optimizations | https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide#performance-optimizations |
+| Supported languages | https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation guidance
+
+- Start with `azure-functions-dotnet-worker` for isolated-worker startup, middleware, dependency injection, serialization, and invocation issues.
+- Use `azure-webjobs-sdk` and `azure-webjobs-sdk-extensions` for binding pipeline and in-process behavior.
+- Use `azure-functions-host` for runtime, scale, indexing, configuration, and cross-language host issues.
+- Check container image tags and supported language docs when the issue involves runtime support, EOL, or base images.

--- a/templates/skills/azure-functions-common/references/languages/durable-functions.md
+++ b/templates/skills/azure-functions-common/references/languages/durable-functions.md
@@ -1,0 +1,33 @@
+# Azure Functions Diagnostics Reference — Durable Functions
+
+Use this file when investigating Durable Functions issues that cross language boundaries, orchestration behavior, Durable Task Framework behavior, or Durable storage providers.
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-durable-extension | https://github.com/Azure/azure-functions-durable-extension | Durable Functions extension |
+| durabletask | https://github.com/Azure/durabletask | Durable Task Framework and Azure Storage provider |
+| durabletask-dotnet | https://github.com/microsoft/durabletask-dotnet | Durable Task SDK for .NET |
+| azure-functions-durable-js | https://github.com/Azure/azure-functions-durable-js | Durable Functions SDK for JavaScript/TypeScript |
+| azure-functions-durable-python | https://github.com/Azure/azure-functions-durable-python | Durable Functions SDK for Python |
+| durabletask-python | https://github.com/microsoft/durabletask-python | Durable Task SDK for Python |
+| durabletask-java | https://github.com/microsoft/durabletask-java | Durable Task SDK for Java |
+| azure-functions-durable-powershell | https://github.com/Azure/azure-functions-durable-powershell | Durable Functions SDK for PowerShell |
+| durabletask-mssql | https://github.com/microsoft/durabletask-mssql | SQL Server storage provider |
+| durabletask-netherite | https://github.com/microsoft/durabletask-netherite | Netherite/Event Hubs storage provider |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| Durable Functions overview | https://learn.microsoft.com/en-us/azure/azure-functions/durable-functions/durable-functions-overview |
+| Durable Task overview | https://learn.microsoft.com/en-us/azure/durable-task/common/what-is-durable-task |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation guidance
+
+- Search public GitHub issues in `Azure/azure-functions-durable-extension`, `Azure/durabletask`, and `Azure/azure-functions-host` first.
+- Add language-specific Durable repos when the app language is known.
+- Add `microsoft/durabletask-mssql` or `microsoft/durabletask-netherite` when the storage backend is known.

--- a/templates/skills/azure-functions-common/references/languages/java.md
+++ b/templates/skills/azure-functions-common/references/languages/java.md
@@ -1,0 +1,32 @@
+# Azure Functions Diagnostics Reference — Java
+
+Use this file when investigating Azure Functions issues involving Java apps, the Java worker, annotations, Maven deployment, Java dependency versions, or Java runtime support.
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-java-worker | https://github.com/Azure/azure-functions-java-worker | Java worker runtime, gRPC server, loader, invocation handling |
+| azure-functions-java-library | https://github.com/Azure/azure-functions-java-library | Java annotations and Azure Functions types |
+| azure-functions-java-additions | https://github.com/Azure/azure-functions-java-additions | Java core library, SDK types, optional libraries |
+| azure-maven-plugins | https://github.com/microsoft/azure-maven-plugins | Maven deployment and build integration |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior that affects Java apps |
+
+## Public documentation and registries
+
+| Topic | URL |
+|------|-----|
+| Java developer guide | https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java |
+| Quarkus integration | https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-first-quarkus |
+| Spring Cloud Function on Azure | https://learn.microsoft.com/en-us/azure/developer/java/spring-framework/getting-started-with-spring-cloud-function-in-azure |
+| Maven Central | https://search.maven.org/ |
+| Supported languages | https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation guidance
+
+- Check official docs, Java worker issues/wiki, and related host/library issues before root-cause recommendations.
+- Search `Azure/azure-functions-java-worker`, `Azure/azure-functions-java-library`, and `Azure/azure-functions-host` when the issue spans worker and host boundaries.
+- Compare Maven Central metadata when dependency changes are suspected.
+- Public host PR examples for Java-related host changes: https://github.com/Azure/azure-functions-host/pull/8365, https://github.com/Azure/azure-functions-host/pull/9084, https://github.com/Azure/azure-functions-host/pull/10231.

--- a/templates/skills/azure-functions-common/references/languages/node-typescript.md
+++ b/templates/skills/azure-functions-common/references/languages/node-typescript.md
@@ -1,0 +1,31 @@
+# Azure Functions Diagnostics Reference — Node.js / TypeScript
+
+Use this file when investigating Azure Functions issues involving Node.js, TypeScript, the v4 programming model, `@azure/functions`, package versions, or Node runtime support.
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-nodejs-worker | https://github.com/Azure/azure-functions-nodejs-worker | Node.js worker runtime |
+| azure-functions-nodejs-library | https://github.com/Azure/azure-functions-nodejs-library | `@azure/functions` package and v4 programming model APIs |
+| azure-functions-nodejs-extensions | https://github.com/Azure/azure-functions-nodejs-extensions | SDK type binding extensions |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior that affects Node.js apps |
+
+## Public documentation and registries
+
+| Topic | URL |
+|------|-----|
+| Node.js developer guide | https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node |
+| Node.js troubleshooting guide | https://learn.microsoft.com/en-us/azure/azure-functions/functions-node-troubleshoot |
+| v3 to v4 migration guide | https://learn.microsoft.com/en-us/azure/azure-functions/functions-node-upgrade-v4 |
+| `@azure/functions` npm package | https://www.npmjs.com/package/@azure/functions |
+| Supported languages | https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation guidance
+
+- Prioritize `azure-functions-nodejs-library` for v4 programming model behavior.
+- Use `azure-functions-nodejs-worker` for worker startup, gRPC, invocation, and process failures.
+- Check npm package metadata and public GitHub issues before concluding root cause when package changes are part of the hypothesis.
+- Include `azure-functions-host` when trigger indexing, host startup, scale, or cross-worker behavior is involved.

--- a/templates/skills/azure-functions-common/references/languages/powershell.md
+++ b/templates/skills/azure-functions-common/references/languages/powershell.md
@@ -1,0 +1,25 @@
+# Azure Functions Diagnostics Reference — PowerShell
+
+Use this file when investigating Azure Functions issues involving PowerShell apps, the PowerShell worker, PowerShell runtime support, or PowerShell container images.
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-powershell-worker | https://github.com/Azure/azure-functions-powershell-worker | PowerShell worker runtime |
+| azure-functions-powershell-library | https://github.com/Azure/azure-functions-powershell-library | PowerShell SDK/library |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior that affects PowerShell apps |
+
+## Public documentation
+
+| Topic | URL |
+|------|-----|
+| PowerShell developer guide | https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell |
+| Supported languages | https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation guidance
+
+- Include public MCR image tags when investigating runtime support, image refresh, CVEs, or EOL-related symptoms.
+- Include `azure-functions-host` when trigger indexing, host startup, scale, or cross-worker behavior is involved.

--- a/templates/skills/azure-functions-common/references/languages/python.md
+++ b/templates/skills/azure-functions-common/references/languages/python.md
@@ -1,0 +1,32 @@
+# Azure Functions Diagnostics Reference — Python
+
+Use this file when investigating Azure Functions issues involving Python apps, the Python worker, Python package dependencies, SDK type bindings, or Python runtime support.
+
+## Public repositories
+
+| Repository | URL | Use |
+|-----------|-----|-----|
+| azure-functions-python-worker | https://github.com/Azure/azure-functions-python-worker | Python worker runtime |
+| azure-functions-python-library | https://github.com/Azure/azure-functions-python-library | `azure-functions` PyPI package |
+| azure-functions-python-extensions | https://github.com/Azure/azure-functions-python-extensions | SDK type binding extensions |
+| azure-functions-host | https://github.com/Azure/azure-functions-host | Host/runtime behavior that affects Python apps |
+
+## Public documentation and registries
+
+| Topic | URL |
+|------|-----|
+| Python developer guide | https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python |
+| Python troubleshooting guide | https://learn.microsoft.com/en-us/azure/azure-functions/recover-python-functions |
+| Python scale and performance | https://learn.microsoft.com/en-us/azure/azure-functions/python-scale-performance-reference |
+| Python build options | https://learn.microsoft.com/en-us/azure/azure-functions/python-build-options |
+| PyPI package registry | https://pypi.org/project/azure-functions/ |
+| Supported languages | https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages |
+| Best practices | https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices |
+| Diagnostics overview | https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics |
+
+## Investigation guidance
+
+- The public troubleshooting guide is the first stop for `ModuleNotFoundError`, worker indexing failures, native dependency problems, and worker process exits.
+- Check PyPI metadata when package version changes are part of the hypothesis.
+- Include `azure-functions-host` if symptoms involve indexing, trigger discovery, host startup, or scale behavior.
+- Check MCR image tags and supported language docs for runtime support and EOL issues.

--- a/templates/skills/azure-functions-common/references/routing.md
+++ b/templates/skills/azure-functions-common/references/routing.md
@@ -1,0 +1,61 @@
+# Azure Functions Common Reference Routing
+
+Use this file to choose which small reference files to load. Do not load every reference.
+
+Reference files are bundled with `azure-functions-common`:
+
+- Language references: `references/languages/`
+- Extension references: `references/extensions/`
+
+## Language routing
+
+| Inventory signal | Load |
+| ------------------ | ------ |
+| `FUNCTIONS_WORKER_RUNTIME=dotnet` or `dotnet-isolated` | `languages/csharp.md` |
+| `FUNCTIONS_WORKER_RUNTIME=python` | `languages/python.md` |
+| `FUNCTIONS_WORKER_RUNTIME=node` | `languages/node-typescript.md` |
+| `FUNCTIONS_WORKER_RUNTIME=java` | `languages/java.md` |
+| `FUNCTIONS_WORKER_RUNTIME=powershell` | `languages/powershell.md` |
+| Durable bindings, Durable package, or orchestration/entity/activity symptom | `languages/durable-functions.md` |
+
+## Extension routing
+
+For any trigger or binding investigation, include `azure-webjobs-sdk` when the symptom involves core binding pipeline behavior, trigger indexing, binding metadata, `%SETTING%` name resolution, or listener startup. Use the matching extension reference below for the extension-specific implementation repository.
+
+| Trigger / binding / symptom | Load |
+| ----------------------------- | ------ |
+| `httpTrigger`, HTTP routing, auth level, request/response | `extensions/http.md` |
+| `timerTrigger`, schedule, missed execution | `extensions/timer.md` |
+| `blobTrigger`, `blob` | `extensions/storage-blob.md` |
+| `queueTrigger`, `queue`, poison messages | `extensions/storage-queue.md` |
+| `serviceBusTrigger`, `serviceBus`, lock renewal, settlement, sessions | `extensions/service-bus.md` |
+| `eventHubTrigger`, `eventHub`, checkpoints, partition ownership | `extensions/event-hubs.md` |
+| `eventGridTrigger`, `eventGrid`, validation, delivery | `extensions/event-grid.md` |
+| `cosmosDBTrigger`, `cosmosDB`, leases, change feed | `extensions/cosmos-db.md` |
+| `table` | `extensions/azure-tables.md` |
+| Durable bindings | `extensions/durable-functions.md` |
+| `Sql`, `SqlTrigger` | `extensions/sql.md` |
+| `MySql`, `MySqlTrigger` | `extensions/mysql.md` |
+| `signalR*` | `extensions/signalr.md` |
+| `webPubSub*` | `extensions/web-pubsub.md` |
+| `kafkaTrigger`, `kafka` | `extensions/kafka.md` |
+| `rabbitMQTrigger`, `rabbitMQ` | `extensions/rabbitmq.md` |
+| `redis*` | `extensions/redis.md` |
+| `sendGrid` | `extensions/sendgrid.md` |
+| `twilioSms` | `extensions/twilio.md` |
+| `dapr*` | `extensions/dapr.md` |
+| Fabric bindings | `extensions/fabric.md` |
+| MCP bindings | `extensions/mcp.md` |
+| Non-.NET extension version, bundle loading, missing binding, binding resolution | `extensions/extension-bundles.md` |
+
+## Symptom routing
+
+| Symptom | First skills/references |
+| --------- | ------------------------- |
+| Need app specifications | `azure-functions-inventory` |
+| Current health, errors, metrics, logs, Activity Log | `azure-functions-health-status` |
+| Deployment failure | Inventory, health/status, `extensions/extension-bundles.md` if binding resolution appears in logs |
+| Function indexing failure | Inventory, health/status traces, matching language and extension references |
+| Trigger not firing | Inventory trigger list, health/status traces, matching extension reference |
+| Runtime startup failure | Inventory runtime settings, health/status traces, matching language reference |
+| Network/connectivity failure | Inventory network shape, health dependencies/traces, matching extension reference |

--- a/templates/skills/azure-functions-common/skill.yaml
+++ b/templates/skills/azure-functions-common/skill.yaml
@@ -1,0 +1,13 @@
+id: azure-functions-common
+title: Azure Functions Common References
+description: "Shared Azure Functions reference material for the Azure Functions skill suite: runtime/language routing, trigger/binding extension references, official docs and repository pointers. Use only when another Azure Functions skill needs reusable language or binding context. Not intended as a standalone user-facing workflow."
+category: reference
+targets:
+  ghcp: true
+  claude: true
+  codex: true
+tags:
+  - reference
+  - shared
+  - languages
+  - extensions

--- a/templates/skills/azure-functions-diagnostics/SKILL.md
+++ b/templates/skills/azure-functions-diagnostics/SKILL.md
@@ -1,0 +1,68 @@
+# Azure Functions Diagnostics
+
+Use this skill to diagnose and resolve Azure Functions issues by orchestrating focused skills and loading only the references needed for the current app.
+
+Write final answers in the user's language.
+
+## Core principle
+
+Do not load all diagnostic references up front. First collect the app inventory, infer runtime/language and trigger/binding/extension shape, then load only the matching language and extension reference files.
+
+For multi-step reviews, source investigations, or remediation work, create a short checklist plan file or todo list and update it after each completed step. Do not require a checklist for quick read-only diagnosis because it adds token overhead.
+
+## Required inputs
+
+Ask only for missing inputs needed to start:
+
+- Function App name, unless already provided.
+- Subscription ID/name and resource group, if needed to disambiguate.
+- Symptom, error message, command output, or portal/deployment failure context.
+- Time window, default `24h` for current or recent production issues.
+
+If the user has a local workspace issue without a deployed app, skip Azure resource collection and start from local project/runtime/trigger discovery.
+
+## Diagnostic workflow
+
+Follow [workflow.md](references/workflow.md). Use shared reference routing from [../azure-functions-common/references/routing.md](../azure-functions-common/references/routing.md) only after inventory/health data identifies the relevant runtime, trigger, binding, or symptom.
+
+Fast path:
+
+1. Use `azure-functions-inventory` to collect static app specifications.
+2. Use `azure-functions-health-status` to collect current health, metrics, telemetry, and Activity Log.
+3. Use [../azure-functions-common/references/routing.md](../azure-functions-common/references/routing.md) to select only the required language and extension references.
+4. Use [evidence-checklist.md](references/evidence-checklist.md) before stating root cause or recommended fixes.
+5. Prefer official documentation, official repositories, official samples, and package/container registries before broader web sources.
+
+## Reference loading rules
+
+Use `azure-functions-common` for shared runtime, language, and trigger/binding references.
+
+- Load exactly one language reference when the runtime is known, plus Durable only when Durable is involved.
+- Load only extension references matching the app's triggers/bindings or the symptom.
+- Load Extension Bundles only for non-.NET apps or extension-version/binding-resolution symptoms.
+- Do not load migration provenance during normal diagnostics.
+
+## Guardrails
+
+- Redact secrets, connection strings, keys, tokens, SAS URLs, and storage credentials.
+- Report setting names and whether values exist; do not reveal values.
+- Ask before cloning large repositories, using sparse checkout, deploying to Azure, restarting apps, changing configuration, or running disruptive commands.
+- Distinguish confirmed evidence from hypotheses.
+- For transient issues, state whether the current app is healthy and identify the historical evidence used.
+
+## Output shape
+
+Use this concise structure unless the user asks for a different format:
+
+```text
+Target: <app/resource/local project>
+Symptom: <summary>
+Inventory: <runtime/plan/network/triggers summary>
+Health: <current state/metrics/log findings summary>
+Relevant references loaded: <language refs>, <extension refs>
+Findings: <evidence-backed bullets>
+Likely cause: <confirmed or suspected>
+Recommended actions: <ordered steps>
+Validation plan: <local/E2E/Azure validation steps>
+Gaps: <missing permissions/telemetry/context>
+```

--- a/templates/skills/azure-functions-diagnostics/graph.yaml
+++ b/templates/skills/azure-functions-diagnostics/graph.yaml
@@ -1,0 +1,14 @@
+id: azure-functions-diagnostics
+title: Azure Functions Diagnostics
+suggestions:
+  on_success:
+    - target: azure-functions-inventory
+      reason: "Re-collect inventory if app shape changed."
+      priority: 50
+  on_failure:
+    - target: azure-functions-health-status
+      reason: "Re-check current health and telemetry."
+      priority: 70
+entry_conditions:
+  - user_reports_issue
+  - investigation_required

--- a/templates/skills/azure-functions-diagnostics/references/evidence-checklist.md
+++ b/templates/skills/azure-functions-diagnostics/references/evidence-checklist.md
@@ -1,0 +1,47 @@
+# Azure Functions Diagnostics Evidence Checklist
+
+Use this checklist before presenting root cause or remediation.
+
+## Target and time
+
+- Target app or local project is identified.
+- Subscription/resource group are identified when Azure resources are involved.
+- Time window is stated.
+- Current vs historical/transient issue is clear.
+
+## Inventory evidence
+
+- Runtime/language is known or explicitly unknown.
+- Hosting plan, OS, and Functions runtime are known.
+- Trigger/binding inventory is known or unavailable with reason.
+- Relevant app settings are checked by name/presence only; secrets are redacted.
+- Network shape is checked when connectivity could be relevant.
+
+## Health evidence
+
+- App state and plan state are checked.
+- Resource Health is checked when supported.
+- Metrics are checked for the time window.
+- Application Insights / Log Analytics tables are checked when available.
+- Exceptions, warning/error traces, dependency failures, and Activity Log are checked when relevant.
+
+## Reference evidence
+
+- Matching language reference is loaded when language is known.
+- Matching extension reference is loaded when trigger/binding is known.
+- Official documentation or official repository evidence is preferred over community sources.
+- Known GitHub issues/PRs are checked when the symptom matches a likely product issue.
+
+## Hypothesis quality
+
+- The conclusion states whether root cause is confirmed or suspected.
+- The evidence supports the conclusion.
+- Alternative explanations are mentioned when still plausible.
+- Gaps are listed explicitly.
+
+## Remediation safety
+
+- Recommended changes are minimal and reversible where possible.
+- Disruptive actions require user confirmation.
+- Azure deployment, app restart, config mutation, or large repo clone requires user confirmation.
+- Validation plan is included.

--- a/templates/skills/azure-functions-diagnostics/references/workflow.md
+++ b/templates/skills/azure-functions-diagnostics/references/workflow.md
@@ -1,0 +1,83 @@
+# Azure Functions Diagnostics Workflow
+
+Use this workflow for deployed or deployment-targeted Azure Functions issues.
+
+## 1. Understand the symptom
+
+Collect only what is needed:
+
+- Error message or failing command (`func`, `az`, `azd`, portal, deployment pipeline, runtime invocation).
+- Function App name, subscription, resource group, and time window.
+- Whether the issue is current, intermittent, historical, deployment-time, startup-time, or invocation-time.
+
+For multi-step reviews, source investigation, or remediation, maintain a concise checklist plan and mark each step complete as work progresses. Skip this for quick read-only diagnosis to keep token use low.
+
+## 2. Inventory first
+
+Use the `azure-functions-inventory` skill.
+
+Inventory should identify:
+
+- Runtime/language.
+- Hosting plan/SKU/OS.
+- Functions runtime version.
+- Trigger and binding inventory.
+- Deployment mode and selected app settings, with secrets redacted.
+- Network shape: VNet integration, private endpoints, public network access.
+- Related resources in the resource group.
+
+## 3. Health and telemetry second
+
+Use the `azure-functions-health-status` skill.
+
+Health should identify:
+
+- Current app state and Resource Health if supported.
+- Plan status and core metrics.
+- Application Insights / Log Analytics requests, exceptions, traces, dependencies.
+- Trigger status and indexing/configuration issues.
+- Recent Activity Log changes.
+
+## 4. Route to focused references
+
+Use `../../azure-functions-common/references/routing.md` after inventory and trigger discovery.
+
+Load only:
+
+- The matching language reference.
+- The matching extension references.
+- Extension Bundles reference only when bundle resolution is relevant.
+
+## 5. Known issue research
+
+Prioritize information sources in this order:
+
+1. Microsoft Learn / Azure Docs.
+2. Official Azure or Microsoft GitHub repositories, issues, PRs, and release notes.
+3. Official package/container registries such as npm, PyPI, Maven Central, NuGet, Docker Hub, and MCR.
+4. Official samples.
+5. Broader internet sources only as secondary context; treat blogs and Stack Overflow as potentially outdated.
+
+## 6. Source investigation
+
+Search/query first. Clone only when needed.
+
+Ask before cloning large repositories or using sparse checkout. Prefer sparse checkout for large repositories such as `azure-sdk-for-net`.
+
+## 7. Validate the hypothesis
+
+Before presenting root cause:
+
+- Confirm whether the issue is still happening.
+- If transient, state the historical evidence and current health separately.
+- Compare logs, metrics, configuration, known issues, and source behavior.
+
+## 8. Remediate and verify
+
+Recommend minimal safe changes first.
+
+If code/config is changed:
+
+- Validate locally when possible.
+- Run E2E smoke tests when possible.
+- Ask before deploying to Azure or making disruptive changes.

--- a/templates/skills/azure-functions-diagnostics/skill.yaml
+++ b/templates/skills/azure-functions-diagnostics/skill.yaml
@@ -1,0 +1,14 @@
+id: azure-functions-diagnostics
+title: Azure Functions Diagnostics
+description: "Use when diagnosing or resolving Azure Functions issues: deployment failures, runtime errors, trigger/binding failures, language worker issues, telemetry/log analysis, known issue research, source investigation, and remediation. Acts as a facade that routes to focused Azure Functions skills and small language/extension references."
+category: task
+targets:
+  ghcp: true
+  claude: true
+  codex: true
+mcp_preferred:
+  - azure
+tags:
+  - diagnose
+  - troubleshoot
+  - telemetry

--- a/templates/skills/azure-functions-health-status/SKILL.md
+++ b/templates/skills/azure-functions-health-status/SKILL.md
@@ -1,0 +1,66 @@
+# Azure Functions Health Status
+
+Use this skill to investigate the current status and health of an existing Azure Function App.
+
+Write final answers in the user's language.
+
+## Required interaction
+
+Ask only for missing inputs that are needed to identify the app and time window:
+
+- Function App name (required unless already provided)
+- Subscription ID or name (optional)
+- Resource group (optional)
+- Investigation time window, default `24h` (optional)
+
+If subscription or resource group is unknown, discover them with Resource Graph. If multiple matching apps are found, ask the user to choose one.
+
+## Fast path
+
+1. Call Azure best practices for `azurefunctions` first when available.
+2. Run the bundled health script for the current shell/OS:
+   - `scripts/get-functionapp-health-status.ps1 -AppName <app-name>`
+   - `scripts/get-functionapp-health-status.sh -a <app-name>` on macOS/Linux or Bash
+   - Add `-SubscriptionId <sub>` and/or `-ResourceGroup <rg>` when known.
+   - Add `-Hours <n>` when the user requests a specific time window.
+   - For Bash, use `-s <sub>`, `-g <resource-group>`, and/or `-H <hours>` when known.
+   - Bash script requires Azure CLI plus a working `python3` or `python` executable for JSON shaping.
+3. If bundled script execution is unavailable, use `references/health-status-commands-and-kql.md`.
+4. Report health findings and action items; avoid dumping raw logs unless requested.
+
+If health findings require runtime or trigger-specific interpretation, use `../azure-functions-common/references/routing.md` on demand. Do not load shared language/extension references for plain status output.
+
+## Scope boundary
+
+This skill should collect:
+
+- Current app state: enabled/running/stopped, metadata availability, runtime availability
+- Plan status and Resource Health result
+- Azure Monitor metrics: instance count, CPU, memory, execution counts/units, always-ready units
+- Trigger status summary and notable disabled or indexing-failed functions
+- Application Insights/Log Analytics: request counts/failures/p95, dependency failures, exceptions, warning/error traces
+- Recent Activity Log events
+- Gaps: missing telemetry, unsupported Resource Health, unavailable diagnostic data
+
+Do not perform full static inventory beyond fields needed to interpret health. Use the inventory skill for detailed specifications.
+
+## Interpretation rules
+
+- For Flex Consumption, Resource Health may return `Unknown` or `Unsupported`; rely on app metadata, plan status, metrics, telemetry, and Activity Log.
+- Workspace-based Application Insights uses `AppRequests`, `AppExceptions`, `AppTraces`, and `AppDependencies`; classic tables may be empty.
+- Treat unresolved `%SETTING_NAME%` placeholders in traces/exceptions as configuration/indexing issues.
+- Redact connection strings, keys, tokens, and storage secrets. It is safe to report setting names and whether values exist.
+
+## Output template
+
+```text
+Target: <app> (<resource-group>, <subscription>, <region>)
+Current status: app <state>, metadata <availability/runtime>, plan <status>, Resource Health <state/reason>
+Metrics: instances <max/avg>, CPU <max>, memory <max>, executions <summary>
+Execution: requests <n>, failed <n>, p95 highlights <...>; dependency failures <n>
+Triggers: enabled <n>, disabled <n>; indexing/config issues <summary>
+Recent changes: <Activity Log summary>
+Findings: <1-3 bullets>
+Recommended next actions: <1-3 bullets>
+Gaps: <unavailable telemetry or unsupported checks>
+```

--- a/templates/skills/azure-functions-health-status/graph.yaml
+++ b/templates/skills/azure-functions-health-status/graph.yaml
@@ -1,0 +1,13 @@
+id: azure-functions-health-status
+title: Azure Functions Health Status
+suggestions:
+  on_success:
+    - target: azure-functions-diagnostics
+      reason: "Use diagnostics to interpret findings and recommend fixes."
+      priority: 80
+  on_failure:
+    - target: azure-functions-inventory
+      reason: "Re-collect inventory to confirm app identity and configuration."
+      priority: 60
+entry_conditions:
+  - app_identified

--- a/templates/skills/azure-functions-health-status/references/health-status-commands-and-kql.md
+++ b/templates/skills/azure-functions-health-status/references/health-status-commands-and-kql.md
@@ -1,0 +1,121 @@
+# Azure Functions Health Status Commands and KQL
+
+Use these commands only for current status and health investigation. For static specifications, use the inventory skill.
+
+## Current app state and plan status
+
+```powershell
+$AppName = '<function-app-name>'
+$SubscriptionId = '<subscription-id>' # optional
+$ResourceGroup = '<resource-group>'   # optional
+$Hours = 24
+
+az account set --subscription $SubscriptionId
+$ResourceId = az functionapp show -g $ResourceGroup -n $AppName --query id -o tsv
+
+az rest --method get --url "https://management.azure.com${ResourceId}?api-version=2023-12-01" `
+  --query "{state:properties.state,enabled:properties.enabled,availabilityState:properties.availabilityState,runtimeAvailabilityState:properties.runtimeAvailabilityState,serverFarmId:properties.serverFarmId}" -o json
+```
+
+## Resource Health
+
+```powershell
+az rest --method get --url "https://management.azure.com${ResourceId}/providers/Microsoft.ResourceHealth/availabilityStatuses/current?api-version=2022-10-01" `
+  --query "{availabilityState:properties.availabilityState,summary:properties.summary,reasonType:properties.reasonType,reportedTime:properties.reportedTime,title:properties.title}" -o json
+```
+
+## Trigger enabled/disabled summary
+
+```powershell
+$funcs = az functionapp function list -g $ResourceGroup -n $AppName -o json | ConvertFrom-Json
+$summary = $funcs | ForEach-Object {
+  $binding = $_.config.bindings | Where-Object { $_.direction -eq 'In' } | Select-Object -First 1
+  [pscustomobject]@{ Function=($_.name -replace '^.*/',''); Trigger=$binding.type; Disabled=$_.isDisabled }
+}
+$summary | Group-Object Trigger, Disabled | ForEach-Object {
+  [pscustomobject]@{ Trigger=$_.Group[0].Trigger; Disabled=$_.Group[0].Disabled; Count=$_.Count }
+} | Sort-Object Trigger,Disabled | ConvertTo-Json -Depth 4
+```
+
+## Azure Monitor Metrics
+
+```powershell
+az monitor metrics list --resource $ResourceId `
+  --metric "InstanceCount,CpuPercentage,AverageMemoryWorkingSet,OnDemandFunctionExecutionCount,OnDemandFunctionExecutionUnits,AlwaysReadyFunctionExecutionCount,AlwaysReadyFunctionExecutionUnits,AlwaysReadyUnits" `
+  --interval PT1H --aggregation Average Total -o json
+```
+
+## Application Insights / Log Analytics
+
+Get workspace ID:
+
+```powershell
+$app = az functionapp show -g $ResourceGroup -n $AppName -o json | ConvertFrom-Json
+$AiResourceId = $app.tags.'hidden-link: /app-insights-resource-id'
+$WorkspaceResourceId = az resource show --ids $AiResourceId --query properties.WorkspaceResourceId -o tsv
+$WorkspaceId = az monitor log-analytics workspace show --ids $WorkspaceResourceId --query customerId -o tsv
+```
+
+Use Log Analytics REST API if the CLI extension is unavailable:
+
+```powershell
+$tmp = Join-Path $env:TEMP 'la-query.json'
+@{ query = 'AppRequests | where TimeGenerated > ago(24h) | count' } | ConvertTo-Json -Compress | Set-Content -Path $tmp -Encoding utf8
+az rest --method post --url "https://api.loganalytics.io/v1/workspaces/$WorkspaceId/query" --body "@$tmp" --headers "Content-Type=application/json" -o json
+```
+
+Table coverage:
+
+```kusto
+union withsource=TableName AppRequests, AppExceptions, AppTraces, AppDependencies
+| where TimeGenerated > ago(7d)
+| summarize Count=count(), Latest=max(TimeGenerated) by TableName
+```
+
+Requests:
+
+```kusto
+AppRequests
+| where TimeGenerated > ago(24h)
+| summarize Count=count(), Failed=countif(Success == false), AvgDurationMs=avg(DurationMs), P95DurationMs=percentile(DurationMs,95), Latest=max(TimeGenerated) by OperationName
+| order by Count desc
+| take 30
+```
+
+Exceptions:
+
+```kusto
+AppExceptions
+| where TimeGenerated > ago(24h)
+| summarize Count=count(), Latest=max(TimeGenerated) by OperationName, ProblemId, Type, OuterMessage
+| order by Count desc
+| take 20
+```
+
+Warning/error traces:
+
+```kusto
+AppTraces
+| where TimeGenerated > ago(24h)
+| where SeverityLevel >= 2
+| summarize Count=count(), Latest=max(TimeGenerated) by SeverityLevel, Message
+| order by Count desc
+| take 20
+```
+
+Dependencies:
+
+```kusto
+AppDependencies
+| where TimeGenerated > ago(24h)
+| summarize Count=count(), Failed=countif(Success == false), AvgDurationMs=avg(DurationMs), P95DurationMs=percentile(DurationMs,95), Latest=max(TimeGenerated) by Type, Target, Name
+| order by Failed desc, Count desc
+| take 20
+```
+
+## Activity Log
+
+```powershell
+az monitor activity-log list --resource-id $ResourceId --offset ${Hours}h --max-events 20 `
+  --query "[].{time:eventTimestamp,operation:operationName.value,status:status.value,caller:caller,level:level,correlationId:correlationId}" -o json
+```

--- a/templates/skills/azure-functions-health-status/scripts/get-functionapp-health-status.ps1
+++ b/templates/skills/azure-functions-health-status/scripts/get-functionapp-health-status.ps1
@@ -1,0 +1,172 @@
+param(
+    [Parameter(Mandatory=$true)] [string] $AppName,
+    [string] $SubscriptionId,
+    [string] $ResourceGroup,
+    [int] $Hours = 24
+)
+
+$ErrorActionPreference = 'Continue'
+
+function Invoke-AzJson([string] $Command) {
+    $out = Invoke-Expression "$Command 2>`$null"
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($out)) { return $null }
+    try { return $out | ConvertFrom-Json } catch { return $null }
+}
+
+function Invoke-LogAnalyticsRest([string] $WorkspaceCustomerId, [string] $Kql) {
+    if (-not $WorkspaceCustomerId) { return $null }
+    $tmp = Join-Path $env:TEMP ("la-query-{0}.json" -f ([guid]::NewGuid().ToString('N')))
+    try {
+        @{ query = $Kql } | ConvertTo-Json -Compress | Set-Content -Path $tmp -Encoding utf8
+        $resultText = az rest --method post --url "https://api.loganalytics.io/v1/workspaces/$WorkspaceCustomerId/query" --body "@$tmp" --headers "Content-Type=application/json" -o json 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($resultText)) { return $null }
+        $result = $resultText | ConvertFrom-Json
+        if ($result.tables -and $result.tables.Count -gt 0) { return $result.tables[0].rows }
+        return $null
+    } catch {
+        return $null
+    } finally {
+        Remove-Item -Path $tmp -ErrorAction SilentlyContinue
+    }
+}
+
+if ($SubscriptionId) { az account set --subscription $SubscriptionId | Out-Null }
+
+$resource = $null
+try {
+    az config set extension.use_dynamic_install=yes_without_prompt | Out-Null
+    az extension add --name resource-graph --upgrade --only-show-errors | Out-Null
+    $where = "type =~ 'microsoft.web/sites' and name =~ '$AppName'"
+    if ($ResourceGroup) { $where += " and resourceGroup =~ '$ResourceGroup'" }
+    $query = "Resources | where $where | project name, id, resourceGroup, subscriptionId, location, kind, properties"
+    $graph = Invoke-AzJson "az graph query -q `"$query`" -o json"
+    if ($graph -and $graph.data -and $graph.data.Count -gt 0) { $resource = $graph.data[0] }
+} catch { }
+
+if (-not $resource -and $SubscriptionId) {
+    $list = Invoke-AzJson "az resource list --name $AppName --resource-type Microsoft.Web/sites -o json"
+    if ($list -and $list.Count -gt 0) { $resource = $list[0] }
+}
+
+if (-not $resource) {
+    [pscustomobject]@{ error = 'Function App not found'; appName = $AppName } | ConvertTo-Json -Depth 5
+    exit 1
+}
+
+$SubscriptionId = $resource.subscriptionId
+$ResourceGroup = $resource.resourceGroup
+$ResourceId = $resource.id
+az account set --subscription $SubscriptionId | Out-Null
+
+$siteUrl = 'https://management.azure.com' + $ResourceId + '?api-version=2023-12-01'
+$site = Invoke-AzJson "az rest --method get --url `"$siteUrl`" -o json"
+if (-not $site) { $site = Invoke-AzJson "az functionapp show -g $ResourceGroup -n $AppName -o json" }
+
+$planId = $site.properties.serverFarmId
+if (-not $planId) { $planId = $site.serverFarmId }
+$plan = if ($planId) {
+    $planUrl = 'https://management.azure.com' + $planId + '?api-version=2023-12-01'
+    Invoke-AzJson "az rest --method get --url `"$planUrl`" -o json"
+} else { $null }
+
+$healthUrl = 'https://management.azure.com' + $ResourceId + '/providers/Microsoft.ResourceHealth/availabilityStatuses/current?api-version=2022-10-01'
+$health = Invoke-AzJson "az rest --method get --url `"$healthUrl`" -o json"
+
+$funcs = Invoke-AzJson "az functionapp function list -g $ResourceGroup -n $AppName -o json"
+$functionSummary = @($funcs | ForEach-Object {
+    $binding = $_.config.bindings | Where-Object { $_.direction -eq 'In' } | Select-Object -First 1
+    [pscustomobject]@{ function=($_.name -replace '^.*/',''); trigger=$binding.type; disabled=$_.isDisabled }
+})
+$triggerCounts = @($functionSummary | Group-Object trigger, disabled | ForEach-Object {
+    [pscustomobject]@{ trigger=$_.Group[0].trigger; disabled=$_.Group[0].disabled; count=$_.Count }
+} | Sort-Object trigger, disabled)
+
+$metricNames = 'InstanceCount,CpuPercentage,AverageMemoryWorkingSet,OnDemandFunctionExecutionCount,OnDemandFunctionExecutionUnits,AlwaysReadyFunctionExecutionCount,AlwaysReadyFunctionExecutionUnits,AlwaysReadyUnits'
+$metricsRaw = Invoke-AzJson "az monitor metrics list --resource `"$ResourceId`" --metric `"$metricNames`" --interval PT1H --aggregation Average Total -o json"
+$metrics = @()
+if ($metricsRaw -and $metricsRaw.value) {
+    $metrics = @($metricsRaw.value | ForEach-Object {
+        $totals = @()
+        $averages = @()
+        foreach ($series in $_.timeseries) {
+            foreach ($point in $series.data) {
+                if ($null -ne $point.total) { $totals += [double]$point.total }
+                if ($null -ne $point.average) { $averages += [double]$point.average }
+            }
+        }
+        [pscustomobject]@{
+            name = $_.name.value
+            unit = $_.unit
+            totalSum = if ($totals.Count) { ($totals | Measure-Object -Sum).Sum } else { $null }
+            averageMax = if ($averages.Count) { ($averages | Measure-Object -Maximum).Maximum } else { $null }
+            nonZeroTotalBucketCount = @($totals | Where-Object { $_ -ne 0 }).Count
+            nonZeroAverageBucketCount = @($averages | Where-Object { $_ -ne 0 }).Count
+        }
+    })
+}
+
+$activityRaw = Invoke-AzJson "az monitor activity-log list --resource-id `"$ResourceId`" --offset $($Hours)h --max-events 20 -o json"
+$activity = @($activityRaw | ForEach-Object {
+    [pscustomobject]@{
+        time = $_.eventTimestamp
+        operation = $_.operationName.value
+        status = $_.status.value
+        caller = $_.caller
+        level = $_.level
+        correlationId = $_.correlationId
+    }
+})
+
+$aiResourceId = $null
+if ($site.tags) { $aiResourceId = $site.tags.'hidden-link: /app-insights-resource-id' }
+$workspaceResourceId = $null
+$workspaceCustomerId = $null
+if ($aiResourceId) {
+    $ai = Invoke-AzJson "az resource show --ids `"$aiResourceId`" -o json"
+    $workspaceResourceId = $ai.properties.WorkspaceResourceId
+    if (-not $workspaceResourceId) { $workspaceResourceId = $ai.properties.workspaceResourceId }
+    if ($workspaceResourceId) {
+        $workspace = Invoke-AzJson "az monitor log-analytics workspace show --ids `"$workspaceResourceId`" -o json"
+        $workspaceCustomerId = $workspace.customerId
+    }
+}
+
+$telemetry = $null
+if ($workspaceCustomerId) {
+    $telemetry = [pscustomobject]@{
+        workspaceResourceId = $workspaceResourceId
+        tableCounts7d = Invoke-LogAnalyticsRest $workspaceCustomerId "union withsource=TableName AppRequests, AppExceptions, AppTraces, AppDependencies | where TimeGenerated > ago(7d) | summarize Count=count(), Latest=max(TimeGenerated) by TableName | order by TableName"
+        requests = Invoke-LogAnalyticsRest $workspaceCustomerId "AppRequests | where TimeGenerated > ago($($Hours)h) | summarize Count=count(), Failed=countif(Success == false), AvgDurationMs=avg(DurationMs), P95DurationMs=percentile(DurationMs,95), Latest=max(TimeGenerated) by OperationName | order by Count desc | take 30"
+        exceptions = Invoke-LogAnalyticsRest $workspaceCustomerId "AppExceptions | where TimeGenerated > ago($($Hours)h) | summarize Count=count(), Latest=max(TimeGenerated) by OperationName, ProblemId, Type, OuterMessage | order by Count desc | take 20"
+        errorTraces = Invoke-LogAnalyticsRest $workspaceCustomerId "AppTraces | where TimeGenerated > ago($($Hours)h) | where SeverityLevel >= 2 | summarize Count=count(), Latest=max(TimeGenerated) by SeverityLevel, Message | order by Count desc | take 20"
+        dependencies = Invoke-LogAnalyticsRest $workspaceCustomerId "AppDependencies | where TimeGenerated > ago($($Hours)h) | summarize Count=count(), Failed=countif(Success == false), AvgDurationMs=avg(DurationMs), P95DurationMs=percentile(DurationMs,95), Latest=max(TimeGenerated) by Type, Target, Name | order by Failed desc, Count desc | take 20"
+    }
+}
+
+[pscustomobject]@{
+    resource = [pscustomobject]@{
+        id = $ResourceId
+        name = $AppName
+        resourceGroup = $ResourceGroup
+        subscriptionId = $SubscriptionId
+        location = $site.location
+        kind = $site.kind
+    }
+    currentStatus = [pscustomobject]@{
+        enabled = $site.properties.enabled
+        state = $site.properties.state
+        availabilityState = $site.properties.availabilityState
+        runtimeAvailabilityState = $site.properties.runtimeAvailabilityState
+        planStatus = $plan.properties.status
+    }
+    resourceHealth = if ($health) { [pscustomobject]@{ availabilityState=$health.properties.availabilityState; summary=$health.properties.summary; reasonType=$health.properties.reasonType; reportedTime=$health.properties.reportedTime; title=$health.properties.title } } else { $null }
+    triggers = [pscustomobject]@{ counts=$triggerCounts; functions=$functionSummary }
+    metrics = $metrics
+    applicationInsights = $telemetry
+    activityLog = $activity
+    gaps = [pscustomobject]@{
+        applicationInsightsResourceFound = [bool]$aiResourceId
+        workspaceFound = [bool]$workspaceCustomerId
+        resourceHealthReturned = [bool]$health
+    }
+} | ConvertTo-Json -Depth 30

--- a/templates/skills/azure-functions-health-status/scripts/get-functionapp-health-status.sh
+++ b/templates/skills/azure-functions-health-status/scripts/get-functionapp-health-status.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 -a <app-name> [-s <subscription-id-or-name>] [-g <resource-group>] [-H <hours>]" >&2
+}
+
+APP_NAME=""
+SUBSCRIPTION_ID=""
+RESOURCE_GROUP=""
+HOURS="24"
+
+while getopts ":a:s:g:H:h" opt; do
+  case "$opt" in
+    a) APP_NAME="$OPTARG" ;;
+    s) SUBSCRIPTION_ID="$OPTARG" ;;
+    g) RESOURCE_GROUP="$OPTARG" ;;
+    H) HOURS="$OPTARG" ;;
+    h) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$APP_NAME" ]]; then
+  usage
+  exit 2
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "$PYTHON_BIN" ]]; then
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c 'import json' >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$PYTHON_BIN" ]] || ! "$PYTHON_BIN" -c 'import json' >/dev/null 2>&1; then
+  echo "A working python3 or python executable is required for JSON shaping" >&2
+  exit 2
+fi
+
+az_json() {
+  az "$@" -o json 2>/dev/null || true
+}
+
+json_get() {
+  "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin); path=sys.argv[1].split("."); cur=data
+for p in path:
+    if cur in (None, ""):
+        cur=None; break
+    cur = cur[int(p)] if isinstance(cur, list) else cur.get(p)
+print("" if cur is None else cur)' "$1"
+}
+
+log_analytics_query() {
+  local workspace_id="$1"
+  local kql="$2"
+  if [[ -z "$workspace_id" ]]; then
+    echo "null"
+    return
+  fi
+  local body
+  body="$(mktemp)"
+  "$PYTHON_BIN" -c 'import json,sys; open(sys.argv[1],"w",encoding="utf-8").write(json.dumps({"query":sys.argv[2]}))' "$body" "$kql"
+  local result
+  result="$(az rest --method post --url "https://api.loganalytics.io/v1/workspaces/${workspace_id}/query" --body "@$body" --headers "Content-Type=application/json" -o json 2>/dev/null || true)"
+  rm -f "$body"
+  if [[ -z "$result" ]]; then
+    echo "null"
+    return
+  fi
+  printf '%s' "$result" | "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin); tables=data.get("tables") or []; print(json.dumps((tables[0].get("rows") if tables else None)))' 2>/dev/null || echo "null"
+}
+
+if [[ -n "$SUBSCRIPTION_ID" ]]; then
+  az account set --subscription "$SUBSCRIPTION_ID" >/dev/null
+fi
+
+az config set extension.use_dynamic_install=yes_without_prompt >/dev/null 2>&1 || true
+az extension add --name resource-graph --upgrade --only-show-errors >/dev/null 2>&1 || true
+
+WHERE="type =~ 'microsoft.web/sites' and name =~ '$APP_NAME'"
+if [[ -n "$RESOURCE_GROUP" ]]; then
+  WHERE="$WHERE and resourceGroup =~ '$RESOURCE_GROUP'"
+fi
+QUERY="Resources | where $WHERE | project name, id, resourceGroup, subscriptionId, location, kind, properties | take 1"
+GRAPH_JSON="$(az_json graph query -q "$QUERY")"
+RESOURCE_JSON="$(printf '%s' "$GRAPH_JSON" | "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin) if not sys.stdin.isatty() else {}; rows=data.get("data") or []; print(json.dumps(rows[0] if rows else None))' 2>/dev/null || echo null)"
+
+if [[ "$RESOURCE_JSON" == "null" || -z "$RESOURCE_JSON" ]]; then
+  if [[ -n "$SUBSCRIPTION_ID" ]]; then
+    LIST_JSON="$(az_json resource list --name "$APP_NAME" --resource-type Microsoft.Web/sites)"
+    RESOURCE_JSON="$(printf '%s' "$LIST_JSON" | "$PYTHON_BIN" -c 'import json,sys; rows=json.load(sys.stdin); print(json.dumps(rows[0] if rows else None))' 2>/dev/null || echo null)"
+  fi
+fi
+
+if [[ "$RESOURCE_JSON" == "null" || -z "$RESOURCE_JSON" ]]; then
+  "$PYTHON_BIN" -c 'import json,sys; print(json.dumps({"error":"Function App not found","appName":sys.argv[1]}, indent=2))' "$APP_NAME"
+  exit 1
+fi
+
+SUBSCRIPTION_ID="$(printf '%s' "$RESOURCE_JSON" | json_get subscriptionId)"
+RESOURCE_GROUP="$(printf '%s' "$RESOURCE_JSON" | json_get resourceGroup)"
+RESOURCE_ID="$(printf '%s' "$RESOURCE_JSON" | json_get id)"
+az account set --subscription "$SUBSCRIPTION_ID" >/dev/null
+
+SITE_JSON="$(az_json rest --method get --url "https://management.azure.com${RESOURCE_ID}?api-version=2023-12-01")"
+if [[ -z "$SITE_JSON" || "$SITE_JSON" == "null" ]]; then
+  SITE_JSON="$(az_json functionapp show -g "$RESOURCE_GROUP" -n "$APP_NAME")"
+fi
+PLAN_ID="$(printf '%s' "$SITE_JSON" | "$PYTHON_BIN" -c 'import json,sys; s=json.load(sys.stdin); print((s.get("properties") or {}).get("serverFarmId") or s.get("serverFarmId") or "")')"
+PLAN_JSON="null"
+if [[ -n "$PLAN_ID" ]]; then
+  PLAN_JSON="$(az_json rest --method get --url "https://management.azure.com${PLAN_ID}?api-version=2023-12-01")"
+fi
+HEALTH_JSON="$(az_json rest --method get --url "https://management.azure.com${RESOURCE_ID}/providers/Microsoft.ResourceHealth/availabilityStatuses/current?api-version=2022-10-01")"
+FUNCS_JSON="$(az_json functionapp function list -g "$RESOURCE_GROUP" -n "$APP_NAME")"
+METRICS_JSON="$(az_json monitor metrics list --resource "$RESOURCE_ID" --metric "InstanceCount,CpuPercentage,AverageMemoryWorkingSet,OnDemandFunctionExecutionCount,OnDemandFunctionExecutionUnits,AlwaysReadyFunctionExecutionCount,AlwaysReadyFunctionExecutionUnits,AlwaysReadyUnits" --interval PT1H --aggregation Average Total)"
+ACTIVITY_JSON="$(az_json monitor activity-log list --resource-id "$RESOURCE_ID" --offset "${HOURS}h" --max-events 20)"
+
+AI_RESOURCE_ID="$(printf '%s' "$SITE_JSON" | "$PYTHON_BIN" -c 'import json,sys; s=json.load(sys.stdin); print((s.get("tags") or {}).get("hidden-link: /app-insights-resource-id") or "")')"
+WORKSPACE_RESOURCE_ID=""
+WORKSPACE_CUSTOMER_ID=""
+if [[ -n "$AI_RESOURCE_ID" ]]; then
+  AI_JSON="$(az_json resource show --ids "$AI_RESOURCE_ID")"
+  WORKSPACE_RESOURCE_ID="$(printf '%s' "$AI_JSON" | "$PYTHON_BIN" -c 'import json,sys; a=json.load(sys.stdin); p=a.get("properties") or {}; print(p.get("WorkspaceResourceId") or p.get("workspaceResourceId") or "")' 2>/dev/null || true)"
+  if [[ -n "$WORKSPACE_RESOURCE_ID" ]]; then
+    WORKSPACE_JSON="$(az_json monitor log-analytics workspace show --ids "$WORKSPACE_RESOURCE_ID")"
+    WORKSPACE_CUSTOMER_ID="$(printf '%s' "$WORKSPACE_JSON" | "$PYTHON_BIN" -c 'import json,sys; print((json.load(sys.stdin) or {}).get("customerId") or "")' 2>/dev/null || true)"
+  fi
+fi
+
+TABLE_COUNTS_JSON="$(log_analytics_query "$WORKSPACE_CUSTOMER_ID" "union withsource=TableName AppRequests, AppExceptions, AppTraces, AppDependencies | where TimeGenerated > ago(7d) | summarize Count=count(), Latest=max(TimeGenerated) by TableName | order by TableName")"
+REQUESTS_JSON="$(log_analytics_query "$WORKSPACE_CUSTOMER_ID" "AppRequests | where TimeGenerated > ago(${HOURS}h) | summarize Count=count(), Failed=countif(Success == false), AvgDurationMs=avg(DurationMs), P95DurationMs=percentile(DurationMs,95), Latest=max(TimeGenerated) by OperationName | order by Count desc | take 30")"
+EXCEPTIONS_JSON="$(log_analytics_query "$WORKSPACE_CUSTOMER_ID" "AppExceptions | where TimeGenerated > ago(${HOURS}h) | summarize Count=count(), Latest=max(TimeGenerated) by OperationName, ProblemId, Type, OuterMessage | order by Count desc | take 20")"
+ERROR_TRACES_JSON="$(log_analytics_query "$WORKSPACE_CUSTOMER_ID" "AppTraces | where TimeGenerated > ago(${HOURS}h) | where SeverityLevel >= 2 | summarize Count=count(), Latest=max(TimeGenerated) by SeverityLevel, Message | order by Count desc | take 20")"
+DEPENDENCIES_JSON="$(log_analytics_query "$WORKSPACE_CUSTOMER_ID" "AppDependencies | where TimeGenerated > ago(${HOURS}h) | summarize Count=count(), Failed=countif(Success == false), AvgDurationMs=avg(DurationMs), P95DurationMs=percentile(DurationMs,95), Latest=max(TimeGenerated) by Type, Target, Name | order by Failed desc, Count desc | take 20")"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+printf '%s' "$SITE_JSON" > "$TMP_DIR/site.json"
+printf '%s' "$PLAN_JSON" > "$TMP_DIR/plan.json"
+printf '%s' "$HEALTH_JSON" > "$TMP_DIR/health.json"
+printf '%s' "$FUNCS_JSON" > "$TMP_DIR/functions.json"
+printf '%s' "$METRICS_JSON" > "$TMP_DIR/metricsRaw.json"
+printf '%s' "$ACTIVITY_JSON" > "$TMP_DIR/activityRaw.json"
+printf '%s' "$TABLE_COUNTS_JSON" > "$TMP_DIR/tableCounts.json"
+printf '%s' "$REQUESTS_JSON" > "$TMP_DIR/requests.json"
+printf '%s' "$EXCEPTIONS_JSON" > "$TMP_DIR/exceptions.json"
+printf '%s' "$ERROR_TRACES_JSON" > "$TMP_DIR/errorTraces.json"
+printf '%s' "$DEPENDENCIES_JSON" > "$TMP_DIR/dependencies.json"
+
+"$PYTHON_BIN" - "$TMP_DIR" "$APP_NAME" "$RESOURCE_GROUP" "$SUBSCRIPTION_ID" "$RESOURCE_ID" "$WORKSPACE_RESOURCE_ID" "$WORKSPACE_CUSTOMER_ID" <<'PY'
+import json, os, sys
+
+base, app_name, resource_group, subscription_id, resource_id, workspace_resource_id, workspace_customer_id = sys.argv[1:8]
+
+def load(name, default=None):
+    path = os.path.join(base, name)
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read().strip()
+        return json.loads(text) if text else default
+    except Exception:
+        return default
+
+site = load("site.json", {}) or {}
+plan = load("plan.json", {}) or {}
+health = load("health.json", None)
+funcs = load("functions.json", []) or []
+metrics_raw = load("metricsRaw.json", {}) or {}
+activity_raw = load("activityRaw.json", []) or []
+
+functions = []
+for func in funcs:
+    bindings = ((func.get("config") or {}).get("bindings") or [])
+    binding = next((b for b in bindings if b.get("direction") == "In"), {})
+    functions.append({
+        "function": (func.get("name") or "").split("/")[-1],
+        "trigger": binding.get("type"),
+        "disabled": func.get("isDisabled"),
+    })
+counts = {}
+for func in functions:
+    key = (func.get("trigger"), func.get("disabled"))
+    counts[key] = counts.get(key, 0) + 1
+trigger_counts = [
+    {"trigger": trigger, "disabled": disabled, "count": count}
+    for (trigger, disabled), count in sorted(counts.items(), key=lambda x: (str(x[0][0]), str(x[0][1])))
+]
+
+metrics = []
+for metric in metrics_raw.get("value") or []:
+    totals, averages = [], []
+    for series in metric.get("timeseries") or []:
+        for point in series.get("data") or []:
+            if point.get("total") is not None:
+                totals.append(float(point["total"]))
+            if point.get("average") is not None:
+                averages.append(float(point["average"]))
+    metrics.append({
+        "name": (metric.get("name") or {}).get("value"),
+        "unit": metric.get("unit"),
+        "totalSum": sum(totals) if totals else None,
+        "averageMax": max(averages) if averages else None,
+        "nonZeroTotalBucketCount": len([x for x in totals if x != 0]),
+        "nonZeroAverageBucketCount": len([x for x in averages if x != 0]),
+    })
+
+activity = [{
+    "time": item.get("eventTimestamp"),
+    "operation": (item.get("operationName") or {}).get("value"),
+    "status": (item.get("status") or {}).get("value"),
+    "caller": item.get("caller"),
+    "level": item.get("level"),
+    "correlationId": item.get("correlationId"),
+} for item in activity_raw]
+
+telemetry = None
+if workspace_customer_id:
+    telemetry = {
+        "workspaceResourceId": workspace_resource_id or None,
+        "tableCounts7d": load("tableCounts.json", None),
+        "requests": load("requests.json", None),
+        "exceptions": load("exceptions.json", None),
+        "errorTraces": load("errorTraces.json", None),
+        "dependencies": load("dependencies.json", None),
+    }
+
+props = site.get("properties") or {}
+plan_props = plan.get("properties") or {}
+health_props = (health or {}).get("properties") or {}
+output = {
+    "resource": {
+        "id": resource_id,
+        "name": app_name,
+        "resourceGroup": resource_group,
+        "subscriptionId": subscription_id,
+        "location": site.get("location"),
+        "kind": site.get("kind"),
+    },
+    "currentStatus": {
+        "enabled": props.get("enabled"),
+        "state": props.get("state"),
+        "availabilityState": props.get("availabilityState"),
+        "runtimeAvailabilityState": props.get("runtimeAvailabilityState"),
+        "planStatus": plan_props.get("status"),
+    },
+    "resourceHealth": None if not health else {
+        "availabilityState": health_props.get("availabilityState"),
+        "summary": health_props.get("summary"),
+        "reasonType": health_props.get("reasonType"),
+        "reportedTime": health_props.get("reportedTime"),
+        "title": health_props.get("title"),
+    },
+    "triggers": {"counts": trigger_counts, "functions": functions},
+    "metrics": metrics,
+    "applicationInsights": telemetry,
+    "activityLog": activity,
+    "gaps": {
+        "applicationInsightsResourceFound": bool((site.get("tags") or {}).get("hidden-link: /app-insights-resource-id")),
+        "workspaceFound": bool(workspace_customer_id),
+        "resourceHealthReturned": bool(health),
+    },
+}
+print(json.dumps(output, indent=2))
+PY

--- a/templates/skills/azure-functions-health-status/skill.yaml
+++ b/templates/skills/azure-functions-health-status/skill.yaml
@@ -1,0 +1,14 @@
+id: azure-functions-health-status
+title: Azure Functions Health Status
+description: "Use when investigating current Azure Functions app status and health: Running/Stopped state, Resource Health, plan status, Azure Monitor metrics, Application Insights/Log Analytics requests, failures, exceptions, traces, dependencies, and recent Activity Log. Do not use for static inventory-only requests."
+category: task
+targets:
+  ghcp: true
+  claude: true
+  codex: true
+mcp_preferred:
+  - azure
+tags:
+  - health
+  - telemetry
+  - monitoring

--- a/templates/skills/azure-functions-inventory/SKILL.md
+++ b/templates/skills/azure-functions-inventory/SKILL.md
@@ -1,0 +1,55 @@
+# Azure Functions Inventory
+
+Use this skill to collect the static specifications of an existing Azure Function App.
+
+Write final answers in the user's language.
+
+## Required interaction
+
+Ask only for missing inputs that are needed to identify the app:
+
+- Function App name (required unless already provided)
+- Subscription ID or name (optional)
+- Resource group (optional)
+
+If subscription or resource group is unknown, discover them with Resource Graph. If multiple matching apps are found, ask the user to choose one.
+
+## Fast path
+
+1. Call Azure best practices for `azurefunctions` first when available.
+2. Run the bundled inventory script for the current shell/OS:
+   - `scripts/get-functionapp-inventory.ps1 -AppName <app-name>`
+   - `scripts/get-functionapp-inventory.sh -a <app-name>` on macOS/Linux or Bash
+   - Add `-SubscriptionId <sub>` and/or `-ResourceGroup <rg>` when known.
+   - For Bash, use `-s <sub>` and/or `-g <resource-group>` when known.
+   - Bash script requires Azure CLI plus a working `python3` or `python` executable for JSON shaping.
+3. If bundled script execution is unavailable, use `references/inventory-commands.md`.
+4. Report only inventory/specification data unless the user explicitly asks for health or telemetry.
+
+If a caller needs runtime or trigger interpretation after inventory collection, use `../azure-functions-common/references/routing.md` on demand. Do not load shared language/extension references for plain inventory output.
+
+## Scope boundary
+
+This skill should collect:
+
+- Resource identity: subscription, resource group, region, resource ID, host name
+- Plan/SKU/runtime: plan name/SKU/status, OS, runtime stack/version, Functions runtime
+- Flex config: deployment storage type/auth, memory, max instances, always-ready value, update strategy
+- Network/security: VNet integration, public network access, HTTPS only, TLS, FTPS, private endpoint count if available
+- Identity/settings: managed identity type and selected setting presence with secrets redacted
+- Functions inventory: functions and trigger types, enabled/disabled counts
+- Related resources in the resource group, summarized by resource type/name/SKU
+
+Do not include metrics, Application Insights, exceptions, traces, dependencies, Activity Log, or Resource Health analysis. Use the health skill for those.
+
+## Output template
+
+```text
+Target: <app> (<resource-group>, <subscription>, <region>)
+Plan/Runtime: <plan sku>, <kind>, <runtime>, Functions <version>, memory <MB>, max <n>, alwaysReady <value>
+Network/Identity: VNet <subnet>, publicAccess <value>, identity <type>
+Settings: <selected setting names and presence only>
+Triggers: enabled <n>, disabled <n>; trigger breakdown <summary>
+Related resources: <short resource type/name summary>
+Gaps: <unavailable metadata, if any>
+```

--- a/templates/skills/azure-functions-inventory/graph.yaml
+++ b/templates/skills/azure-functions-inventory/graph.yaml
@@ -1,0 +1,13 @@
+id: azure-functions-inventory
+title: Azure Functions Inventory
+suggestions:
+  on_success:
+    - target: azure-functions-health-status
+      reason: "Inventory collected. Check current health and telemetry next."
+      priority: 80
+  on_failure:
+    - target: azure-functions-diagnostics
+      reason: "Use diagnostics to triage missing/blocked inventory data."
+      priority: 60
+entry_conditions:
+  - app_identified

--- a/templates/skills/azure-functions-inventory/references/inventory-commands.md
+++ b/templates/skills/azure-functions-inventory/references/inventory-commands.md
@@ -1,0 +1,56 @@
+# Azure Functions Inventory Commands
+
+Use these commands only for static Function App specifications. For health, metrics, exceptions, traces, dependencies, or Activity Log, use the health skill.
+
+## Locate the app
+
+```powershell
+$AppName = '<function-app-name>'
+$SubscriptionId = '<subscription-id>' # optional
+$ResourceGroup = '<resource-group>'   # optional
+
+az config set extension.use_dynamic_install=yes_without_prompt | Out-Null
+az extension add --name resource-graph --upgrade --only-show-errors
+az graph query -q "Resources | where type =~ 'microsoft.web/sites' and name =~ '$AppName' | project name, id, resourceGroup, subscriptionId, location, kind, properties" -o json
+```
+
+## App, plan, runtime, and config
+
+```powershell
+az account set --subscription $SubscriptionId
+$ResourceId = az functionapp show -g $ResourceGroup -n $AppName --query id -o tsv
+
+az rest --method get --url "https://management.azure.com${ResourceId}?api-version=2023-12-01" `
+  --query "{id:id,name:name,location:location,kind:kind,enabled:properties.enabled,state:properties.state,defaultHostName:properties.defaultHostName,serverFarmId:properties.serverFarmId,virtualNetworkSubnetId:properties.virtualNetworkSubnetId,httpsOnly:properties.httpsOnly,publicNetworkAccess:properties.publicNetworkAccess,lastModifiedTimeUtc:properties.lastModifiedTimeUtc,identity:identity,functionAppConfig:properties.functionAppConfig}" -o json
+
+$PlanId = az functionapp show -g $ResourceGroup -n $AppName --query "properties.serverFarmId || serverFarmId" -o tsv
+az rest --method get --url "https://management.azure.com${PlanId}?api-version=2023-12-01" `
+  --query "{id:id,name:name,location:location,sku:sku,status:properties.status,reserved:properties.reserved,zoneRedundant:properties.zoneRedundant}" -o json
+
+az rest --method get --url "https://management.azure.com${ResourceId}/config/web?api-version=2023-12-01" `
+  --query "{minTlsVersion:properties.minTlsVersion,ftpsState:properties.ftpsState,alwaysOn:properties.alwaysOn,http20Enabled:properties.http20Enabled,healthCheckPath:properties.healthCheckPath,use32BitWorkerProcess:properties.use32BitWorkerProcess}" -o json
+```
+
+## Selected app setting presence
+
+```powershell
+$settings = az functionapp config appsettings list -g $ResourceGroup -n $AppName -o json | ConvertFrom-Json
+$names = @('FUNCTIONS_EXTENSION_VERSION','FUNCTIONS_WORKER_RUNTIME','APPLICATIONINSIGHTS_CONNECTION_STRING','APPINSIGHTS_INSTRUMENTATIONKEY','AzureWebJobsStorage','AzureWebJobsStorage__accountName','AzureWebJobsStorage__credential','WEBSITE_RUN_FROM_PACKAGE','WEBSITE_CONTENTSHARE','WEBSITE_CONTENTAZUREFILECONNECTIONSTRING')
+$settings | Where-Object { $names -contains $_.name } | ForEach-Object {
+  $v = if ($_.name -match 'CONNECTION|Storage|KEY|SECRET|INSIGHTS|TOKEN|PASSWORD|SAS|ACCOUNT') { '***redacted***' } else { $_.value }
+  [pscustomobject]@{ name=$_.name; hasValue=($null -ne $_.value -and $_.value -ne ''); value=$v }
+} | ConvertTo-Json -Depth 5
+```
+
+## Functions and trigger inventory
+
+```powershell
+$funcs = az functionapp function list -g $ResourceGroup -n $AppName -o json | ConvertFrom-Json
+$summary = $funcs | ForEach-Object {
+  $binding = $_.config.bindings | Where-Object { $_.direction -eq 'In' } | Select-Object -First 1
+  [pscustomobject]@{ Function=($_.name -replace '^.*/',''); Trigger=$binding.type; Disabled=$_.isDisabled }
+}
+$summary | Group-Object Trigger, Disabled | ForEach-Object {
+  [pscustomobject]@{ Trigger=$_.Group[0].Trigger; Disabled=$_.Group[0].Disabled; Count=$_.Count }
+} | Sort-Object Trigger,Disabled | ConvertTo-Json -Depth 4
+```

--- a/templates/skills/azure-functions-inventory/scripts/get-functionapp-inventory.ps1
+++ b/templates/skills/azure-functions-inventory/scripts/get-functionapp-inventory.ps1
@@ -1,0 +1,127 @@
+param(
+    [Parameter(Mandatory=$true)] [string] $AppName,
+    [string] $SubscriptionId,
+    [string] $ResourceGroup
+)
+
+$ErrorActionPreference = 'Continue'
+
+function Invoke-AzJson([string] $Command) {
+    $out = Invoke-Expression "$Command 2>`$null"
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($out)) { return $null }
+    try { return $out | ConvertFrom-Json } catch { return $null }
+}
+
+function Redact-Setting([string] $name, $value) {
+    if ($name -match 'CONNECTION|Storage|KEY|SECRET|INSIGHTS|TOKEN|PASSWORD|SAS|ACCOUNT') { return '***redacted***' }
+    return $value
+}
+
+if ($SubscriptionId) { az account set --subscription $SubscriptionId | Out-Null }
+
+$resource = $null
+try {
+    az config set extension.use_dynamic_install=yes_without_prompt | Out-Null
+    az extension add --name resource-graph --upgrade --only-show-errors | Out-Null
+    $where = "type =~ 'microsoft.web/sites' and name =~ '$AppName'"
+    if ($ResourceGroup) { $where += " and resourceGroup =~ '$ResourceGroup'" }
+    $query = "Resources | where $where | project name, id, resourceGroup, subscriptionId, location, kind, properties"
+    $graph = Invoke-AzJson "az graph query -q `"$query`" -o json"
+    if ($graph -and $graph.data -and $graph.data.Count -gt 0) { $resource = $graph.data[0] }
+} catch { }
+
+if (-not $resource -and $SubscriptionId) {
+    $list = Invoke-AzJson "az resource list --name $AppName --resource-type Microsoft.Web/sites -o json"
+    if ($list -and $list.Count -gt 0) { $resource = $list[0] }
+}
+
+if (-not $resource) {
+    [pscustomobject]@{ error = 'Function App not found'; appName = $AppName } | ConvertTo-Json -Depth 5
+    exit 1
+}
+
+$SubscriptionId = $resource.subscriptionId
+$ResourceGroup = $resource.resourceGroup
+$ResourceId = $resource.id
+az account set --subscription $SubscriptionId | Out-Null
+
+$siteUrl = 'https://management.azure.com' + $ResourceId + '?api-version=2023-12-01'
+$site = Invoke-AzJson "az rest --method get --url `"$siteUrl`" -o json"
+if (-not $site) { $site = Invoke-AzJson "az functionapp show -g $ResourceGroup -n $AppName -o json" }
+
+$planId = $site.properties.serverFarmId
+if (-not $planId) { $planId = $site.serverFarmId }
+$plan = if ($planId) {
+    $planUrl = 'https://management.azure.com' + $planId + '?api-version=2023-12-01'
+    Invoke-AzJson "az rest --method get --url `"$planUrl`" -o json"
+} else { $null }
+
+$webConfigUrl = 'https://management.azure.com' + $ResourceId + '/config/web?api-version=2023-12-01'
+$webConfig = Invoke-AzJson "az rest --method get --url `"$webConfigUrl`" -o json"
+
+$settingsRaw = Invoke-AzJson "az functionapp config appsettings list -g $ResourceGroup -n $AppName -o json"
+$settingsWanted = @(
+    'FUNCTIONS_EXTENSION_VERSION',
+    'FUNCTIONS_WORKER_RUNTIME',
+    'APPLICATIONINSIGHTS_CONNECTION_STRING',
+    'APPINSIGHTS_INSTRUMENTATIONKEY',
+    'AzureWebJobsStorage',
+    'AzureWebJobsStorage__accountName',
+    'AzureWebJobsStorage__credential',
+    'WEBSITE_RUN_FROM_PACKAGE',
+    'WEBSITE_CONTENTSHARE',
+    'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
+)
+$settings = @($settingsRaw | Where-Object { $settingsWanted -contains $_.name } | ForEach-Object {
+    [pscustomobject]@{ name=$_.name; hasValue=($null -ne $_.value -and $_.value -ne ''); value=(Redact-Setting $_.name $_.value) }
+})
+
+$funcs = Invoke-AzJson "az functionapp function list -g $ResourceGroup -n $AppName -o json"
+$functionSummary = @($funcs | ForEach-Object {
+    $binding = $_.config.bindings | Where-Object { $_.direction -eq 'In' } | Select-Object -First 1
+    [pscustomobject]@{ function=($_.name -replace '^.*/',''); trigger=$binding.type; disabled=$_.isDisabled }
+})
+$triggerCounts = @($functionSummary | Group-Object trigger, disabled | ForEach-Object {
+    [pscustomobject]@{ trigger=$_.Group[0].trigger; disabled=$_.Group[0].disabled; count=$_.Count }
+} | Sort-Object trigger, disabled)
+
+$vnetIntegration = Invoke-AzJson "az webapp vnet-integration list -g $ResourceGroup -n $AppName -o json"
+$privateEndpoints = Invoke-AzJson "az network private-endpoint-connection list -g $ResourceGroup -n $AppName --type Microsoft.Web/sites -o json"
+$relatedResources = Invoke-AzJson "az resource list -g $ResourceGroup --query `"[].{name:name,type:type,location:location,sku:sku.name}`" -o json"
+
+[pscustomobject]@{
+    resource = [pscustomobject]@{
+        id = $ResourceId
+        name = $AppName
+        resourceGroup = $ResourceGroup
+        subscriptionId = $SubscriptionId
+        location = $site.location
+        kind = $site.kind
+        defaultHostName = $site.properties.defaultHostName
+        hostNames = $site.properties.hostNames
+    }
+    app = [pscustomobject]@{
+        enabled = $site.properties.enabled
+        state = $site.properties.state
+        sku = $site.properties.sku
+        functionAppConfig = $site.properties.functionAppConfig
+        lastModifiedTimeUtc = $site.properties.lastModifiedTimeUtc
+    }
+    plan = if ($plan) { [pscustomobject]@{ id=$plan.id; name=$plan.name; sku=$plan.sku; status=$plan.properties.status; location=$plan.location; reserved=$plan.properties.reserved; zoneRedundant=$plan.properties.zoneRedundant } } else { $null }
+    network = [pscustomobject]@{
+        virtualNetworkSubnetId = $site.properties.virtualNetworkSubnetId
+        publicNetworkAccess = $site.properties.publicNetworkAccess
+        httpsOnly = $site.properties.httpsOnly
+        minTlsVersion = $webConfig.properties.minTlsVersion
+        ftpsState = $webConfig.properties.ftpsState
+        vnetRouteAllEnabled = $site.properties.vnetRouteAllEnabled
+        vnetContentShareEnabled = $site.properties.vnetContentShareEnabled
+        vnetImagePullEnabled = $site.properties.vnetImagePullEnabled
+        vnetIntegration = $vnetIntegration
+        privateEndpointConnectionCount = @($privateEndpoints).Count
+    }
+    identity = $site.identity
+    selectedSettings = $settings
+    triggers = [pscustomobject]@{ counts=$triggerCounts; functions=$functionSummary }
+    relatedResources = $relatedResources
+} | ConvertTo-Json -Depth 30

--- a/templates/skills/azure-functions-inventory/scripts/get-functionapp-inventory.sh
+++ b/templates/skills/azure-functions-inventory/scripts/get-functionapp-inventory.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 -a <app-name> [-s <subscription-id-or-name>] [-g <resource-group>]" >&2
+}
+
+APP_NAME=""
+SUBSCRIPTION_ID=""
+RESOURCE_GROUP=""
+
+while getopts ":a:s:g:h" opt; do
+  case "$opt" in
+    a) APP_NAME="$OPTARG" ;;
+    s) SUBSCRIPTION_ID="$OPTARG" ;;
+    g) RESOURCE_GROUP="$OPTARG" ;;
+    h) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$APP_NAME" ]]; then
+  usage
+  exit 2
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "$PYTHON_BIN" ]]; then
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c 'import json' >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$PYTHON_BIN" ]] || ! "$PYTHON_BIN" -c 'import json' >/dev/null 2>&1; then
+  echo "A working python3 or python executable is required for JSON shaping" >&2
+  exit 2
+fi
+
+az_json() {
+  az "$@" -o json 2>/dev/null || true
+}
+
+json_get() {
+  "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin); path=sys.argv[1].split("."); cur=data
+for p in path:
+    if cur in (None, ""):
+        cur=None; break
+    cur = cur[int(p)] if isinstance(cur, list) else cur.get(p)
+print("" if cur is None else cur)' "$1"
+}
+
+if [[ -n "$SUBSCRIPTION_ID" ]]; then
+  az account set --subscription "$SUBSCRIPTION_ID" >/dev/null
+fi
+
+az config set extension.use_dynamic_install=yes_without_prompt >/dev/null 2>&1 || true
+az extension add --name resource-graph --upgrade --only-show-errors >/dev/null 2>&1 || true
+
+WHERE="type =~ 'microsoft.web/sites' and name =~ '$APP_NAME'"
+if [[ -n "$RESOURCE_GROUP" ]]; then
+  WHERE="$WHERE and resourceGroup =~ '$RESOURCE_GROUP'"
+fi
+QUERY="Resources | where $WHERE | project name, id, resourceGroup, subscriptionId, location, kind, properties | take 1"
+GRAPH_JSON="$(az_json graph query -q "$QUERY")"
+RESOURCE_JSON="$(printf '%s' "$GRAPH_JSON" | "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin) if not sys.stdin.isatty() else {}; rows=data.get("data") or []; print(json.dumps(rows[0] if rows else None))' 2>/dev/null || echo null)"
+
+if [[ "$RESOURCE_JSON" == "null" || -z "$RESOURCE_JSON" ]]; then
+  if [[ -n "$SUBSCRIPTION_ID" ]]; then
+    LIST_JSON="$(az_json resource list --name "$APP_NAME" --resource-type Microsoft.Web/sites)"
+    RESOURCE_JSON="$(printf '%s' "$LIST_JSON" | "$PYTHON_BIN" -c 'import json,sys; rows=json.load(sys.stdin); print(json.dumps(rows[0] if rows else None))' 2>/dev/null || echo null)"
+  fi
+fi
+
+if [[ "$RESOURCE_JSON" == "null" || -z "$RESOURCE_JSON" ]]; then
+  "$PYTHON_BIN" -c 'import json,sys; print(json.dumps({"error":"Function App not found","appName":sys.argv[1]}, indent=2))' "$APP_NAME"
+  exit 1
+fi
+
+SUBSCRIPTION_ID="$(printf '%s' "$RESOURCE_JSON" | json_get subscriptionId)"
+RESOURCE_GROUP="$(printf '%s' "$RESOURCE_JSON" | json_get resourceGroup)"
+RESOURCE_ID="$(printf '%s' "$RESOURCE_JSON" | json_get id)"
+az account set --subscription "$SUBSCRIPTION_ID" >/dev/null
+
+SITE_JSON="$(az_json rest --method get --url "https://management.azure.com${RESOURCE_ID}?api-version=2023-12-01")"
+if [[ -z "$SITE_JSON" || "$SITE_JSON" == "null" ]]; then
+  SITE_JSON="$(az_json functionapp show -g "$RESOURCE_GROUP" -n "$APP_NAME")"
+fi
+PLAN_ID="$(printf '%s' "$SITE_JSON" | "$PYTHON_BIN" -c 'import json,sys; s=json.load(sys.stdin); print((s.get("properties") or {}).get("serverFarmId") or s.get("serverFarmId") or "")')"
+PLAN_JSON="null"
+if [[ -n "$PLAN_ID" ]]; then
+  PLAN_JSON="$(az_json rest --method get --url "https://management.azure.com${PLAN_ID}?api-version=2023-12-01")"
+fi
+WEB_CONFIG_JSON="$(az_json rest --method get --url "https://management.azure.com${RESOURCE_ID}/config/web?api-version=2023-12-01")"
+SETTINGS_JSON="$(az_json functionapp config appsettings list -g "$RESOURCE_GROUP" -n "$APP_NAME")"
+FUNCS_JSON="$(az_json functionapp function list -g "$RESOURCE_GROUP" -n "$APP_NAME")"
+VNET_JSON="$(az_json webapp vnet-integration list -g "$RESOURCE_GROUP" -n "$APP_NAME")"
+PRIVATE_ENDPOINTS_JSON="$(az_json network private-endpoint-connection list -g "$RESOURCE_GROUP" -n "$APP_NAME" --type Microsoft.Web/sites)"
+RELATED_JSON="$(az_json resource list -g "$RESOURCE_GROUP" --query '[].{name:name,type:type,location:location,sku:sku.name}')"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+printf '%s' "$SITE_JSON" > "$TMP_DIR/site.json"
+printf '%s' "$PLAN_JSON" > "$TMP_DIR/plan.json"
+printf '%s' "$WEB_CONFIG_JSON" > "$TMP_DIR/webConfig.json"
+printf '%s' "$SETTINGS_JSON" > "$TMP_DIR/settings.json"
+printf '%s' "$FUNCS_JSON" > "$TMP_DIR/functions.json"
+printf '%s' "$VNET_JSON" > "$TMP_DIR/vnet.json"
+printf '%s' "$PRIVATE_ENDPOINTS_JSON" > "$TMP_DIR/privateEndpoints.json"
+printf '%s' "$RELATED_JSON" > "$TMP_DIR/related.json"
+
+"$PYTHON_BIN" - "$TMP_DIR" "$APP_NAME" "$RESOURCE_GROUP" "$SUBSCRIPTION_ID" "$RESOURCE_ID" <<'PY'
+import json, os, re, sys
+
+base, app_name, resource_group, subscription_id, resource_id = sys.argv[1:6]
+
+def load(name, default=None):
+    path = os.path.join(base, name)
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read().strip()
+        return json.loads(text) if text else default
+    except Exception:
+        return default
+
+site = load("site.json", {}) or {}
+plan = load("plan.json", None)
+web = load("webConfig.json", {}) or {}
+settings_raw = load("settings.json", []) or []
+funcs = load("functions.json", []) or []
+vnet = load("vnet.json", None)
+private_endpoints = load("privateEndpoints.json", []) or []
+related = load("related.json", []) or []
+
+wanted = {
+    "FUNCTIONS_EXTENSION_VERSION", "FUNCTIONS_WORKER_RUNTIME",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING", "APPINSIGHTS_INSTRUMENTATIONKEY",
+    "AzureWebJobsStorage", "AzureWebJobsStorage__accountName", "AzureWebJobsStorage__credential",
+    "WEBSITE_RUN_FROM_PACKAGE", "WEBSITE_CONTENTSHARE", "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
+}
+secret_re = re.compile(r"CONNECTION|Storage|KEY|SECRET|INSIGHTS|TOKEN|PASSWORD|SAS|ACCOUNT", re.I)
+settings = []
+for item in settings_raw:
+    name = item.get("name")
+    if name not in wanted:
+        continue
+    value = item.get("value")
+    settings.append({
+        "name": name,
+        "hasValue": value not in (None, ""),
+        "value": "***redacted***" if secret_re.search(name or "") else value,
+    })
+
+functions = []
+for func in funcs:
+    bindings = ((func.get("config") or {}).get("bindings") or [])
+    binding = next((b for b in bindings if b.get("direction") == "In"), {})
+    functions.append({
+        "function": (func.get("name") or "").split("/")[-1],
+        "trigger": binding.get("type"),
+        "disabled": func.get("isDisabled"),
+    })
+
+counts = {}
+for func in functions:
+    key = (func.get("trigger"), func.get("disabled"))
+    counts[key] = counts.get(key, 0) + 1
+trigger_counts = [
+    {"trigger": trigger, "disabled": disabled, "count": count}
+    for (trigger, disabled), count in sorted(counts.items(), key=lambda x: (str(x[0][0]), str(x[0][1])))
+]
+
+props = site.get("properties") or {}
+web_props = web.get("properties") or {}
+plan_props = (plan or {}).get("properties") or {}
+output = {
+    "resource": {
+        "id": resource_id,
+        "name": app_name,
+        "resourceGroup": resource_group,
+        "subscriptionId": subscription_id,
+        "location": site.get("location"),
+        "kind": site.get("kind"),
+        "defaultHostName": props.get("defaultHostName"),
+        "hostNames": props.get("hostNames"),
+    },
+    "app": {
+        "enabled": props.get("enabled"),
+        "state": props.get("state"),
+        "sku": props.get("sku"),
+        "functionAppConfig": props.get("functionAppConfig"),
+        "lastModifiedTimeUtc": props.get("lastModifiedTimeUtc"),
+    },
+    "plan": None if not plan else {
+        "id": plan.get("id"),
+        "name": plan.get("name"),
+        "sku": plan.get("sku"),
+        "status": plan_props.get("status"),
+        "location": plan.get("location"),
+        "reserved": plan_props.get("reserved"),
+        "zoneRedundant": plan_props.get("zoneRedundant"),
+    },
+    "network": {
+        "virtualNetworkSubnetId": props.get("virtualNetworkSubnetId"),
+        "publicNetworkAccess": props.get("publicNetworkAccess"),
+        "httpsOnly": props.get("httpsOnly"),
+        "minTlsVersion": web_props.get("minTlsVersion"),
+        "ftpsState": web_props.get("ftpsState"),
+        "vnetRouteAllEnabled": props.get("vnetRouteAllEnabled"),
+        "vnetContentShareEnabled": props.get("vnetContentShareEnabled"),
+        "vnetImagePullEnabled": props.get("vnetImagePullEnabled"),
+        "vnetIntegration": vnet,
+        "privateEndpointConnectionCount": len(private_endpoints) if isinstance(private_endpoints, list) else 0,
+    },
+    "identity": site.get("identity"),
+    "selectedSettings": settings,
+    "triggers": {"counts": trigger_counts, "functions": functions},
+    "relatedResources": related,
+}
+print(json.dumps(output, indent=2))
+PY

--- a/templates/skills/azure-functions-inventory/skill.yaml
+++ b/templates/skills/azure-functions-inventory/skill.yaml
@@ -1,0 +1,14 @@
+id: azure-functions-inventory
+title: Azure Functions Inventory
+description: "Use when collecting Azure Functions app specifications/inventory only: resource identity, SKU/plan, runtime, Function App config, network, identity, selected app settings, and function/trigger inventory. Do not use for runtime health, failures, metrics, or telemetry investigation."
+category: task
+targets:
+  ghcp: true
+  claude: true
+  codex: true
+mcp_preferred:
+  - azure
+tags:
+  - inventory
+  - specifications
+  - configuration

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -13,8 +13,8 @@ describe('loadSkills', () => {
   let skills;
   beforeAll(() => { skills = loadSkills(join(TEMPLATES_DIR, 'skills')); });
 
-  it('loads all three skills', () => {
-    expect(skills).toHaveLength(3);
+  it('loads all skills', () => {
+    expect(skills).toHaveLength(7);
   });
 
   it('each skill has id, title, content, graph', () => {
@@ -29,7 +29,15 @@ describe('loadSkills', () => {
 
   it('skill IDs match directory names', () => {
     const ids = skills.map(s => s.id).sort();
-    expect(ids).toEqual(['azure-functions-create', 'azure-functions-deploy', 'azure-functions-setup']);
+    expect(ids).toEqual([
+      'azure-functions-common',
+      'azure-functions-create',
+      'azure-functions-deploy',
+      'azure-functions-diagnostics',
+      'azure-functions-health-status',
+      'azure-functions-inventory',
+      'azure-functions-setup',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds the `azure-functions-diagnostics` skill suite to `templates/skills/`, building on a token-efficient facade pattern that orchestrates focused sub-skills and loads only the references needed for the current app.

## What's added

| Skill | Role |
|-------|------|
| `azure-functions-diagnostics` | Facade. Drives inventory → health → routed references → evidence → remediation. |
| `azure-functions-inventory` | Static Function App specs (resource, plan, runtime, network, identity, selected settings, triggers). PS + Bash scripts. |
| `azure-functions-health-status` | Current state + Resource Health + Azure Monitor + App Insights/Log Analytics + Activity Log. PS + Bash scripts. |
| `azure-functions-common` | Shared reference pack: language references (C#, Python, Node/TS, Java, PowerShell, Durable), 22 extension references, and `routing.md`. |

The facade does **not** load all references up front — it routes via `azure-functions-common/references/routing.md` after inventory identifies the runtime / triggers / symptom.

## Build system

The new skills introduced a `scripts/` subdirectory pattern alongside the existing `references/` pattern.

- `src/build/loader.js` now detects optional `scripts/` per skill.
- `src/build/build-target.js` adds `copySkillScripts` / `copySkillAssets`; all three targets (ghcp, claude, codex) emit both `references/` and `scripts/` into every skill output location (`.github/skills/<id>/`, `skills/<id>/`, `.claude/skills/<id>/`).
- `tests/build.test.js` updated for the new skill count (3 → 7) and ID list.

## Validation

- `npm test` — **62/62 passed**.
- E2E: ran `node bin/azure-functions-skills.js setup --dir ./tmp --agent ghcp` and `--agent claude` into fresh subdirectories. Verified that:
  - `.github/skills/azure-functions-{common,diagnostics,health-status,inventory}/` exist with correct `SKILL.md`, `references/`, `scripts/`.
  - `skills/azure-functions-*/` (plugin format) mirrors the same content.
  - `.claude/skills/azure-functions-health-status/scripts/*.{ps1,sh}` and `references/*.md` are deployed.
  - Single YAML frontmatter (no duplication) on emitted SKILL.md.
