### PR TITLE
chore: bump package version to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.1.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-functions-skills",
-      "version": "0.1.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "vitest": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-loom/azure-functions-skills",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AI assistant plugins for Azure Functions — one-command setup for GitHub Copilot, Claude Code, and Codex",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump npm package version to 0.10.0 in package.json and package-lock.json

## Validation
- npm run build
- npm test
- npm run lint