### PR TITLE
Add Azure Functions best practices skill

### DIFF
--- a/.github/plugins/azure-functions-skills/agents/functions-copilot.agent.md
+++ b/.github/plugins/azure-functions-skills/agents/functions-copilot.agent.md
@@ -22,6 +22,7 @@ You have access to the following MCP server — use it proactively:
 | **azure-functions-setup** | User needs to set up their environment, install tools, or verify prerequisites |
 | **azure-functions-create** | User wants to create a new Functions project or add functions to an existing one |
 | **azure-functions-deploy** | User wants to deploy their app to Azure |
+| **azure-functions-best-practices** | User wants to review, harden, optimize, or remediate an existing Function App against Azure Functions best practices |
 | **azure-functions-diagnostics** | User reports deployment failures, runtime errors, trigger/binding failures, language worker issues, telemetry/log analysis needs, or asks for troubleshooting/remediation |
 
 ## Routing Rules
@@ -30,15 +31,18 @@ You have access to the following MCP server — use it proactively:
 2. **Environment issues** ("func not found", "az not installed") → azure-functions-setup
 3. **New project** ("create", "scaffold", "init", "new function") → azure-functions-create
 4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy
-5. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
-6. **After azure-functions-setup succeeds** → Suggest azure-functions-create
-7. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
-8. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
+5. **Best-practices review / hardening / optimization** ("best practices", "review my Function App", "harden", "optimize configuration", "production readiness") → azure-functions-best-practices
+6. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
+7. **After azure-functions-setup succeeds** → Suggest azure-functions-create
+8. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
+9. **After azure-functions-deploy succeeds** → Suggest azure-functions-best-practices for production readiness review
+10. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
 
 ## Behavior
 
 - Always explain WHY you're routing to a skill
 - Use the MCP template tools to fetch real template code — never hallucinate boilerplate
+- For proactive review, route to azure-functions-best-practices before proposing broad configuration changes
 - For troubleshooting, route to azure-functions-diagnostics before proposing fixes unless the root cause is already obvious from gathered evidence
 - If unsure, ask ONE clarifying question (max 1)
 - After any skill completes, suggest the next logical step from the graph

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-best-practices/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-best-practices/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: azure-functions-best-practices
+description: "Use when reviewing an existing Azure Function App against Azure Functions best practices and proposing safe, approval-gated remediations for runtime, configuration, identity, security, observability, performance, scale, cost, triggers, and bindings."
+---
+
+
+# Azure Functions Best Practices Review
+
+Use this skill to review an existing Azure Function App, prioritize best-practice findings, and help apply approved remediations.
+
+Write final answers in the user's language.
+
+## When to use
+
+- Review my Function App for best practices
+- Improve or harden an existing Azure Functions app
+- Check whether a Function App follows recommended settings
+- Suggest safe fixes for Function App configuration, runtime, scale, security, or observability
+- Prepare a best-practices report before production readiness review
+
+## Do not use for
+
+- Creating a new Function App: use `azure-functions-create`
+- Static inventory only: use `azure-functions-inventory`
+- Current health/status only: use `azure-functions-health-status`
+- Active incident root-cause analysis: use `azure-functions-diagnostics`
+- Deployment-only tasks: use `azure-functions-deploy`
+- Generic Azure compliance scans: use Azure-wide compliance tooling when available
+
+## Core principles
+
+1. **Evidence first** — do not recommend changes until app inventory is collected.
+2. **MCP guidance first** — before scoring findings, call the Azure best-practices MCP guidance for Azure Functions (`get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions` and `action: all`) when the tool is available.
+3. **Report before remediation** — present findings and ask which fixes to apply.
+4. **Approval-gated changes** — do not update app settings, restart apps, deploy code, change networking, change identity/RBAC, or modify source/IaC without explicit user approval.
+5. **Load references on demand** — use `azure-functions-common` routing to load only relevant language and trigger/binding references.
+6. **Redact secrets** — report setting names and presence only; never reveal values.
+
+## Required best-practices guidance
+
+Treat Azure best-practices MCP output as the authoritative current guidance layer for this skill. Always attempt to retrieve it before producing the review report, unless the tool is unavailable. If it is unavailable, state that the MCP guidance could not be loaded and continue with the local checklist as a fallback.
+
+Use the MCP output to update the evaluation baseline for items such as supported runtime versions, Functions Host v4, extension bundle range, Flex Consumption guidance, authentication posture, private networking, Application Insights, trigger/binding recommendations, and language-specific recommendations.
+
+## Required inputs
+
+Ask only for missing inputs needed to start:
+
+- Function App name, unless already provided
+- Subscription ID/name and resource group, if needed to disambiguate
+- Review scope: `quick`, `full`, `security`, `performance-scale`, `cost`, `observability`, or `configuration`
+- Whether local source/IaC is available when the user wants code or infrastructure fixes
+
+## Workflow
+
+1. **Collect static evidence** with `azure-functions-inventory`.
+2. **Collect runtime evidence when useful** with `azure-functions-health-status` for production readiness, performance, observability, or degraded apps.
+3. **Get current MCP guidance** from Azure Functions best-practices guidance (`get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions` and `action: all`) and cite whether it was loaded.
+4. **Route references** through `../azure-functions-common/references/routing.md` based on runtime and trigger/binding inventory.
+5. **Evaluate findings** using [review-checklist.md](references/review-checklist.md).
+6. **Prioritize results** as Critical, High, Medium, or Low.
+7. **Present a report first** with evidence, risk, recommendation, and validation plan.
+8. **Ask for approval** before any remediation.
+9. **Apply approved fixes** or generate commands/IaC/source patches using [remediation-patterns.md](references/remediation-patterns.md).
+10. **Validate after changes** by rerunning the relevant inventory, health, or deployment checks.
+
+## Output shape
+
+Use this structure unless the user asks for a different format:
+
+```text
+Target: <app> (<resource-group>, <subscription>, <region>)
+Scope: <quick/full/security/performance-scale/cost/observability/configuration>
+Inventory summary: <plan/runtime/triggers/network/identity/settings summary>
+Runtime signals: <health/metrics/telemetry summary or not collected>
+Findings:
+  Critical:
+    - <finding with evidence and risk>
+  High:
+    - <finding with evidence and risk>
+  Medium:
+    - <finding with evidence and risk>
+  Low:
+    - <finding with evidence and risk>
+Recommended remediations:
+  1. <safe fix, approval required before applying>
+  2. <manual/IaC/source change recommendation>
+Validation plan:
+  - <post-change checks>
+Gaps: <missing permissions/telemetry/source/IaC>
+```
+
+## Next steps
+
+- If findings indicate active failures, suggest `azure-functions-diagnostics`.
+- If the user only wanted inventory, suggest `azure-functions-inventory` next time.
+- If approved fixes require deployment, suggest `azure-functions-deploy` after validation.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-best-practices/references/remediation-patterns.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-best-practices/references/remediation-patterns.md
@@ -1,0 +1,37 @@
+# Azure Functions Best Practices Remediation Patterns
+
+Use these patterns only after presenting findings and receiving explicit user approval for the selected fixes.
+
+## Safe remediation workflow
+
+1. Restate the selected finding and proposed change.
+2. Confirm impact, rollback, and whether a restart or deployment may occur.
+3. Prefer IaC/source patches when the user's project contains the authoritative configuration.
+4. Use CLI or Azure MCP changes only when the user confirms the live resource is the source of truth.
+5. Redact secrets in commands and output.
+6. Re-run inventory or health checks after changes.
+
+## Remediation types
+
+| Type | Examples | Default behavior |
+| --- | --- | --- |
+| Report-only | Unsupported runtime, weak observability, missing tags | Explain and recommend next step |
+| App setting update | `FUNCTIONS_EXTENSION_VERSION`, extension bundle-related settings, telemetry settings | Show exact setting names and ask before applying |
+| Identity/RBAC | Managed identity enablement, role assignments for Storage/Event Hubs/Service Bus/Key Vault | Generate commands/IaC; require approval before execution |
+| Network/security | HTTPS-only, TLS, FTPS, public network access, private endpoints | Treat as potentially disruptive; require explicit approval |
+| Source/IaC patch | `host.json`, Bicep/Terraform, workflow files | Use file edits and run validation checks |
+| Deployment/runtime change | plan migration, runtime upgrade, slot swap, restart | Handoff to deploy/upgrade/diagnostics skills as appropriate |
+
+## Validation after fixes
+
+- Static configuration changes: rerun `azure-functions-inventory`.
+- Runtime/health changes: rerun `azure-functions-health-status` for the requested time window.
+- Trigger/binding changes: validate trigger indexing and invoke or enqueue a test event when safe.
+- Source/IaC changes: run project build/tests and deployment validation before publishing.
+- Security/RBAC changes: verify access with least privilege and confirm no secret values are printed.
+
+## Escalation rules
+
+- Use `azure-functions-diagnostics` when a best-practice finding is tied to an active failure.
+- Use `azure-functions-deploy` when approved changes require deployment.
+- Use Azure-wide compliance, cost, RBAC, quota, or upgrade skills/tools for broad cross-service analysis.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-best-practices/references/review-checklist.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-best-practices/references/review-checklist.md
@@ -1,0 +1,76 @@
+# Azure Functions Best Practices Review Checklist
+
+Use this checklist after collecting Function App inventory. Apply only sections relevant to the requested scope and collected evidence.
+
+## Runtime and programming model
+
+- Functions host is v4.
+- Language runtime is supported and current enough for the selected stack.
+- .NET apps prefer isolated worker for new or modernized apps.
+- JavaScript/TypeScript apps use the v4 programming model when practical.
+- Python apps use the v2 programming model when practical.
+- Python Function Apps run on Linux.
+- Durable Functions workloads consider Durable Task Scheduler when appropriate.
+
+## Host and app configuration
+
+- `FUNCTIONS_EXTENSION_VERSION` is configured for Functions v4.
+- `FUNCTIONS_WORKER_RUNTIME` matches the deployed app language.
+- Non-.NET apps use extension bundle `[4.*, 5.0.0)` unless there is a justified exception.
+- Required app settings are present; unresolved `%SETTING_NAME%` placeholders are treated as configuration issues.
+- `local.settings.json` is used only for local development and is not committed with secrets.
+- `WEBSITE_RUN_FROM_PACKAGE` / package deployment settings are consistent with the deployment method.
+
+## Security and networking
+
+- HTTPS-only is enabled.
+- TLS version is current for production use.
+- FTPS is disabled or restricted when not needed.
+- Anonymous HTTP triggers are intentional and documented.
+- Public network access, VNet integration, and private endpoints match the app's sensitivity and architecture.
+- App settings, connection strings, SAS tokens, and keys are not exposed in output.
+
+## Identity and RBAC
+
+- Managed identity is enabled when the app accesses Azure resources.
+- Identity-based connections are preferred over raw connection strings where supported.
+- `AzureWebJobsStorage` identity-based settings include the required service URIs and credential settings.
+- Storage, Event Hubs, Service Bus, Key Vault, App Configuration, and Durable Task Scheduler role assignments follow least privilege.
+- RBAC changes are proposed separately and require approval before execution.
+
+## Storage and triggers/bindings
+
+- Blob triggers prefer Event Grid source where appropriate.
+- Blob triggers on Flex Consumption have required queue endpoint, Event Grid subscription, and always-ready considerations.
+- Queue triggers have poison-message handling and visibility-timeout settings appropriate for workload behavior.
+- Service Bus triggers account for lock renewal, sessions, settlement, retry, and concurrency.
+- Event Hubs triggers account for consumer group, checkpointing, partition ownership, batch size, and throughput.
+- Cosmos DB triggers account for lease container, change feed behavior, and throughput.
+- Timer triggers have schedule, timezone, and missed-execution behavior documented.
+
+## Observability and operations
+
+- Application Insights is enabled for production apps.
+- Request, dependency, exception, and trace telemetry are available or gaps are documented.
+- Sampling is intentional and cost-aware.
+- Alerts exist for failed executions, exceptions, dependency failures, throttling, and availability where appropriate.
+- Recent Activity Log changes are reviewed when configuration drift is suspected.
+- Tags and ownership metadata are present where required by the environment.
+
+## Scale, performance, and cost
+
+- Hosting plan matches workload needs; Flex Consumption is preferred for new serverless deployments when suitable.
+- Premium or Dedicated plans are justified by networking, cold start, duration, or workload requirements.
+- Always-ready instances are justified by latency or trigger bootstrap requirements.
+- Max instance, memory, and concurrency settings are intentional.
+- One Function App per independently scaling workload is considered for horizontal scaling.
+- App Insights ingestion, always-ready units, storage transactions, and overprovisioned plans are called out as cost drivers.
+
+## Severity guide
+
+| Severity | Guidance |
+| --- | --- |
+| Critical | App cannot start, functions cannot index, secrets are exposed, production telemetry is absent, or public anonymous access is unintended. |
+| High | Unsupported runtime, insecure auth/networking, broken identity/storage configuration, or trigger setup likely to lose or block events. |
+| Medium | Missing alerts, weak cost/scale posture, suboptimal host settings, incomplete RBAC modernization, or missing operational metadata. |
+| Low | Documentation gaps, optional modernization, naming/tagging improvements, or future optimization opportunities. |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The CLI auto-detects which coding agents you have (GitHub Copilot, Claude Code, 
 
   Skills available:
     • azure-functions-common — Azure Functions Common References
+    • azure-functions-best-practices — Azure Functions Best Practices Review
     • azure-functions-create — Create Azure Functions App
     • azure-functions-deploy — Deploy Azure Functions
     • azure-functions-diagnostics — Azure Functions Diagnostics
@@ -148,6 +149,7 @@ Register the extracted plugin directory with your agent's plugin-from-source flo
 | Skill | Description |
 | --- | --- |
 | **azure-functions-common** | Shared language, runtime, trigger, binding, and extension references for the suite |
+| **azure-functions-best-practices** | Review existing Function Apps against Azure Functions best practices and guide approved remediations |
 | **azure-functions-create** | Scaffold a new Azure Functions project with language and template selection |
 | **azure-functions-deploy** | Deploy Azure Functions apps using official tools |
 | **azure-functions-diagnostics** | Diagnose deployment failures, runtime errors, trigger/binding failures, telemetry issues, and related incidents |

--- a/templates/agents/functions-copilot.agent.md
+++ b/templates/agents/functions-copilot.agent.md
@@ -22,6 +22,7 @@ You have access to the following MCP server — use it proactively:
 | **azure-functions-setup** | User needs to set up their environment, install tools, or verify prerequisites |
 | **azure-functions-create** | User wants to create a new Functions project or add functions to an existing one |
 | **azure-functions-deploy** | User wants to deploy their app to Azure |
+| **azure-functions-best-practices** | User wants to review, harden, optimize, or remediate an existing Function App against Azure Functions best practices |
 | **azure-functions-diagnostics** | User reports deployment failures, runtime errors, trigger/binding failures, language worker issues, telemetry/log analysis needs, or asks for troubleshooting/remediation |
 
 ## Routing Rules
@@ -30,15 +31,18 @@ You have access to the following MCP server — use it proactively:
 2. **Environment issues** ("func not found", "az not installed") → azure-functions-setup
 3. **New project** ("create", "scaffold", "init", "new function") → azure-functions-create
 4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy
-5. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
-6. **After azure-functions-setup succeeds** → Suggest azure-functions-create
-7. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
-8. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
+5. **Best-practices review / hardening / optimization** ("best practices", "review my Function App", "harden", "optimize configuration", "production readiness") → azure-functions-best-practices
+6. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
+7. **After azure-functions-setup succeeds** → Suggest azure-functions-create
+8. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
+9. **After azure-functions-deploy succeeds** → Suggest azure-functions-best-practices for production readiness review
+10. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
 
 ## Behavior
 
 - Always explain WHY you're routing to a skill
 - Use the MCP template tools to fetch real template code — never hallucinate boilerplate
+- For proactive review, route to azure-functions-best-practices before proposing broad configuration changes
 - For troubleshooting, route to azure-functions-diagnostics before proposing fixes unless the root cause is already obvious from gathered evidence
 - If unsure, ask ONE clarifying question (max 1)
 - After any skill completes, suggest the next logical step from the graph

--- a/templates/skills/azure-functions-best-practices/SKILL.md
+++ b/templates/skills/azure-functions-best-practices/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: azure-functions-best-practices
+title: Azure Functions Best Practices Review
+description: "Use when reviewing an existing Azure Function App against Azure Functions best practices and proposing safe, approval-gated remediations for runtime, configuration, identity, security, observability, performance, scale, cost, triggers, and bindings."
+category: task
+---
+
+# Azure Functions Best Practices Review
+
+Use this skill to review an existing Azure Function App, prioritize best-practice findings, and help apply approved remediations.
+
+Write final answers in the user's language.
+
+## When to use
+
+- Review my Function App for best practices
+- Improve or harden an existing Azure Functions app
+- Check whether a Function App follows recommended settings
+- Suggest safe fixes for Function App configuration, runtime, scale, security, or observability
+- Prepare a best-practices report before production readiness review
+
+## Do not use for
+
+- Creating a new Function App: use `azure-functions-create`
+- Static inventory only: use `azure-functions-inventory`
+- Current health/status only: use `azure-functions-health-status`
+- Active incident root-cause analysis: use `azure-functions-diagnostics`
+- Deployment-only tasks: use `azure-functions-deploy`
+- Generic Azure compliance scans: use Azure-wide compliance tooling when available
+
+## Core principles
+
+1. **Evidence first** — do not recommend changes until app inventory is collected.
+2. **MCP guidance first** — before scoring findings, call the Azure best-practices MCP guidance for Azure Functions (`get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions` and `action: all`) when the tool is available.
+3. **Report before remediation** — present findings and ask which fixes to apply.
+4. **Approval-gated changes** — do not update app settings, restart apps, deploy code, change networking, change identity/RBAC, or modify source/IaC without explicit user approval.
+5. **Load references on demand** — use `azure-functions-common` routing to load only relevant language and trigger/binding references.
+6. **Redact secrets** — report setting names and presence only; never reveal values.
+
+## Required best-practices guidance
+
+Treat Azure best-practices MCP output as the authoritative current guidance layer for this skill. Always attempt to retrieve it before producing the review report, unless the tool is unavailable. If it is unavailable, state that the MCP guidance could not be loaded and continue with the local checklist as a fallback.
+
+Use the MCP output to update the evaluation baseline for items such as supported runtime versions, Functions Host v4, extension bundle range, Flex Consumption guidance, authentication posture, private networking, Application Insights, trigger/binding recommendations, and language-specific recommendations.
+
+## Required inputs
+
+Ask only for missing inputs needed to start:
+
+- Function App name, unless already provided
+- Subscription ID/name and resource group, if needed to disambiguate
+- Review scope: `quick`, `full`, `security`, `performance-scale`, `cost`, `observability`, or `configuration`
+- Whether local source/IaC is available when the user wants code or infrastructure fixes
+
+## Workflow
+
+1. **Collect static evidence** with `azure-functions-inventory`.
+2. **Collect runtime evidence when useful** with `azure-functions-health-status` for production readiness, performance, observability, or degraded apps.
+3. **Get current MCP guidance** from Azure Functions best-practices guidance (`get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions` and `action: all`) and cite whether it was loaded.
+4. **Route references** through `../azure-functions-common/references/routing.md` based on runtime and trigger/binding inventory.
+5. **Evaluate findings** using [review-checklist.md](references/review-checklist.md).
+6. **Prioritize results** as Critical, High, Medium, or Low.
+7. **Present a report first** with evidence, risk, recommendation, and validation plan.
+8. **Ask for approval** before any remediation.
+9. **Apply approved fixes** or generate commands/IaC/source patches using [remediation-patterns.md](references/remediation-patterns.md).
+10. **Validate after changes** by rerunning the relevant inventory, health, or deployment checks.
+
+## Output shape
+
+Use this structure unless the user asks for a different format:
+
+```text
+Target: <app> (<resource-group>, <subscription>, <region>)
+Scope: <quick/full/security/performance-scale/cost/observability/configuration>
+Inventory summary: <plan/runtime/triggers/network/identity/settings summary>
+Runtime signals: <health/metrics/telemetry summary or not collected>
+Findings:
+  Critical:
+    - <finding with evidence and risk>
+  High:
+    - <finding with evidence and risk>
+  Medium:
+    - <finding with evidence and risk>
+  Low:
+    - <finding with evidence and risk>
+Recommended remediations:
+  1. <safe fix, approval required before applying>
+  2. <manual/IaC/source change recommendation>
+Validation plan:
+  - <post-change checks>
+Gaps: <missing permissions/telemetry/source/IaC>
+```
+
+## Next steps
+
+- If findings indicate active failures, suggest `azure-functions-diagnostics`.
+- If the user only wanted inventory, suggest `azure-functions-inventory` next time.
+- If approved fixes require deployment, suggest `azure-functions-deploy` after validation.

--- a/templates/skills/azure-functions-best-practices/references/remediation-patterns.md
+++ b/templates/skills/azure-functions-best-practices/references/remediation-patterns.md
@@ -1,0 +1,37 @@
+# Azure Functions Best Practices Remediation Patterns
+
+Use these patterns only after presenting findings and receiving explicit user approval for the selected fixes.
+
+## Safe remediation workflow
+
+1. Restate the selected finding and proposed change.
+2. Confirm impact, rollback, and whether a restart or deployment may occur.
+3. Prefer IaC/source patches when the user's project contains the authoritative configuration.
+4. Use CLI or Azure MCP changes only when the user confirms the live resource is the source of truth.
+5. Redact secrets in commands and output.
+6. Re-run inventory or health checks after changes.
+
+## Remediation types
+
+| Type | Examples | Default behavior |
+| --- | --- | --- |
+| Report-only | Unsupported runtime, weak observability, missing tags | Explain and recommend next step |
+| App setting update | `FUNCTIONS_EXTENSION_VERSION`, extension bundle-related settings, telemetry settings | Show exact setting names and ask before applying |
+| Identity/RBAC | Managed identity enablement, role assignments for Storage/Event Hubs/Service Bus/Key Vault | Generate commands/IaC; require approval before execution |
+| Network/security | HTTPS-only, TLS, FTPS, public network access, private endpoints | Treat as potentially disruptive; require explicit approval |
+| Source/IaC patch | `host.json`, Bicep/Terraform, workflow files | Use file edits and run validation checks |
+| Deployment/runtime change | plan migration, runtime upgrade, slot swap, restart | Handoff to deploy/upgrade/diagnostics skills as appropriate |
+
+## Validation after fixes
+
+- Static configuration changes: rerun `azure-functions-inventory`.
+- Runtime/health changes: rerun `azure-functions-health-status` for the requested time window.
+- Trigger/binding changes: validate trigger indexing and invoke or enqueue a test event when safe.
+- Source/IaC changes: run project build/tests and deployment validation before publishing.
+- Security/RBAC changes: verify access with least privilege and confirm no secret values are printed.
+
+## Escalation rules
+
+- Use `azure-functions-diagnostics` when a best-practice finding is tied to an active failure.
+- Use `azure-functions-deploy` when approved changes require deployment.
+- Use Azure-wide compliance, cost, RBAC, quota, or upgrade skills/tools for broad cross-service analysis.

--- a/templates/skills/azure-functions-best-practices/references/review-checklist.md
+++ b/templates/skills/azure-functions-best-practices/references/review-checklist.md
@@ -1,0 +1,76 @@
+# Azure Functions Best Practices Review Checklist
+
+Use this checklist after collecting Function App inventory. Apply only sections relevant to the requested scope and collected evidence.
+
+## Runtime and programming model
+
+- Functions host is v4.
+- Language runtime is supported and current enough for the selected stack.
+- .NET apps prefer isolated worker for new or modernized apps.
+- JavaScript/TypeScript apps use the v4 programming model when practical.
+- Python apps use the v2 programming model when practical.
+- Python Function Apps run on Linux.
+- Durable Functions workloads consider Durable Task Scheduler when appropriate.
+
+## Host and app configuration
+
+- `FUNCTIONS_EXTENSION_VERSION` is configured for Functions v4.
+- `FUNCTIONS_WORKER_RUNTIME` matches the deployed app language.
+- Non-.NET apps use extension bundle `[4.*, 5.0.0)` unless there is a justified exception.
+- Required app settings are present; unresolved `%SETTING_NAME%` placeholders are treated as configuration issues.
+- `local.settings.json` is used only for local development and is not committed with secrets.
+- `WEBSITE_RUN_FROM_PACKAGE` / package deployment settings are consistent with the deployment method.
+
+## Security and networking
+
+- HTTPS-only is enabled.
+- TLS version is current for production use.
+- FTPS is disabled or restricted when not needed.
+- Anonymous HTTP triggers are intentional and documented.
+- Public network access, VNet integration, and private endpoints match the app's sensitivity and architecture.
+- App settings, connection strings, SAS tokens, and keys are not exposed in output.
+
+## Identity and RBAC
+
+- Managed identity is enabled when the app accesses Azure resources.
+- Identity-based connections are preferred over raw connection strings where supported.
+- `AzureWebJobsStorage` identity-based settings include the required service URIs and credential settings.
+- Storage, Event Hubs, Service Bus, Key Vault, App Configuration, and Durable Task Scheduler role assignments follow least privilege.
+- RBAC changes are proposed separately and require approval before execution.
+
+## Storage and triggers/bindings
+
+- Blob triggers prefer Event Grid source where appropriate.
+- Blob triggers on Flex Consumption have required queue endpoint, Event Grid subscription, and always-ready considerations.
+- Queue triggers have poison-message handling and visibility-timeout settings appropriate for workload behavior.
+- Service Bus triggers account for lock renewal, sessions, settlement, retry, and concurrency.
+- Event Hubs triggers account for consumer group, checkpointing, partition ownership, batch size, and throughput.
+- Cosmos DB triggers account for lease container, change feed behavior, and throughput.
+- Timer triggers have schedule, timezone, and missed-execution behavior documented.
+
+## Observability and operations
+
+- Application Insights is enabled for production apps.
+- Request, dependency, exception, and trace telemetry are available or gaps are documented.
+- Sampling is intentional and cost-aware.
+- Alerts exist for failed executions, exceptions, dependency failures, throttling, and availability where appropriate.
+- Recent Activity Log changes are reviewed when configuration drift is suspected.
+- Tags and ownership metadata are present where required by the environment.
+
+## Scale, performance, and cost
+
+- Hosting plan matches workload needs; Flex Consumption is preferred for new serverless deployments when suitable.
+- Premium or Dedicated plans are justified by networking, cold start, duration, or workload requirements.
+- Always-ready instances are justified by latency or trigger bootstrap requirements.
+- Max instance, memory, and concurrency settings are intentional.
+- One Function App per independently scaling workload is considered for horizontal scaling.
+- App Insights ingestion, always-ready units, storage transactions, and overprovisioned plans are called out as cost drivers.
+
+## Severity guide
+
+| Severity | Guidance |
+| --- | --- |
+| Critical | App cannot start, functions cannot index, secrets are exposed, production telemetry is absent, or public anonymous access is unintended. |
+| High | Unsupported runtime, insecure auth/networking, broken identity/storage configuration, or trigger setup likely to lose or block events. |
+| Medium | Missing alerts, weak cost/scale posture, suboptimal host settings, incomplete RBAC modernization, or missing operational metadata. |
+| Low | Documentation gaps, optional modernization, naming/tagging improvements, or future optimization opportunities. |

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -81,6 +81,7 @@ describe('loadAgents', () => {
   it('loads functions-copilot agent', () => {
     expect(agents.copilot).toBeTruthy();
     expect(agents.copilot).toContain('functions-copilot');
+    expect(agents.copilot).toContain('azure-functions-best-practices');
     expect(agents.copilot).toContain('azure-functions-diagnostics');
   });
 });


### PR DESCRIPTION
## Summary

Adds a new `azure-functions-best-practices` skill for reviewing existing Azure Function Apps against Azure Functions best practices and proposing safe, approval-gated remediations.

## Changes

- Added the canonical `templates/skills/azure-functions-best-practices` skill.
- Added on-demand references for review checklist and remediation patterns.
- Regenerated the committed plugin payload under `.github/plugins/azure-functions-skills` for the new skill.
- Updated `functions-copilot` routing so best-practices, hardening, optimization, and production-readiness requests route to the new skill.
- Made Azure best-practices MCP guidance an explicit required guidance layer for the skill (`get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions` and `action: all`).
- Updated README skill listings and build test coverage.

## Validation

- `npm run check`
  - lint passed
  - typecheck passed
  - skill validation passed
  - plugin payload verification passed
  - 73 tests passed
  - build passed

## Self-review

- Confirmed the skill follows the existing `SKILL.md` frontmatter-based template model.
- Kept detailed guidance in `references/` so the primary skill stays concise and loads supporting material on demand.
- Confirmed the skill now explicitly attempts to load Azure Functions best-practices MCP guidance before producing a review report, with local checklist fallback when the tool is unavailable.
- Confirmed remediation guidance is approval-gated and avoids exposing secrets.
- Confirmed no `PLAN-*.md` files are committed.
