### PR TITLE
Proxy Azure Functions deploy to Azure Skills

### DIFF
--- a/.github/plugins/azure-functions-skills/agents/functions-copilot.agent.md
+++ b/.github/plugins/azure-functions-skills/agents/functions-copilot.agent.md
@@ -21,7 +21,7 @@ You have access to the following MCP server — use it proactively:
 |-------|------------|
 | **azure-functions-setup** | User needs to set up their environment, install tools, or verify prerequisites |
 | **azure-functions-create** | User wants to create a new Functions project or add functions to an existing one |
-| **azure-functions-deploy** | User wants to deploy their app to Azure |
+| **azure-functions-deploy** | User wants to deploy their app to Azure; this is the Azure Functions-facing proxy to Azure Skills deployment |
 | **azure-functions-best-practices** | User wants to review, harden, optimize, or remediate an existing Function App against Azure Functions best practices |
 | **azure-functions-diagnostics** | User reports deployment failures, runtime errors, trigger/binding failures, language worker issues, telemetry/log analysis needs, or asks for troubleshooting/remediation |
 
@@ -30,7 +30,7 @@ You have access to the following MCP server — use it proactively:
 1. **New user / unclear intent** → Start with azure-functions-setup
 2. **Environment issues** ("func not found", "az not installed") → azure-functions-setup
 3. **New project** ("create", "scaffold", "init", "new function") → azure-functions-create
-4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy
+4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy, which should proxy to Azure Skills (`azure-prepare` → `azure-validate` → `azure-deploy`)
 5. **Best-practices review / hardening / optimization** ("best practices", "review my Function App", "harden", "optimize configuration", "production readiness") → azure-functions-best-practices
 6. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
 7. **After azure-functions-setup succeeds** → Suggest azure-functions-create
@@ -42,6 +42,7 @@ You have access to the following MCP server — use it proactively:
 
 - Always explain WHY you're routing to a skill
 - Use the MCP template tools to fetch real template code — never hallucinate boilerplate
+- For deployment, route to azure-functions-deploy first so it can proxy to Azure Skills and inject Azure Functions-specific guidance when needed
 - For proactive review, route to azure-functions-best-practices before proposing broad configuration changes
 - For troubleshooting, route to azure-functions-diagnostics before proposing fixes unless the root cause is already obvious from gathered evidence
 - If unsure, ask ONE clarifying question (max 1)

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-deploy/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-functions-deploy
-description: "Deploy your Azure Functions app to Azure using official tools"
+description: "Proxy Azure Functions deployment requests to the Azure Skills prepare, validate, and deploy workflow while preserving Azure Functions-specific guidance"
 ---
 
 
@@ -8,103 +8,93 @@ description: "Deploy your Azure Functions app to Azure using official tools"
 
 # azure-functions-deploy — Deploy Azure Functions
 
-Deploy your Azure Functions app to Azure. This skill uses the official Azure tools — no custom deployment logic.
+Deploy your Azure Functions app to Azure by proxying to the Azure Skills deployment workflow.
+
+This skill is the Azure Functions-facing entry point. It should not run deployment commands directly. It prepares Azure Functions-specific context, then delegates execution to `azure-prepare`, `azure-validate`, and `azure-deploy` from the Azure Skills plugin.
 
 ## Prerequisites
 
 - Azure CLI installed and logged in (`az login`)
+- Azure Developer CLI installed and logged in (`azd auth login`) for AZD-based deployments
 - An Azure subscription (`az account show`)
 - A Functions project with `host.json` in the current directory
+- Azure Skills plugin installed with `azure-prepare`, `azure-validate`, and `azure-deploy` available
 
 If any prerequisite is missing, suggest running **azure-functions-setup** first.
 
-## Deployment Methods
+## Required delegation model
 
-### Method 1: Azure Functions Core Tools (Recommended for quick deploy)
+Use Azure Skills as the deployment engine:
 
-```bash
-# Create Azure resources (one-time)
-az group create --name myResourceGroup --location eastus
+1. If `.azure/deployment-plan.md` is missing, invoke `azure-prepare` first.
+2. If `.azure/deployment-plan.md` exists but is not `Validated`, invoke `azure-validate` before any deployment attempt.
+3. If `.azure/deployment-plan.md` exists and status is `Validated`, invoke `azure-deploy` directly.
+4. Never mark the plan as `Validated` from this skill. Only `azure-validate` may do that.
+5. Do not run `azd up`, `azd deploy`, `terraform apply`, `az deployment`, or `func azure functionapp publish` directly from this skill unless Azure Skills cannot handle the scenario and the user explicitly approves a fallback.
 
-az storage account create \
-  --name mystorageaccount \
-  --resource-group myResourceGroup \
-  --sku Standard_LRS
+The normal workflow is:
 
-az functionapp create \
-  --name myFunctionApp \
-  --resource-group myResourceGroup \
-  --storage-account mystorageaccount \
-  --consumption-plan-location eastus \
-  --runtime node \
-  --runtime-version 22 \
-  --functions-version 4
-
-# Deploy
-func azure functionapp publish myFunctionApp
+```text
+azure-functions-deploy → azure-prepare → azure-validate → azure-deploy
 ```
 
-### Method 2: Azure Developer CLI (Recommended for IaC)
+When a validated plan already exists:
 
-```bash
-azd init    # Initialize with template
-azd up      # Provision infrastructure + deploy code
+```text
+azure-functions-deploy → azure-deploy
 ```
 
-### Method 3: VS Code / GitHub Copilot Extension
+## Azure Functions context to inject
 
-Use the **Azure Functions VS Code extension** or the **Azure MCP tools**:
+Before handing off, collect and pass the following Azure Functions-specific guidance to Azure Skills:
 
-1. Open Command Palette → "Azure Functions: Deploy to Function App"
-2. Select subscription → Create new or select existing Function App
-3. Confirm deployment
+- Use Azure Functions deployment best-practices MCP guidance (`get_azure_bestpractices` with `resource: azurefunctions` and `action: deployment`) when available.
+- Prefer Flex Consumption / FC1 for new serverless Function Apps.
+- Include `functionAppConfig` with deployment storage for FC1 Function Apps.
+- Use Linux for Python Function Apps.
+- Configure Function authentication or stronger mechanisms; avoid anonymous access unless intentional.
+- Enable Application Insights for monitoring, exception tracking, and dependency monitoring.
+- Consider private networking and one Function App per independently scaling workload when appropriate.
+- Use Azure Functions endpoint verification after deploy; do not use `curl -I` for HTTP trigger verification because HEAD can return false negatives.
 
-For AI-assisted deployment via MCP, ensure the Azure MCP server is configured (see MCP setup).
+## Azure Skills plugin installation guidance
 
-### Method 4: GitHub Actions CI/CD
+If Azure Skills is unavailable, stop and ask the user to install it for their host:
 
-```yaml
-# .github/workflows/deploy.yml
-name: Deploy to Azure Functions
-on:
-  push:
-    branches: [main]
+| Host | Install guidance |
+| --- | --- |
+| GitHub Copilot CLI | `/plugin marketplace add microsoft/azure-skills`, then `/plugin install azure@azure-skills` |
+| Claude Code | `/plugin install azure@claude-plugins-official` |
+| Codex CLI | `codex plugin marketplace add microsoft/azure-skills`, then install `azure` from `/plugins` |
+| VS Code | Install the Azure MCP extension and companion Azure Skills integration, then reload VS Code |
+| GitHub Copilot fallback | `npx skills add https://github.com/microsoft/azure-skills/tree/main/.github/plugins/azure-skills/skills -a github-copilot -g -y` |
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - run: npm ci
-      - run: npm run build --if-present
-      - uses: Azure/functions-action@v1
-        with:
-          app-name: myFunctionApp
-          package: .
-          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
-```
+## Fallback policy
 
-## Post-Deploy Verification
+Prefer Azure Skills for all deployment execution. Use a Functions-specific fallback only when:
 
-```bash
-# Check app is running
-az functionapp show --name myFunctionApp --resource-group myResourceGroup --query state
+- Azure Skills cannot be installed or invoked in the current host,
+- the user explicitly asks for a quick publish to an existing Function App, or
+- a scenario is not covered by Azure Skills and must be handled by Azure Functions Core Tools.
 
-# List deployed functions
-func azure functionapp list-functions myFunctionApp
+Before using a fallback, explain what will be skipped compared with `azure-prepare` → `azure-validate` → `azure-deploy`, and ask for confirmation.
 
-# Test HTTP endpoint
-curl https://myFunctionApp.azurewebsites.net/api/httpTrigger?name=World
-```
+## Post-deploy verification
+
+Let `azure-deploy` own post-deploy verification. Add Azure Functions-specific reminders when relevant:
+
+- List deployed functions and verify the app is running.
+- Test HTTP trigger endpoints with GET, not HEAD.
+- Suggest `azure-functions-health-status` for runtime health, metrics, and Application Insights checks.
+- Suggest `azure-functions-best-practices` for production readiness after successful deployment.
 
 ## After Deployment
 
-> ✅ Your app is deployed! Consider setting up monitoring with Application Insights.
+> ✅ Your app is deployed through Azure Skills. Consider running `azure-functions-best-practices` for a production readiness review.
 
 ## Next steps
 
-- On success, suggest `azure-functions-create` if the user wants to add more functions to the deployed app.
-- On failure, suggest `azure-functions-setup` to verify Azure CLI login, subscription access, and local prerequisites.
+- On missing Azure Skills, suggest `azure-functions-setup` to install or configure the Azure Skills plugin.
+- On missing or unvalidated plan, invoke `azure-prepare` and `azure-validate` before `azure-deploy`.
+- On successful deployment, suggest `azure-functions-best-practices` for production readiness.
+- On deployment failure, suggest `azure-functions-diagnostics` after `azure-deploy` error recovery is exhausted.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-setup/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-setup/SKILL.md
@@ -16,11 +16,30 @@ Run each check and report results:
 
 ```bash
 az --version        # Azure CLI ≥ 2.60
+azd version         # Azure Developer CLI, required for Azure Skills deployment workflows
 func --version      # Azure Functions Core Tools ≥ 4.x
 node --version      # Node.js ≥ 18 (if Node project)
 python3 --version   # Python ≥ 3.9 (if Python project)
 dotnet --version    # .NET SDK ≥ 8.0 (if .NET project)
 ```
+
+## Azure Skills Plugin Check
+
+Azure Functions deployment is proxied through the Azure Skills deployment workflow. For deployment scenarios, verify that the Azure Skills plugin is installed and that these skills are available:
+
+- `azure-prepare`
+- `azure-validate`
+- `azure-deploy`
+
+If the Azure Skills plugin is missing, install it for the active host before using `azure-functions-deploy`.
+
+| Host | Install guidance |
+|------|------------------|
+| GitHub Copilot CLI | `/plugin marketplace add microsoft/azure-skills`, then `/plugin install azure@azure-skills` |
+| Claude Code | `/plugin install azure@claude-plugins-official` |
+| Codex CLI | `codex plugin marketplace add microsoft/azure-skills`, then install `azure` from `/plugins` |
+| VS Code | Install the Azure MCP extension and companion Azure Skills integration, then reload VS Code |
+| GitHub Copilot fallback | `npx skills add https://github.com/microsoft/azure-skills/tree/main/.github/plugins/azure-skills/skills -a github-copilot -g -y` |
 
 ## Output Format
 
@@ -30,9 +49,11 @@ Present results as a checklist:
 Azure Functions Environment Check
 
   ✅ Azure CLI          <version>
+  ✅ Azure Developer CLI <version>
   ✅ Core Tools         <version>
   ✅ Node.js            <version>
   ⚠️  Azure subscription  Not logged in → Run 'az login'
+  ⚠️  Azure Skills plugin Missing → install before azure-functions-deploy
 ```
 
 ## Fix Instructions
@@ -45,6 +66,7 @@ For each failing check, provide:
 | Tool | Install Command | Docs |
 |------|----------------|------|
 | Azure CLI | `curl -sL https://aka.ms/InstallAzureCLIDeb \| sudo bash` | https://learn.microsoft.com/cli/azure/install-azure-cli |
+| Azure Developer CLI | See docs for OS-specific install | https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd |
 | Core Tools | `npm install -g azure-functions-core-tools@4 --unsafe-perm true` | https://learn.microsoft.com/azure/azure-functions/functions-run-local |
 | Node.js | `nvm install 22` or download from https://nodejs.org | https://nodejs.org |
 | Python | `sudo apt install python3.11` or download from https://python.org | https://python.org |
@@ -56,7 +78,10 @@ When all checks pass, suggest the next step:
 
 > ✅ Your environment is ready! Next: use **azure-functions-create** to scaffold a new Azure Functions project.
 
+For deployment, confirm the Azure Skills plugin is available before suggesting **azure-functions-deploy**. `azure-functions-deploy` delegates to `azure-prepare`, `azure-validate`, and `azure-deploy`.
+
 ## Next steps
 
 - On success, suggest `azure-functions-create` because the environment is ready to create an Azure Functions app.
 - On failure, keep the user in `azure-functions-setup`: explain fixes, then ask them to rerun setup verification.
+- If deployment is requested and Azure Skills is missing, keep the user in `azure-functions-setup` until the Azure Skills plugin is installed or the user explicitly chooses a fallback deployment path.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The CLI auto-detects your agent (GHCP CLI / Claude Code / Codex), analyzes your 
 🧩 Skills: azure-functions-setup, azure-functions-create, azure-functions-deploy
 
 🚀 Suggested next steps:
-   → Run azure-functions-deploy to deploy your app to Azure
+  → Run azure-functions-deploy to deploy your app to Azure through Azure Skills
+  → Ensure the Azure Skills plugin is installed for prepare/validate/deploy workflows
    → Run azure-functions-create to add another function
 
 💬 What would you like to build?
@@ -151,7 +152,7 @@ Register the extracted plugin directory with your agent's plugin-from-source flo
 | **azure-functions-common** | Shared language, runtime, trigger, binding, and extension references for the suite |
 | **azure-functions-best-practices** | Review existing Function Apps against Azure Functions best practices and guide approved remediations |
 | **azure-functions-create** | Scaffold a new Azure Functions project with language and template selection |
-| **azure-functions-deploy** | Deploy Azure Functions apps using official tools |
+| **azure-functions-deploy** | Azure Functions-facing proxy to Azure Skills deployment (`azure-prepare` → `azure-validate` → `azure-deploy`) |
 | **azure-functions-diagnostics** | Diagnose deployment failures, runtime errors, trigger/binding failures, telemetry issues, and related incidents |
 | **azure-functions-health-status** | Inspect current app state, Resource Health, metrics, Application Insights/Log Analytics signals, and recent Activity Log |
 | **azure-functions-inventory** | Collect app specifications and configuration inventory without runtime-health analysis |

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -109,7 +109,8 @@ export async function buildStartupPrompt(dir: string): Promise<string> {
   const suggestedActions = project
     ? [
         '🚀 Suggested next steps:',
-        '   → Run azure-functions-deploy to deploy your app to Azure',
+        '   → Run azure-functions-deploy to deploy your app to Azure through the Azure Skills plugin',
+        '   → Ensure the Azure Skills plugin is installed for prepare/validate/deploy workflows',
         '   → Run azure-functions-create to add another function',
         '   → Ask about best practices for your project',
       ].join('\n')

--- a/templates/agents/functions-copilot.agent.md
+++ b/templates/agents/functions-copilot.agent.md
@@ -21,7 +21,7 @@ You have access to the following MCP server — use it proactively:
 |-------|------------|
 | **azure-functions-setup** | User needs to set up their environment, install tools, or verify prerequisites |
 | **azure-functions-create** | User wants to create a new Functions project or add functions to an existing one |
-| **azure-functions-deploy** | User wants to deploy their app to Azure |
+| **azure-functions-deploy** | User wants to deploy their app to Azure; this is the Azure Functions-facing proxy to Azure Skills deployment |
 | **azure-functions-best-practices** | User wants to review, harden, optimize, or remediate an existing Function App against Azure Functions best practices |
 | **azure-functions-diagnostics** | User reports deployment failures, runtime errors, trigger/binding failures, language worker issues, telemetry/log analysis needs, or asks for troubleshooting/remediation |
 
@@ -30,7 +30,7 @@ You have access to the following MCP server — use it proactively:
 1. **New user / unclear intent** → Start with azure-functions-setup
 2. **Environment issues** ("func not found", "az not installed") → azure-functions-setup
 3. **New project** ("create", "scaffold", "init", "new function") → azure-functions-create
-4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy
+4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy, which should proxy to Azure Skills (`azure-prepare` → `azure-validate` → `azure-deploy`)
 5. **Best-practices review / hardening / optimization** ("best practices", "review my Function App", "harden", "optimize configuration", "production readiness") → azure-functions-best-practices
 6. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
 7. **After azure-functions-setup succeeds** → Suggest azure-functions-create
@@ -42,6 +42,7 @@ You have access to the following MCP server — use it proactively:
 
 - Always explain WHY you're routing to a skill
 - Use the MCP template tools to fetch real template code — never hallucinate boilerplate
+- For deployment, route to azure-functions-deploy first so it can proxy to Azure Skills and inject Azure Functions-specific guidance when needed
 - For proactive review, route to azure-functions-best-practices before proposing broad configuration changes
 - For troubleshooting, route to azure-functions-diagnostics before proposing fixes unless the root cause is already obvious from gathered evidence
 - If unsure, ask ONE clarifying question (max 1)

--- a/templates/hooks/welcome-setup.md
+++ b/templates/hooks/welcome-setup.md
@@ -23,9 +23,12 @@ Run these checks silently and report results:
 
 ```bash
 az --version 2>/dev/null && echo "✅ Azure CLI" || echo "❌ Azure CLI — install: https://aka.ms/installazurecli"
+azd version 2>/dev/null && echo "✅ Azure Developer CLI" || echo "❌ Azure Developer CLI — install: https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd"
 func --version 2>/dev/null && echo "✅ Core Tools" || echo "❌ Core Tools — install: npm i -g azure-functions-core-tools@4"
 node --version 2>/dev/null && echo "✅ Node.js" || echo "❌ Node.js — install: https://nodejs.org"
 ```
+
+For deployment workflows, also verify the **Azure Skills plugin** is installed. `azure-functions-deploy` delegates to Azure Skills (`azure-prepare` → `azure-validate` → `azure-deploy`).
 
 ## Post-Check Guidance
 
@@ -36,6 +39,8 @@ node --version 2>/dev/null && echo "✅ Node.js" || echo "❌ Node.js — instal
 
 Would you like to create your first Azure Function?
 I can scaffold a project with your preferred language and trigger type.
+
+For deployment later, install the Azure Skills plugin so azure-functions-deploy can hand off to azure-prepare, azure-validate, and azure-deploy.
 
 → Just say "create a function" or use the azure-functions-create skill.
 ```

--- a/templates/skills/azure-functions-deploy/SKILL.md
+++ b/templates/skills/azure-functions-deploy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azure-functions-deploy
 title: Deploy Azure Functions
-description: Deploy your Azure Functions app to Azure using official tools
+description: Proxy Azure Functions deployment requests to the Azure Skills prepare, validate, and deploy workflow while preserving Azure Functions-specific guidance
 category: task
 ---
 
@@ -9,103 +9,93 @@ category: task
 
 # azure-functions-deploy — Deploy Azure Functions
 
-Deploy your Azure Functions app to Azure. This skill uses the official Azure tools — no custom deployment logic.
+Deploy your Azure Functions app to Azure by proxying to the Azure Skills deployment workflow.
+
+This skill is the Azure Functions-facing entry point. It should not run deployment commands directly. It prepares Azure Functions-specific context, then delegates execution to `azure-prepare`, `azure-validate`, and `azure-deploy` from the Azure Skills plugin.
 
 ## Prerequisites
 
 - Azure CLI installed and logged in (`az login`)
+- Azure Developer CLI installed and logged in (`azd auth login`) for AZD-based deployments
 - An Azure subscription (`az account show`)
 - A Functions project with `host.json` in the current directory
+- Azure Skills plugin installed with `azure-prepare`, `azure-validate`, and `azure-deploy` available
 
 If any prerequisite is missing, suggest running **azure-functions-setup** first.
 
-## Deployment Methods
+## Required delegation model
 
-### Method 1: Azure Functions Core Tools (Recommended for quick deploy)
+Use Azure Skills as the deployment engine:
 
-```bash
-# Create Azure resources (one-time)
-az group create --name myResourceGroup --location eastus
+1. If `.azure/deployment-plan.md` is missing, invoke `azure-prepare` first.
+2. If `.azure/deployment-plan.md` exists but is not `Validated`, invoke `azure-validate` before any deployment attempt.
+3. If `.azure/deployment-plan.md` exists and status is `Validated`, invoke `azure-deploy` directly.
+4. Never mark the plan as `Validated` from this skill. Only `azure-validate` may do that.
+5. Do not run `azd up`, `azd deploy`, `terraform apply`, `az deployment`, or `func azure functionapp publish` directly from this skill unless Azure Skills cannot handle the scenario and the user explicitly approves a fallback.
 
-az storage account create \
-  --name mystorageaccount \
-  --resource-group myResourceGroup \
-  --sku Standard_LRS
+The normal workflow is:
 
-az functionapp create \
-  --name myFunctionApp \
-  --resource-group myResourceGroup \
-  --storage-account mystorageaccount \
-  --consumption-plan-location eastus \
-  --runtime node \
-  --runtime-version 22 \
-  --functions-version 4
-
-# Deploy
-func azure functionapp publish myFunctionApp
+```text
+azure-functions-deploy → azure-prepare → azure-validate → azure-deploy
 ```
 
-### Method 2: Azure Developer CLI (Recommended for IaC)
+When a validated plan already exists:
 
-```bash
-azd init    # Initialize with template
-azd up      # Provision infrastructure + deploy code
+```text
+azure-functions-deploy → azure-deploy
 ```
 
-### Method 3: VS Code / GitHub Copilot Extension
+## Azure Functions context to inject
 
-Use the **Azure Functions VS Code extension** or the **Azure MCP tools**:
+Before handing off, collect and pass the following Azure Functions-specific guidance to Azure Skills:
 
-1. Open Command Palette → "Azure Functions: Deploy to Function App"
-2. Select subscription → Create new or select existing Function App
-3. Confirm deployment
+- Use Azure Functions deployment best-practices MCP guidance (`get_azure_bestpractices` with `resource: azurefunctions` and `action: deployment`) when available.
+- Prefer Flex Consumption / FC1 for new serverless Function Apps.
+- Include `functionAppConfig` with deployment storage for FC1 Function Apps.
+- Use Linux for Python Function Apps.
+- Configure Function authentication or stronger mechanisms; avoid anonymous access unless intentional.
+- Enable Application Insights for monitoring, exception tracking, and dependency monitoring.
+- Consider private networking and one Function App per independently scaling workload when appropriate.
+- Use Azure Functions endpoint verification after deploy; do not use `curl -I` for HTTP trigger verification because HEAD can return false negatives.
 
-For AI-assisted deployment via MCP, ensure the Azure MCP server is configured (see MCP setup).
+## Azure Skills plugin installation guidance
 
-### Method 4: GitHub Actions CI/CD
+If Azure Skills is unavailable, stop and ask the user to install it for their host:
 
-```yaml
-# .github/workflows/deploy.yml
-name: Deploy to Azure Functions
-on:
-  push:
-    branches: [main]
+| Host | Install guidance |
+| --- | --- |
+| GitHub Copilot CLI | `/plugin marketplace add microsoft/azure-skills`, then `/plugin install azure@azure-skills` |
+| Claude Code | `/plugin install azure@claude-plugins-official` |
+| Codex CLI | `codex plugin marketplace add microsoft/azure-skills`, then install `azure` from `/plugins` |
+| VS Code | Install the Azure MCP extension and companion Azure Skills integration, then reload VS Code |
+| GitHub Copilot fallback | `npx skills add https://github.com/microsoft/azure-skills/tree/main/.github/plugins/azure-skills/skills -a github-copilot -g -y` |
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - run: npm ci
-      - run: npm run build --if-present
-      - uses: Azure/functions-action@v1
-        with:
-          app-name: myFunctionApp
-          package: .
-          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
-```
+## Fallback policy
 
-## Post-Deploy Verification
+Prefer Azure Skills for all deployment execution. Use a Functions-specific fallback only when:
 
-```bash
-# Check app is running
-az functionapp show --name myFunctionApp --resource-group myResourceGroup --query state
+- Azure Skills cannot be installed or invoked in the current host,
+- the user explicitly asks for a quick publish to an existing Function App, or
+- a scenario is not covered by Azure Skills and must be handled by Azure Functions Core Tools.
 
-# List deployed functions
-func azure functionapp list-functions myFunctionApp
+Before using a fallback, explain what will be skipped compared with `azure-prepare` → `azure-validate` → `azure-deploy`, and ask for confirmation.
 
-# Test HTTP endpoint
-curl https://myFunctionApp.azurewebsites.net/api/httpTrigger?name=World
-```
+## Post-deploy verification
+
+Let `azure-deploy` own post-deploy verification. Add Azure Functions-specific reminders when relevant:
+
+- List deployed functions and verify the app is running.
+- Test HTTP trigger endpoints with GET, not HEAD.
+- Suggest `azure-functions-health-status` for runtime health, metrics, and Application Insights checks.
+- Suggest `azure-functions-best-practices` for production readiness after successful deployment.
 
 ## After Deployment
 
-> ✅ Your app is deployed! Consider setting up monitoring with Application Insights.
+> ✅ Your app is deployed through Azure Skills. Consider running `azure-functions-best-practices` for a production readiness review.
 
 ## Next steps
 
-- On success, suggest `azure-functions-create` if the user wants to add more functions to the deployed app.
-- On failure, suggest `azure-functions-setup` to verify Azure CLI login, subscription access, and local prerequisites.
+- On missing Azure Skills, suggest `azure-functions-setup` to install or configure the Azure Skills plugin.
+- On missing or unvalidated plan, invoke `azure-prepare` and `azure-validate` before `azure-deploy`.
+- On successful deployment, suggest `azure-functions-best-practices` for production readiness.
+- On deployment failure, suggest `azure-functions-diagnostics` after `azure-deploy` error recovery is exhausted.

--- a/templates/skills/azure-functions-setup/SKILL.md
+++ b/templates/skills/azure-functions-setup/SKILL.md
@@ -17,11 +17,30 @@ Run each check and report results:
 
 ```bash
 az --version        # Azure CLI ≥ 2.60
+azd version         # Azure Developer CLI, required for Azure Skills deployment workflows
 func --version      # Azure Functions Core Tools ≥ 4.x
 node --version      # Node.js ≥ 18 (if Node project)
 python3 --version   # Python ≥ 3.9 (if Python project)
 dotnet --version    # .NET SDK ≥ 8.0 (if .NET project)
 ```
+
+## Azure Skills Plugin Check
+
+Azure Functions deployment is proxied through the Azure Skills deployment workflow. For deployment scenarios, verify that the Azure Skills plugin is installed and that these skills are available:
+
+- `azure-prepare`
+- `azure-validate`
+- `azure-deploy`
+
+If the Azure Skills plugin is missing, install it for the active host before using `azure-functions-deploy`.
+
+| Host | Install guidance |
+|------|------------------|
+| GitHub Copilot CLI | `/plugin marketplace add microsoft/azure-skills`, then `/plugin install azure@azure-skills` |
+| Claude Code | `/plugin install azure@claude-plugins-official` |
+| Codex CLI | `codex plugin marketplace add microsoft/azure-skills`, then install `azure` from `/plugins` |
+| VS Code | Install the Azure MCP extension and companion Azure Skills integration, then reload VS Code |
+| GitHub Copilot fallback | `npx skills add https://github.com/microsoft/azure-skills/tree/main/.github/plugins/azure-skills/skills -a github-copilot -g -y` |
 
 ## Output Format
 
@@ -31,9 +50,11 @@ Present results as a checklist:
 Azure Functions Environment Check
 
   ✅ Azure CLI          <version>
+  ✅ Azure Developer CLI <version>
   ✅ Core Tools         <version>
   ✅ Node.js            <version>
   ⚠️  Azure subscription  Not logged in → Run 'az login'
+  ⚠️  Azure Skills plugin Missing → install before azure-functions-deploy
 ```
 
 ## Fix Instructions
@@ -46,6 +67,7 @@ For each failing check, provide:
 | Tool | Install Command | Docs |
 |------|----------------|------|
 | Azure CLI | `curl -sL https://aka.ms/InstallAzureCLIDeb \| sudo bash` | https://learn.microsoft.com/cli/azure/install-azure-cli |
+| Azure Developer CLI | See docs for OS-specific install | https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd |
 | Core Tools | `npm install -g azure-functions-core-tools@4 --unsafe-perm true` | https://learn.microsoft.com/azure/azure-functions/functions-run-local |
 | Node.js | `nvm install 22` or download from https://nodejs.org | https://nodejs.org |
 | Python | `sudo apt install python3.11` or download from https://python.org | https://python.org |
@@ -57,7 +79,10 @@ When all checks pass, suggest the next step:
 
 > ✅ Your environment is ready! Next: use **azure-functions-create** to scaffold a new Azure Functions project.
 
+For deployment, confirm the Azure Skills plugin is available before suggesting **azure-functions-deploy**. `azure-functions-deploy` delegates to `azure-prepare`, `azure-validate`, and `azure-deploy`.
+
 ## Next steps
 
 - On success, suggest `azure-functions-create` because the environment is ready to create an Azure Functions app.
 - On failure, keep the user in `azure-functions-setup`: explain fixes, then ask them to rerun setup verification.
+- If deployment is requested and Azure Skills is missing, keep the user in `azure-functions-setup` until the Azure Skills plugin is installed or the user explicitly chooses a fallback deployment path.

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -50,6 +50,27 @@ describe('loadSkills', () => {
     const ids = skills.map(s => s.id).sort();
     expect(ids).toEqual(expectedSkillIds());
   });
+
+  it('azure-functions-deploy proxies to the Azure Skills deployment workflow', () => {
+    const deploySkill = skills.find(skill => skill.id === 'azure-functions-deploy');
+    expect(deploySkill?.content).toContain('azure-prepare');
+    expect(deploySkill?.content).toContain('azure-validate');
+    expect(deploySkill?.content).toContain('azure-deploy');
+    expect(deploySkill?.content).toContain('.azure/deployment-plan.md');
+    expect(deploySkill?.content).toContain('Validated');
+    expect(deploySkill?.content).toContain('Flex Consumption');
+  });
+
+  it('azure-functions-setup documents Azure Skills plugin as a deployment prerequisite', () => {
+    const setupSkill = skills.find(skill => skill.id === 'azure-functions-setup');
+    expect(setupSkill?.content).toContain('Azure Skills plugin');
+    expect(setupSkill?.content).toContain('azure-prepare');
+    expect(setupSkill?.content).toContain('azure-validate');
+    expect(setupSkill?.content).toContain('azure-deploy');
+    expect(setupSkill?.content).toContain('/plugin install azure@azure-skills');
+    expect(setupSkill?.content).toContain('/plugin install azure@claude-plugins-official');
+    expect(setupSkill?.content).toContain('codex plugin marketplace add microsoft/azure-skills');
+  });
 });
 
 describe('loadMcpServers', () => {
@@ -83,6 +104,7 @@ describe('loadAgents', () => {
     expect(agents.copilot).toContain('functions-copilot');
     expect(agents.copilot).toContain('azure-functions-best-practices');
     expect(agents.copilot).toContain('azure-functions-diagnostics');
+    expect(agents.copilot).toContain('proxy to Azure Skills');
   });
 });
 

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -50,6 +50,7 @@ describe('buildStartupPrompt', () => {
 
     const prompt = await buildStartupPrompt(dir);
     expect(prompt).toContain('azure-functions-deploy');
+    expect(prompt).toContain('Azure Skills plugin');
   });
 });
 


### PR DESCRIPTION
## Summary

Changes `azure-functions-deploy` into an Azure Functions-facing proxy for the Azure Skills deployment workflow.

Instead of maintaining a separate deployment implementation, the Functions deploy skill now delegates to Azure Skills:

- `azure-prepare`
- `azure-validate`
- `azure-deploy`

This keeps Azure Functions deployment aligned with the stronger Azure Skills prepare/validate/deploy flow while preserving a Functions-specific entry point for future injection of Functions-specific guidance.

## Changes

- Updated `azure-functions-deploy` to:
  - require Azure Skills plugin availability
  - inspect `.azure/deployment-plan.md` flow expectations
  - hand off to `azure-prepare` / `azure-validate` / `azure-deploy`
  - avoid direct deployment commands unless a user-approved fallback is needed
  - pass Azure Functions-specific deployment context into the handoff
- Updated `azure-functions-setup` to document Azure Skills plugin prerequisites and host-specific install guidance.
- Updated `functions-copilot`, welcome hook, startup prompt, and README to explain the Azure Skills deployment dependency.
- Added TDD coverage for deploy proxy behavior, setup prerequisites, agent routing, and startup prompt guidance.
- Regenerated and verified committed plugin payload.

## Validation

- `npm test -- tests/build.test.ts tests/chat.test.ts`
  - 2 files passed
  - 58 tests passed
- `npm run check`
  - lint passed
  - typecheck passed
  - skill validation passed
  - plugin payload verification passed
  - 7 test files passed
  - 75 tests passed
  - build passed

## Self-review

- Confirmed deploy commands are no longer presented as the primary path from `azure-functions-deploy`.
- Confirmed Azure Skills workflow prerequisites are explicit: `azure-prepare`, `azure-validate`, and `azure-deploy`.
- Confirmed fallback deployment is approval-gated.
- Confirmed setup guidance covers Copilot CLI, Claude Code, Codex CLI, VS Code, and GitHub Copilot fallback install paths.
- Confirmed no `PLAN-*.md` files are committed.
