### PR TITLE
feat: install Azure Skills prerequisite for Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ azure-functions-skills setup
 ```
 
 The CLI auto-detects which coding agents you have (GitHub Copilot, Claude Code, Codex) and installs the right files.
+For GitHub Copilot, `setup` also checks for the Azure Skills plugin used by the deployment workflow and installs it through the Copilot plugin CLI when available.
 
 ```
 🔍 Detecting coding agents...
@@ -41,6 +42,9 @@ The CLI auto-detects which coding agents you have (GitHub Copilot, Claude Code, 
     • azure-functions-inventory — Azure Functions Inventory
     • azure-functions-setup — Azure Functions Setup
 
+  External prerequisites:
+    • azure-skills (ghcp) — installed: Azure Skills plugin installed for GitHub Copilot.
+
   Get started: Ask your AI assistant to "set up Azure Functions"
 ```
 
@@ -50,7 +54,11 @@ The CLI auto-detects which coding agents you have (GitHub Copilot, Claude Code, 
 npx @agent-loom/azure-functions-skills setup --agent ghcp
 npx @agent-loom/azure-functions-skills setup --agent claude --agent codex
 npx @agent-loom/azure-functions-skills setup --dir ./my-app
+npx @agent-loom/azure-functions-skills setup --check-prerequisites
+npx @agent-loom/azure-functions-skills setup --skip-prerequisites
 ```
+
+`--check-prerequisites` reports missing external prerequisites without installing them. `--skip-prerequisites` disables external checks for CI or offline environments.
 
 ### Launch with Welcome Prompt (`chat`)
 
@@ -87,7 +95,11 @@ Specify an agent or custom prompt:
 npx @agent-loom/azure-functions-skills chat --agent github-copilot
 npx @agent-loom/azure-functions-skills chat --agent codex --dir ./my-app
 npx @agent-loom/azure-functions-skills chat --prompt "Create an HTTP trigger function"
+npx @agent-loom/azure-functions-skills chat --check-prerequisites
+npx @agent-loom/azure-functions-skills chat --skip-prerequisites
 ```
+
+When `chat` launches GitHub Copilot CLI, it checks for Azure Skills before launch. If the shell-level Copilot plugin command is unavailable, it prints the manual plugin commands and continues.
 
 ### Use as a Library (VS Code Extension)
 

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -29,12 +29,16 @@ if (!command || command === '--help' || command === '-h') {
     --agent <name>     Specify agent: ghcp, claude, codex (repeatable)
     --dir <path>       Target directory (default: current directory)
     --as-plugin        Register as a native platform plugin (instead of copying files)
+    --check-prerequisites  Check external prerequisites without installing them
+    --skip-prerequisites   Skip external prerequisite checks
 
   Options (chat):
     --agent <name>     Agent: github-copilot, claude-code, codex (auto-detected if omitted)
     --prompt <text>    Custom prompt (overrides startup template)
     --dir <path>       Working directory (default: current directory)
     --as-plugin        Ensure plugin is registered before launching agent
+    --check-prerequisites  Check external prerequisites without installing them
+    --skip-prerequisites   Skip external prerequisite checks
 
   Options (build):
     --target <name>    Build target: ghcp, claude, codex
@@ -53,6 +57,7 @@ if (command === 'setup') {
   const agents = [];
   let dir = process.cwd();
   let asPlugin = false;
+  let prerequisites = 'auto';
 
   for (let i = 1; i < args.length; i++) {
     if (args[i] === '--agent' && args[i + 1]) {
@@ -61,6 +66,10 @@ if (command === 'setup') {
       dir = args[++i];
     } else if (args[i] === '--as-plugin') {
       asPlugin = true;
+    } else if (args[i] === '--check-prerequisites') {
+      prerequisites = 'check-only';
+    } else if (args[i] === '--skip-prerequisites') {
+      prerequisites = 'skip';
     }
   }
 
@@ -104,10 +113,18 @@ if (command === 'setup') {
     }
 
     console.log('\n⚡ Plugins registered! Updates will be picked up automatically when you update the npm package.');
+
+    const { ensurePrerequisites } = await import('../lib/setup/prerequisites/index.js');
+    const prerequisiteResults = await ensurePrerequisites({
+      targets: detectedAgents,
+      projectDir: dir,
+      mode: prerequisites,
+    });
+    printPrerequisiteResults(prerequisiteResults);
   } else {
     // File copy mode (original behavior)
     console.log(`\n📁 Installing to: ${dir}\n`);
-    const result = await applySetup(dir, { agents: detectedAgents });
+    const result = await applySetup(dir, { agents: detectedAgents, prerequisites });
     console.log(result.welcomeMessage);
   }
 } else if (command === 'chat') {
@@ -117,12 +134,15 @@ if (command === 'setup') {
   let prompt = null;
   let dir = process.cwd();
   let asPlugin = false;
+  let prerequisites = 'auto';
 
   for (let i = 1; i < args.length; i++) {
     if (args[i] === '--agent' && args[i + 1]) agent = args[++i];
     else if (args[i] === '--prompt' && args[i + 1]) prompt = args[++i];
     else if (args[i] === '--dir' && args[i + 1]) dir = args[++i];
     else if (args[i] === '--as-plugin') asPlugin = true;
+    else if (args[i] === '--check-prerequisites') prerequisites = 'check-only';
+    else if (args[i] === '--skip-prerequisites') prerequisites = 'skip';
   }
 
   // If --as-plugin, ensure plugin is registered first
@@ -168,6 +188,7 @@ if (command === 'setup') {
 
   const options = { agent, dir };
   if (prompt) options.prompt = prompt;
+  options.prerequisites = prerequisites;
   await chat(options);
 } else if (command === 'build') {
   // Delegate to build script
@@ -180,4 +201,17 @@ if (command === 'setup') {
 } else {
   console.error(`Unknown command: ${command}`);
   process.exit(1);
+}
+
+function printPrerequisiteResults(results) {
+  const actionable = results.filter(result => result.status !== 'present' && result.status !== 'skipped');
+  if (actionable.length === 0) return;
+
+  console.log('\nExternal prerequisites:');
+  for (const result of actionable) {
+    console.log(`  ⚠️  ${result.id} (${result.target}): ${result.message}`);
+    for (const command of result.commands || []) {
+      console.log(`     → ${command}`);
+    }
+  }
 }

--- a/docs/azure-skills-prerequisite-cli-design.md
+++ b/docs/azure-skills-prerequisite-cli-design.md
@@ -1,0 +1,311 @@
+# Azure Skills Prerequisite Handling for CLI Setup/Chat
+
+## Context
+
+`azure-functions-deploy` delegates deployment execution to Azure Skills (`azure-prepare` → `azure-validate` → `azure-deploy`). Therefore the CLI commands in this package must not only install Azure Functions Skills, but also ensure the Azure Skills plugin is available for deployment scenarios.
+
+Tracking issue: https://github.com/Azure/azure-functions-skills/issues/46
+
+## Goals
+
+- Add CLI-level prerequisite handling for Azure Skills in `setup` and `chat`.
+- Support GitHub Copilot first.
+- Use a structure that can later add Claude Code and Codex without changing setup/chat call sites.
+- Prefer automatic installation for GitHub Copilot only when a reliable shell-executable path is available.
+- Return clear status: already present, installed, skipped, unsupported, failed, or manual action required.
+
+## Non-goals
+
+- Do not vendor or copy Azure Skills content into this repository.
+- Do not implement Claude Code or Codex installation in the first PR.
+- Do not block non-deployment use cases when Azure Skills installation fails; report the limitation and continue installing Azure Functions Skills.
+- Do not execute agent slash commands from the shell. Slash-command install paths should be shown as manual guidance unless the host exposes a reliable CLI equivalent.
+
+## Proposed architecture
+
+Add a shared prerequisite module under `src/setup/`:
+
+```text
+src/setup/prerequisites/
+  index.ts
+  azure-skills.ts
+  types.ts
+```
+
+### Types
+
+```ts
+export type PrerequisiteMode = 'auto' | 'check-only' | 'skip';
+export type PrerequisiteStatus =
+  | 'present'
+  | 'installed'
+  | 'manual-action-required'
+  | 'unsupported'
+  | 'skipped'
+  | 'failed';
+
+export interface PrerequisiteContext {
+  target: BuildTargetName;
+  projectDir: string;
+  mode: PrerequisiteMode;
+  runner?: CommandRunner;
+}
+
+export interface PrerequisiteResult {
+  id: string;
+  target: BuildTargetName;
+  status: PrerequisiteStatus;
+  message: string;
+  commands?: string[];
+  details?: string[];
+}
+
+export interface PrerequisiteProvider {
+  id: string;
+  supports(target: BuildTargetName): boolean;
+  check(context: PrerequisiteContext): Promise<PrerequisiteResult>;
+  install(context: PrerequisiteContext): Promise<PrerequisiteResult>;
+}
+```
+
+`setup` and `chat` should call one shared function:
+
+```ts
+ensurePrerequisites({
+  targets,
+  projectDir,
+  mode: 'auto',
+  prerequisites: ['azure-skills'],
+});
+```
+
+This keeps setup/chat free of host-specific Azure Skills logic.
+
+## GitHub Copilot provider design
+
+### Target mapping
+
+Use `BuildTargetName` as the provider target:
+
+| Agent / launcher | Build target | Provider support in first PR |
+| --- | --- | --- |
+| GitHub Copilot CLI / VS Code-compatible layout | `ghcp` | Yes, auto-install only when `copilot plugin ...` is available |
+| Claude Code | `claude` | No, return `unsupported` through the shared provider pipeline |
+| Codex CLI | `codex` | No, return `unsupported` through the shared provider pipeline |
+
+### Detection strategy for `ghcp`
+
+Use best-effort detection in this order:
+
+1. **GitHub Copilot CLI plugin list**
+  - Run `copilot plugin list` when the `copilot` command is available.
+  - Treat `azure` / `azure-skills` as present when listed.
+  - This is the primary detection path because a plugin install is normally global/host-managed, not copied into the workspace.
+
+2. **Workspace skill presence fallback**
+  - Check for `.github/skills/azure-deploy/SKILL.md`, `.github/skills/azure-prepare/SKILL.md`, and `.github/skills/azure-validate/SKILL.md` under `projectDir` only as a compatibility fallback for manual/global `skills add` layouts.
+  - Do not rely on workspace files as the plugin-mode signal.
+
+3. **No reliable signal**
+   - Return `manual-action-required` in `check-only` mode.
+  - In `auto` mode, attempt the GitHub Copilot CLI plugin install below.
+
+### Install strategy for `ghcp`
+
+Prefer the GitHub Copilot CLI plugin commands when the `copilot` command is available:
+
+```bash
+copilot plugin marketplace add microsoft/azure-skills
+copilot plugin install azure@azure-skills
+```
+
+These are shell-level equivalents of the interactive slash commands documented by Azure Skills:
+
+```text
+/plugin marketplace add microsoft/azure-skills
+/plugin install azure@azure-skills
+```
+
+The shell-executable `skills add` path is not implemented in the first PR. Keep it as a documented manual recovery option only, because it is not a host plugin install:
+
+```bash
+npx skills add https://github.com/microsoft/azure-skills/tree/main/.github/plugins/azure-skills/skills -a github-copilot -g -y
+```
+
+If the command succeeds:
+
+- return `installed`
+- include a message that the user may need to reload/restart the host for skill indexing
+- optionally rerun `copilot plugin list`, but do not fail if the plugin list output is not parseable immediately after install
+
+If the command fails:
+
+- return `manual-action-required`
+- show manual Copilot plugin commands:
+  - `/plugin marketplace add microsoft/azure-skills`
+  - `/plugin install azure@azure-skills`
+
+### VS Code Copilot behavior
+
+The first implementation targets the shell-available GitHub Copilot CLI plugin commands. For VS Code-only environments where `copilot plugin ...` is unavailable, setup/chat should not fail or try to mutate unknown VS Code state. Instead, the provider returns `manual-action-required` with the equivalent Copilot slash commands and the setup skill can guide the user through host-specific installation.
+
+### Manual guidance for future providers
+
+For `claude`:
+
+```text
+/plugin install azure@claude-plugins-official
+```
+
+For `codex`:
+
+```bash
+codex plugin marketplace add microsoft/azure-skills
+```
+
+Then install `azure` from `/plugins`.
+
+## setup integration
+
+`applySetup` should accept prerequisite options:
+
+```ts
+export interface SetupOptions {
+  agents?: CliAgentName[];
+  prerequisites?: PrerequisiteMode;
+}
+```
+
+Default behavior:
+
+- `setup`: `auto`
+- `setup --skip-prerequisites`: `skip`
+- `setup --check-prerequisites`: `check-only`
+
+Flow:
+
+1. Detect agents.
+2. Install Azure Functions Skills workspace files as today.
+3. Run `ensurePrerequisites` for selected targets.
+4. Include prerequisite results in `SetupResult` and welcome message.
+
+`SetupResult` extension:
+
+```ts
+export interface SetupResult {
+  agents: CliAgentName[];
+  filesWritten: number;
+  welcomeMessage: string;
+  prerequisites?: PrerequisiteResult[];
+}
+```
+
+## chat integration
+
+`chat` should ensure prerequisites before launching the selected agent:
+
+1. Map launcher to setup target (`github-copilot` → `ghcp`).
+2. Run current auto-setup if Azure Functions Skills are missing.
+3. Run `ensurePrerequisites` for Azure Skills.
+4. Print concise prerequisite status to stderr.
+5. Launch agent even if Azure Skills install requires manual action, but include the manual action in startup output so users know deployment is limited.
+
+`ChatOptions` extension:
+
+```ts
+export interface ChatOptions {
+  agent?: LauncherId;
+  prompt?: string;
+  dir?: string;
+  prerequisites?: PrerequisiteMode;
+}
+```
+
+Default behavior:
+
+- `chat`: `auto`
+- `chat --skip-prerequisites`: `skip`
+- `chat --check-prerequisites`: `check-only`
+
+## CLI flags
+
+Add shared setup/chat flags:
+
+```text
+--skip-prerequisites   Do not check or install external prerequisites such as Azure Skills
+--check-prerequisites  Check prerequisites and print guidance, but do not install
+```
+
+Default is `auto` because the user asked setup/chat to install Azure Skills when missing.
+
+## Test plan
+
+### Unit tests
+
+- `azureSkillsProvider.supports('ghcp')` returns true.
+- `azureSkillsProvider.supports('claude' | 'codex')` returns false or manual-only for first PR.
+- `check` returns `present` when `copilot plugin list` includes `azure` or `azure-skills`.
+- `check` returns `present` when all workspace Azure Skills files exist only as fallback.
+- `install` invokes `copilot plugin marketplace add microsoft/azure-skills` and `copilot plugin install azure@azure-skills` for `ghcp` in `auto` mode when `copilot` is available.
+- The first implementation does not run the `npx skills add ... -a github-copilot -g -y` fallback automatically.
+- `install` returns `manual-action-required` with slash-command guidance when command execution fails.
+- `ensurePrerequisites` aggregates provider results and does not throw for manual-action-required.
+
+### setup tests
+
+- `applySetup(..., { agents: ['ghcp'] })` calls Azure Skills prerequisite handling by default.
+- `applySetup(..., { prerequisites: 'skip' })` does not call prerequisite handling.
+- `SetupResult.welcomeMessage` includes Azure Skills prerequisite status.
+
+### chat tests
+
+- `chat({ agent: 'github-copilot' })` runs prerequisite handling before launch.
+- `chat({ prerequisites: 'skip' })` skips prerequisite handling.
+- Missing Azure Skills does not prevent chat launch when the result is `manual-action-required`; it prints guidance.
+
+### CLI tests
+
+- `setup --skip-prerequisites` maps to `prerequisites: 'skip'`.
+- `chat --skip-prerequisites` maps to `prerequisites: 'skip'`.
+- `--check-prerequisites` maps to `check-only`.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Plugin installs are host-managed and normally not visible in workspace files | Use `copilot plugin list` as the primary GitHub Copilot detection path |
+| Slash commands cannot be executed from setup/chat shell | Use shell-level `copilot plugin marketplace add` / `copilot plugin install` commands for GitHub Copilot CLI and show slash commands as manual guidance |
+| Global `npx skills add` fallback is not a plugin install | Keep it as fallback only, clearly label it as non-plugin compatibility behavior |
+| Users only want local create/setup, not deployment | Do not fail setup/chat when Azure Skills cannot be installed; report degraded deployment capability |
+| Claude/Codex install flows differ | Keep provider architecture target-based and return manual guidance until implemented |
+| CI should not install global tools | Add `--skip-prerequisites` / `check-only` and injectable command runner for tests |
+
+## Recommended first implementation PR
+
+1. Add prerequisite types and `azureSkillsProvider` for `ghcp`.
+2. Add `ensurePrerequisites` shared function.
+3. Extend `SetupOptions`, `SetupResult`, and `ChatOptions` with prerequisite mode/result fields.
+4. Implement GitHub Copilot plugin detection via `copilot plugin list`.
+5. Implement GitHub Copilot plugin install via `copilot plugin marketplace add microsoft/azure-skills` and `copilot plugin install azure@azure-skills`.
+6. Wire `setup` and `chat` to call `ensurePrerequisites` by default.
+7. Add CLI flags for `--skip-prerequisites` and `--check-prerequisites`.
+8. Add tests with a fake command runner and temporary workspace files.
+9. Update README with the automatic GitHub Copilot prerequisite behavior and future Claude/Codex note.
+
+## Implemented first pass
+
+- Added `src/setup/prerequisites/types.ts`, `azure-skills.ts`, and `index.ts`.
+- Added `azureSkillsProvider` for `ghcp` only.
+- Added `ensurePrerequisites` with `auto`, `check-only`, and `skip` modes.
+- Extended `SetupOptions`, `SetupResult`, and `ChatOptions` with prerequisite fields.
+- Wired `applySetup` and `chat` to run prerequisite handling by default.
+- Added setup/chat CLI flags: `--skip-prerequisites` and `--check-prerequisites`.
+- Added fake-runner tests so CI does not run real global plugin installs.
+
+## Open questions
+
+- Is `copilot plugin install azure@azure-skills` stable enough to use as the default non-interactive install path in setup/chat?
+- Should `setup` add the marketplace each time idempotently, or first query `copilot plugin marketplace list` once that output is validated?
+- Should `npx skills add ... -g -y` remain available as an explicit fallback flag, or only be documented for manual recovery? Current first pass: manual recovery only.
+- Should `chat` block launch when prerequisite install fails, or continue with a warning? Current recommendation: continue with warning.
+- Should Azure Skills prerequisite handling run for every setup/chat invocation or only when a Functions project exists or deployment is likely? Current recommendation: run by default but non-blocking.

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -11,6 +11,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync, spawn } from 'node:child_process';
 import { applySetup } from '../setup/index.js';
+import { ensurePrerequisites } from '../setup/prerequisites/index.js';
 import { loadSkills } from '../build/loader.js';
 import type { BuildTargetName, ChatOptions, ChatResult, DetectedCliAgent, Launcher, LauncherId } from '../types.js';
 
@@ -156,10 +157,23 @@ export async function chat(options: ChatOptions = {}): Promise<ChatResult> {
   };
   const setupTarget = agentToSetupTarget[agentId];
   if (setupTarget && !isSetupDone(dir, setupTarget)) {
-    const result = await applySetup(dir, { agents: [setupTarget] });
+    const result = await applySetup(dir, {
+      agents: [setupTarget],
+      prerequisites: options.prerequisites,
+      prerequisiteRunner: options.prerequisiteRunner,
+    });
     if (result.filesWritten > 0) {
       process.stderr.write(`📦 Installed ${result.filesWritten} skill files for ${setupTarget}\n`);
     }
+    writePrerequisiteStatus(result.prerequisites || []);
+  } else if (setupTarget) {
+    const prerequisiteResults = await ensurePrerequisites({
+      targets: [setupTarget],
+      projectDir: dir,
+      mode: options.prerequisites || 'auto',
+      runner: options.prerequisiteRunner,
+    });
+    writePrerequisiteStatus(prerequisiteResults);
   }
 
   const startupPrompt = options.prompt || await buildStartupPrompt(dir);
@@ -185,6 +199,16 @@ export async function chat(options: ChatOptions = {}): Promise<ChatResult> {
       resolve({ childProcess: child, agent: agentId, prompt: startupPrompt });
     });
   });
+}
+
+function writePrerequisiteStatus(results: Awaited<ReturnType<typeof ensurePrerequisites>>): void {
+  for (const result of results) {
+    if (result.status === 'present' || result.status === 'skipped') continue;
+    process.stderr.write(`⚠️  ${result.id} (${result.target}): ${result.message}\n`);
+    for (const command of result.commands || []) {
+      process.stderr.write(`   → ${command}\n`);
+    }
+  }
 }
 
 async function pickAgent(): Promise<LauncherId> {

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -10,6 +10,7 @@ import { execSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { loadSkills, loadMcpServers, loadAgents, loadHooks } from '../build/loader.js';
 import { buildTarget } from '../build/build-target.js';
+import { ensurePrerequisites } from './prerequisites/index.js';
 import type { BuildData, CliAgentName, SetupOptions, SetupResult } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,6 +66,7 @@ export async function detectAgents(): Promise<CliAgentName[]> {
  */
 export async function applySetup(targetDir: string, options: SetupOptions = {}): Promise<SetupResult> {
   const agents = options.agents || await detectAgents();
+  const prerequisiteMode = options.prerequisites || 'auto';
 
   // Load canonical sources
   const skills = loadSkills(join(TEMPLATES_DIR, 'skills'));
@@ -100,7 +102,15 @@ export async function applySetup(targetDir: string, options: SetupOptions = {}):
     }
   }
 
+  const prerequisiteResults = await ensurePrerequisites({
+    targets: agents,
+    projectDir: targetDir,
+    mode: prerequisiteMode,
+    runner: options.prerequisiteRunner,
+  });
+
   const skillLines = skills.map(skill => `    • ${skill.id} — ${skill.title}`);
+  const prerequisiteLines = formatPrerequisiteLines(prerequisiteResults);
   const welcomeMessage = [
     '',
     '⚡ Azure Functions Skills installed!',
@@ -111,6 +121,9 @@ export async function applySetup(targetDir: string, options: SetupOptions = {}):
     '  Skills available:',
     ...skillLines,
     '',
+    '  External prerequisites:',
+    ...prerequisiteLines,
+    '',
     '  Get started: Ask your AI assistant to "set up Azure Functions"',
     '',
   ].join('\n');
@@ -119,7 +132,13 @@ export async function applySetup(targetDir: string, options: SetupOptions = {}):
     agents,
     filesWritten: totalFiles,
     welcomeMessage,
+    prerequisites: prerequisiteResults,
   };
+}
+
+function formatPrerequisiteLines(results: SetupResult['prerequisites']): string[] {
+  if (!results || results.length === 0) return ['    • none'];
+  return results.map(result => `    • ${result.id} (${result.target}) — ${result.status}: ${result.message}`);
 }
 
 function copyWorkspaceFiles(src: string, dest: string, agent: CliAgentName): number {

--- a/src/setup/prerequisites/azure-skills.ts
+++ b/src/setup/prerequisites/azure-skills.ts
@@ -1,0 +1,125 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { BuildTargetName } from '../../types.js';
+import type { PrerequisiteContext, PrerequisiteProvider, PrerequisiteResult } from './types.js';
+
+const REQUIRED_AZURE_SKILLS = ['azure-deploy', 'azure-prepare', 'azure-validate'];
+const COPILOT_MARKETPLACE_COMMAND = '/plugin marketplace add microsoft/azure-skills';
+const COPILOT_INSTALL_COMMAND = '/plugin install azure@azure-skills';
+
+export const azureSkillsManualCommands = [
+  COPILOT_MARKETPLACE_COMMAND,
+  COPILOT_INSTALL_COMMAND,
+];
+
+export const azureSkillsProvider: PrerequisiteProvider = {
+  id: 'azure-skills',
+
+  supports(target: BuildTargetName): boolean {
+    return target === 'ghcp';
+  },
+
+  async check(context: PrerequisiteContext): Promise<PrerequisiteResult> {
+    const pluginList = await run(context, 'copilot', ['plugin', 'list']);
+    if (pluginList.exitCode === 0 && hasAzureSkillsPlugin(pluginList.stdout)) {
+      return result(context.target, 'present', 'Azure Skills plugin is installed for GitHub Copilot.');
+    }
+
+    if (hasWorkspaceAzureSkills(context.projectDir)) {
+      return result(
+        context.target,
+        'present',
+        'Azure Skills are present in the workspace fallback layout.',
+      );
+    }
+
+    return result(
+      context.target,
+      'manual-action-required',
+      'Azure Skills plugin is not installed for GitHub Copilot.',
+      azureSkillsManualCommands,
+    );
+  },
+
+  async install(context: PrerequisiteContext): Promise<PrerequisiteResult> {
+    const addMarketplace = await run(context, 'copilot', ['plugin', 'marketplace', 'add', 'microsoft/azure-skills']);
+    if (addMarketplace.exitCode !== 0) {
+      return manualInstallResult(context.target, addMarketplace.stderr || addMarketplace.stdout);
+    }
+
+    const installPlugin = await run(context, 'copilot', ['plugin', 'install', 'azure@azure-skills']);
+    if (installPlugin.exitCode !== 0) {
+      return manualInstallResult(context.target, installPlugin.stderr || installPlugin.stdout);
+    }
+
+    return result(
+      context.target,
+      'installed',
+      'Azure Skills plugin installed for GitHub Copilot. Reload or restart the host if skills are not visible immediately.',
+    );
+  },
+};
+
+function hasAzureSkillsPlugin(output: string): boolean {
+  return /(^|\s)(azure|azure-skills)(\s|$)/i.test(output);
+}
+
+function hasWorkspaceAzureSkills(projectDir: string): boolean {
+  return REQUIRED_AZURE_SKILLS.every(skill => existsSync(join(projectDir, '.github', 'skills', skill, 'SKILL.md')));
+}
+
+async function run(context: PrerequisiteContext, command: string, args: string[]) {
+  const runner = context.runner || defaultRunner;
+  return runner(command, args, { cwd: context.projectDir });
+}
+
+async function defaultRunner(command: string, args: string[]) {
+  const { execFileSync } = await import('node:child_process');
+  try {
+    const stdout = execFileSync(command, args, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (error) {
+    const err = error as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
+    return {
+      exitCode: err.status ?? 1,
+      stdout: bufferToString(err.stdout),
+      stderr: bufferToString(err.stderr) || err.message || '',
+    };
+  }
+}
+
+function bufferToString(value: Buffer | string | undefined): string {
+  if (!value) return '';
+  return typeof value === 'string' ? value : value.toString('utf-8');
+}
+
+function manualInstallResult(target: BuildTargetName, detail?: string): PrerequisiteResult {
+  return result(
+    target,
+    'manual-action-required',
+    'Azure Skills plugin could not be installed automatically for GitHub Copilot. Install it manually and reload the host.',
+    azureSkillsManualCommands,
+    detail ? [detail] : undefined,
+  );
+}
+
+function result(
+  target: BuildTargetName,
+  status: PrerequisiteResult['status'],
+  message: string,
+  commands?: string[],
+  details?: string[],
+): PrerequisiteResult {
+  return {
+    id: 'azure-skills',
+    target,
+    status,
+    message,
+    commands,
+    details,
+  };
+}

--- a/src/setup/prerequisites/index.ts
+++ b/src/setup/prerequisites/index.ts
@@ -1,0 +1,69 @@
+import type { BuildTargetName } from '../../types.js';
+import { azureSkillsProvider } from './azure-skills.js';
+import type { EnsurePrerequisitesOptions, PrerequisiteProvider, PrerequisiteResult } from './types.js';
+
+const DEFAULT_PROVIDERS: PrerequisiteProvider[] = [azureSkillsProvider];
+
+export async function ensurePrerequisites(options: EnsurePrerequisitesOptions): Promise<PrerequisiteResult[]> {
+  const providers = options.providers || DEFAULT_PROVIDERS;
+  const targets = [...new Set(options.targets)];
+
+  if (options.mode === 'skip') {
+    return targets.map(target => skippedResult(target));
+  }
+
+  const results: PrerequisiteResult[] = [];
+  for (const target of targets) {
+    for (const provider of providers) {
+      if (!provider.supports(target)) {
+        results.push(unsupportedResult(provider.id, target));
+        continue;
+      }
+
+      const context = {
+        target,
+        projectDir: options.projectDir,
+        mode: options.mode,
+        runner: options.runner,
+      };
+      const check = await provider.check(context);
+      if (check.status === 'present' || options.mode === 'check-only') {
+        results.push(check);
+        continue;
+      }
+
+      results.push(await provider.install(context));
+    }
+  }
+
+  return results;
+}
+
+function skippedResult(target: BuildTargetName): PrerequisiteResult {
+  return {
+    id: 'azure-skills',
+    target,
+    status: 'skipped',
+    message: 'Azure Skills prerequisite check skipped.',
+  };
+}
+
+function unsupportedResult(id: string, target: BuildTargetName): PrerequisiteResult {
+  return {
+    id,
+    target,
+    status: 'unsupported',
+    message: `Automatic Azure Skills prerequisite handling is not implemented for ${target}.`,
+  };
+}
+
+export type {
+  CommandResult,
+  CommandRunner,
+  EnsurePrerequisitesOptions,
+  PrerequisiteContext,
+  PrerequisiteMode,
+  PrerequisiteProvider,
+  PrerequisiteResult,
+  PrerequisiteStatus,
+} from './types.js';

--- a/src/setup/prerequisites/types.ts
+++ b/src/setup/prerequisites/types.ts
@@ -1,0 +1,52 @@
+import type { BuildTargetName } from '../../types.js';
+
+export type PrerequisiteMode = 'auto' | 'check-only' | 'skip';
+
+export type PrerequisiteStatus =
+  | 'present'
+  | 'installed'
+  | 'manual-action-required'
+  | 'unsupported'
+  | 'skipped'
+  | 'failed';
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CommandRunner {
+  (command: string, args: string[], options?: { cwd?: string }): Promise<CommandResult>;
+}
+
+export interface PrerequisiteContext {
+  target: BuildTargetName;
+  projectDir: string;
+  mode: PrerequisiteMode;
+  runner?: CommandRunner;
+}
+
+export interface PrerequisiteResult {
+  id: string;
+  target: BuildTargetName;
+  status: PrerequisiteStatus;
+  message: string;
+  commands?: string[];
+  details?: string[];
+}
+
+export interface PrerequisiteProvider {
+  id: string;
+  supports(target: BuildTargetName): boolean;
+  check(context: PrerequisiteContext): Promise<PrerequisiteResult>;
+  install(context: PrerequisiteContext): Promise<PrerequisiteResult>;
+}
+
+export interface EnsurePrerequisitesOptions {
+  targets: BuildTargetName[];
+  projectDir: string;
+  mode: PrerequisiteMode;
+  runner?: CommandRunner;
+  providers?: PrerequisiteProvider[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
+import type { CommandRunner, PrerequisiteMode, PrerequisiteResult } from './setup/prerequisites/types.js';
 
 export type BuildTargetName = 'ghcp' | 'claude' | 'codex';
 export type CliAgentName = BuildTargetName;
@@ -42,12 +43,15 @@ export interface BuildData {
 
 export interface SetupOptions {
   agents?: CliAgentName[];
+  prerequisites?: PrerequisiteMode;
+  prerequisiteRunner?: CommandRunner;
 }
 
 export interface SetupResult {
   agents: CliAgentName[];
   filesWritten: number;
   welcomeMessage: string;
+  prerequisites?: PrerequisiteResult[];
 }
 
 export interface LauncherContext {
@@ -70,6 +74,8 @@ export interface ChatOptions {
   agent?: LauncherId;
   prompt?: string;
   dir?: string;
+  prerequisites?: PrerequisiteMode;
+  prerequisiteRunner?: CommandRunner;
 }
 
 export interface ChatResult {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -499,7 +499,7 @@ describe('setup module', () => {
   });
 
   it('applySetup copies files to target directory', async () => {
-    await applySetup(DIST_DIR, { agents: ['ghcp'] });
+    await applySetup(DIST_DIR, { agents: ['ghcp'], prerequisites: 'skip' });
 
     // Should have copilot-instructions.md
     expect(existsSync(join(DIST_DIR, '.github', 'copilot-instructions.md'))).toBe(true);
@@ -508,7 +508,7 @@ describe('setup module', () => {
   });
 
   it('applySetup omits duplicate GHCP plugin directories from workspace root', async () => {
-    await applySetup(DIST_DIR, { agents: ['ghcp'] });
+    await applySetup(DIST_DIR, { agents: ['ghcp'], prerequisites: 'skip' });
 
     expect(existsSync(join(DIST_DIR, '.github', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(true);
     expect(existsSync(join(DIST_DIR, '.github', 'agents', 'functions-copilot.agent.md'))).toBe(true);
@@ -521,7 +521,7 @@ describe('setup module', () => {
   });
 
   it('applySetup handles codex target', async () => {
-    await applySetup(DIST_DIR, { agents: ['codex'] });
+    await applySetup(DIST_DIR, { agents: ['codex'], prerequisites: 'skip' });
 
     expect(existsSync(join(DIST_DIR, 'AGENTS.md'))).toBe(true);
     expect(existsSync(join(DIST_DIR, '.agents', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(true);
@@ -529,7 +529,7 @@ describe('setup module', () => {
   });
 
   it('applySetup omits duplicate Codex plugin skills from workspace root', async () => {
-    await applySetup(DIST_DIR, { agents: ['codex'] });
+    await applySetup(DIST_DIR, { agents: ['codex'], prerequisites: 'skip' });
 
     expect(existsSync(join(DIST_DIR, '.agents', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(true);
     expect(existsSync(join(DIST_DIR, 'skills'))).toBe(false);
@@ -539,14 +539,14 @@ describe('setup module', () => {
   });
 
   it('applySetup handles claude target', async () => {
-    await applySetup(DIST_DIR, { agents: ['claude'] });
+    await applySetup(DIST_DIR, { agents: ['claude'], prerequisites: 'skip' });
 
     expect(existsSync(join(DIST_DIR, 'CLAUDE.md'))).toBe(true);
     expect(existsSync(join(DIST_DIR, '.claude', 'settings.json'))).toBe(true);
   });
 
   it('applySetup handles multiple agents at once', async () => {
-    await applySetup(DIST_DIR, { agents: ['ghcp', 'claude', 'codex'] });
+    await applySetup(DIST_DIR, { agents: ['ghcp', 'claude', 'codex'], prerequisites: 'skip' });
 
     expect(existsSync(join(DIST_DIR, '.github', 'copilot-instructions.md'))).toBe(true);
     expect(existsSync(join(DIST_DIR, 'CLAUDE.md'))).toBe(true);
@@ -554,11 +554,30 @@ describe('setup module', () => {
   });
 
   it('applySetup returns a summary with welcome message', async () => {
-    const result = await applySetup(DIST_DIR, { agents: ['ghcp'] });
+    const result = await applySetup(DIST_DIR, { agents: ['ghcp'], prerequisites: 'skip' });
 
     expect(result.agents).toContain('ghcp');
     expect(result.filesWritten).toBeGreaterThan(0);
     expect(result.welcomeMessage).toContain('Azure Functions');
+  });
+
+  it('applySetup reports Azure Skills prerequisite installation results', async () => {
+    const calls: string[] = [];
+    const result = await applySetup(DIST_DIR, {
+      agents: ['ghcp'],
+      prerequisiteRunner: async (command, args) => {
+        calls.push([command, ...args].join(' '));
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    expect(calls).toEqual([
+      'copilot plugin list',
+      'copilot plugin marketplace add microsoft/azure-skills',
+      'copilot plugin install azure@azure-skills',
+    ]);
+    expect(result.prerequisites?.[0].status).toBe('installed');
+    expect(result.welcomeMessage).toContain('External prerequisites');
   });
 });
 

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -113,7 +113,7 @@ describe('chat auto-setup', () => {
     const testDir = makeTestDir('af-skills-chat-ghcp-');
 
     try {
-      const result = await chat({ agent: 'github-copilot', dir: testDir, prompt: 'test' });
+      const result = await chat({ agent: 'github-copilot', dir: testDir, prompt: 'test', prerequisites: 'skip' });
       if (result?.childProcess) result.childProcess.kill();
     } catch {
       // Expected: copilot binary not found — that's fine
@@ -128,7 +128,7 @@ describe('chat auto-setup', () => {
     const testDir = makeTestDir('af-skills-chat-claude-');
 
     try {
-      const result = await chat({ agent: 'claude-code', dir: testDir, prompt: 'test' });
+      const result = await chat({ agent: 'claude-code', dir: testDir, prompt: 'test', prerequisites: 'skip' });
       // If claude is installed, kill the spawned process immediately
       if (result?.childProcess) result.childProcess.kill();
     } catch {
@@ -143,7 +143,7 @@ describe('chat auto-setup', () => {
     const testDir = makeTestDir('af-skills-chat-codex-');
 
     try {
-      const result = await chat({ agent: 'codex', dir: testDir, prompt: 'test' });
+      const result = await chat({ agent: 'codex', dir: testDir, prompt: 'test', prerequisites: 'skip' });
       if (result?.childProcess) result.childProcess.kill();
     } catch {
       // Expected: codex binary not found
@@ -158,14 +158,14 @@ describe('chat auto-setup', () => {
 
     // Pre-install skills
     const { applySetup } = await import('../src/setup/index.js');
-    await applySetup(testDir, { agents: ['ghcp'] });
+    await applySetup(testDir, { agents: ['ghcp'], prerequisites: 'skip' });
 
     // Get content of instructions file
     const instrPath = join(testDir, '.github', 'copilot-instructions.md');
     const contentBefore = readFileSync(instrPath, 'utf-8');
 
     try {
-      const result = await chat({ agent: 'github-copilot', dir: testDir, prompt: 'test' });
+      const result = await chat({ agent: 'github-copilot', dir: testDir, prompt: 'test', prerequisites: 'skip' });
       if (result?.childProcess) result.childProcess.kill();
     } catch {
       // Expected
@@ -174,5 +174,31 @@ describe('chat auto-setup', () => {
     // File should not have been re-written (same content)
     const contentAfter = readFileSync(instrPath, 'utf-8');
     expect(contentAfter).toBe(contentBefore);
+  }, 15000);
+
+  it('checks Azure Skills prerequisites before launching GitHub Copilot', async () => {
+    const testDir = makeTestDir('af-skills-chat-prereq-');
+    const calls: string[] = [];
+
+    try {
+      const result = await chat({
+        agent: 'github-copilot',
+        dir: testDir,
+        prompt: 'test',
+        prerequisiteRunner: async (command, args) => {
+          calls.push([command, ...args].join(' '));
+          return { exitCode: 0, stdout: '', stderr: '' };
+        },
+      });
+      if (result?.childProcess) result.childProcess.kill();
+    } catch {
+      // Expected if the launcher is unavailable.
+    }
+
+    expect(calls).toEqual([
+      'copilot plugin list',
+      'copilot plugin marketplace add microsoft/azure-skills',
+      'copilot plugin install azure@azure-skills',
+    ]);
   }, 15000);
 });

--- a/tests/e2e-commands.test.ts
+++ b/tests/e2e-commands.test.ts
@@ -158,7 +158,7 @@ describe('CLI command E2E', () => {
     for (const target of TARGETS) {
       const projectDir = makeTempDir(`af-skills-e2e-setup-${target}-`);
 
-      runCli(['setup', '--agent', target, '--dir', projectDir]);
+      runCli(['setup', '--agent', target, '--dir', projectDir, '--skip-prerequisites']);
 
       assertWorkspaceLayout(projectDir, target, expectedSkillIds, expectedAgentFiles);
     }
@@ -176,7 +176,7 @@ describe('CLI command E2E', () => {
     for (const { launcherId, setupTarget } of CHAT_AGENTS) {
       const projectDir = makeTempDir(`af-skills-e2e-chat-${setupTarget}-`);
 
-      runCli(['chat', '--agent', launcherId, '--dir', projectDir, '--prompt', 'e2e'], {
+      runCli(['chat', '--agent', launcherId, '--dir', projectDir, '--prompt', 'e2e', '--skip-prerequisites'], {
         env: {
           PATH: pathValue,
           Path: pathValue,

--- a/tests/prerequisites.test.ts
+++ b/tests/prerequisites.test.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { azureSkillsProvider } from '../src/setup/prerequisites/azure-skills.js';
+import { ensurePrerequisites } from '../src/setup/prerequisites/index.js';
+import type { CommandRunner } from '../src/setup/prerequisites/types.js';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+type TestRunner = CommandRunner & { calls: Array<{ command: string; args: string[] }> };
+
+function runnerFrom(responses: Array<{ command: string; args: string[]; stdout?: string; exitCode?: number }>): TestRunner {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const runner = (async (command, args) => {
+    calls.push({ command, args });
+    const response = responses.find(item => item.command === command && JSON.stringify(item.args) === JSON.stringify(args));
+    if (!response) {
+      return { exitCode: 1, stdout: '', stderr: `Unexpected command: ${command} ${args.join(' ')}` };
+    }
+    return { exitCode: response.exitCode ?? 0, stdout: response.stdout ?? '', stderr: '' };
+  }) as TestRunner;
+  runner.calls = calls;
+  return runner;
+}
+
+describe('azureSkillsProvider', () => {
+  it('supports GitHub Copilot first and leaves Claude/Codex for future providers', () => {
+    expect(azureSkillsProvider.supports('ghcp')).toBe(true);
+    expect(azureSkillsProvider.supports('claude')).toBe(false);
+    expect(azureSkillsProvider.supports('codex')).toBe(false);
+  });
+
+  it('detects Azure Skills from copilot plugin list', async () => {
+    const runner = runnerFrom([
+      { command: 'copilot', args: ['plugin', 'list'], stdout: 'azure 1.1.29 enabled\n' },
+    ]);
+
+    const result = await azureSkillsProvider.check({
+      target: 'ghcp',
+      projectDir: createTempDir('af-skills-prereq-'),
+      mode: 'check-only',
+      runner,
+    });
+
+    expect(result.status).toBe('present');
+    expect(result.message).toContain('Azure Skills plugin is installed');
+  });
+
+  it('detects workspace Azure Skills files only as a fallback', async () => {
+    const dir = createTempDir('af-skills-prereq-workspace-');
+    try {
+      for (const skill of ['azure-deploy', 'azure-prepare', 'azure-validate']) {
+        const skillDir = join(dir, '.github', 'skills', skill);
+        mkdirSync(skillDir, { recursive: true });
+        writeFileSync(join(skillDir, 'SKILL.md'), `# ${skill}\n`);
+      }
+      const runner = runnerFrom([
+        { command: 'copilot', args: ['plugin', 'list'], exitCode: 1, stdout: '' },
+      ]);
+
+      const result = await azureSkillsProvider.check({ target: 'ghcp', projectDir: dir, mode: 'check-only', runner });
+
+      expect(result.status).toBe('present');
+      expect(result.message).toContain('workspace fallback');
+    } finally {
+      removeDir(dir);
+    }
+  });
+
+  it('installs Azure Skills through GitHub Copilot plugin commands in auto mode', async () => {
+    const runner = runnerFrom([
+      { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'microsoft/azure-skills'], stdout: 'added\n' },
+      { command: 'copilot', args: ['plugin', 'install', 'azure@azure-skills'], stdout: 'installed\n' },
+    ]);
+
+    const result = await azureSkillsProvider.install({
+      target: 'ghcp',
+      projectDir: createTempDir('af-skills-prereq-install-'),
+      mode: 'auto',
+      runner,
+    });
+
+    expect(result.status).toBe('installed');
+    expect(runner.calls).toEqual([
+      { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'microsoft/azure-skills'] },
+      { command: 'copilot', args: ['plugin', 'install', 'azure@azure-skills'] },
+    ]);
+  });
+
+  it('returns manual guidance when GitHub Copilot plugin install fails', async () => {
+    const runner = runnerFrom([
+      { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'microsoft/azure-skills'], exitCode: 1 },
+    ]);
+
+    const result = await azureSkillsProvider.install({
+      target: 'ghcp',
+      projectDir: createTempDir('af-skills-prereq-manual-'),
+      mode: 'auto',
+      runner,
+    });
+
+    expect(result.status).toBe('manual-action-required');
+    expect(result.commands).toContain('/plugin marketplace add microsoft/azure-skills');
+    expect(result.commands).toContain('/plugin install azure@azure-skills');
+  });
+});
+
+describe('ensurePrerequisites', () => {
+  it('skips prerequisite checks when mode is skip', async () => {
+    const runner = runnerFrom([]);
+
+    const results = await ensurePrerequisites({
+      targets: ['ghcp'],
+      projectDir: createTempDir('af-skills-prereq-skip-'),
+      mode: 'skip',
+      runner,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('skipped');
+    expect(runner.calls).toEqual([]);
+  });
+
+  it('checks then installs missing Azure Skills for GitHub Copilot in auto mode', async () => {
+    const runner = runnerFrom([
+      { command: 'copilot', args: ['plugin', 'list'], exitCode: 0, stdout: 'other-plugin\n' },
+      { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'microsoft/azure-skills'], stdout: 'added\n' },
+      { command: 'copilot', args: ['plugin', 'install', 'azure@azure-skills'], stdout: 'installed\n' },
+    ]);
+
+    const results = await ensurePrerequisites({
+      targets: ['ghcp'],
+      projectDir: createTempDir('af-skills-prereq-auto-'),
+      mode: 'auto',
+      runner,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('installed');
+  });
+});


### PR DESCRIPTION
## Summary

Adds GitHub Copilot-first Azure Skills prerequisite handling for CLI `setup` and `chat`, so the Azure Functions deployment proxy can rely on Azure Skills being available.

Fixes #46.

## Changes

- Adds a shared prerequisite provider pipeline under `src/setup/prerequisites/`.
- Adds a GitHub Copilot Azure Skills provider that checks `copilot plugin list` and installs with:
  - `copilot plugin marketplace add microsoft/azure-skills`
  - `copilot plugin install azure@azure-skills`
- Wires prerequisite handling into `applySetup` and `chat` with non-blocking manual guidance.
- Adds CLI flags for `setup` and `chat`:
  - `--check-prerequisites`
  - `--skip-prerequisites`
- Documents the design and README behavior.
- Adds unit/integration/E2E coverage with fake command runners so CI does not perform global plugin installs.

## Validation

- `npm test -- tests/prerequisites.test.ts tests/build.test.ts tests/chat.test.ts`
- `npm test -- tests/e2e-commands.test.ts`
- `npm run check`

## Notes

Claude Code and Codex automatic Azure Skills installation remain future work tracked by #46. VS Code-only Copilot environments receive manual guidance when the shell-level `copilot plugin ...` command is unavailable.
