### PR TITLE
fix: improve skill definitions based on e2e testing feedback

### DIFF
--- a/templates/skills/azure-functions-best-practices/SKILL.md
+++ b/templates/skills/azure-functions-best-practices/SKILL.md
@@ -54,7 +54,18 @@ Ask only for missing inputs needed to start:
 
 ## Workflow
 
-1. **Collect static evidence** with `azure-functions-inventory`.
+1. **Collect static evidence** with `azure-functions-inventory`. If `azure-functions-inventory` is unavailable, use these Azure CLI commands as fallback:
+
+   ```bash
+   # Function App details
+   az functionapp show --name <app> --resource-group <rg>
+   # Configuration
+   az functionapp config show --name <app> --resource-group <rg>
+   # App settings (names only — do not reveal values)
+   az functionapp config appsettings list --name <app> --resource-group <rg> --query "[].{name:name}"
+   # Deployed functions
+   az functionapp function list --name <app> --resource-group <rg>
+   ```
 2. **Collect runtime evidence when useful** with `azure-functions-health-status` for production readiness, performance, observability, or degraded apps.
 3. **Get current MCP guidance** from Azure Functions best-practices guidance (`get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions` and `action: all`) and cite whether it was loaded.
 4. **Route references** through `../azure-functions-common/references/routing.md` based on runtime and trigger/binding inventory.

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -21,15 +21,15 @@ Ensure `func` (Azure Functions Core Tools v4) is installed. If not, suggest runn
 
 Check whether the following Azure MCP tools are available in your current tool list:
 
-- `functions language list`
-- `functions project get`
-- `functions list or get template`
+- `functions_language_list` — list supported languages and runtime versions
+- `functions_project_get` — scaffold project-level files
+- `functions_template_get` — list templates (language only) or get a specific template (language + template)
 
 These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) and return officially maintained templates across C#, Python, TypeScript, JavaScript, Java and PowerShell.
 
 Also check for the best practices tool:
 
-- `get_azure_bestpractices` with `resource: azurefunctions`
+- `get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions`
 
 - **If available** → proceed with **Path A (MCP primary)**.
 - **If not available** → proceed with **Path B (composition algorithm fallback)**.
@@ -61,11 +61,11 @@ Ask the user (or detect from context):
 
 #### A.2 Discover supported languages
 
-Call `functions language list`. Returns supported languages with runtime versions, programming models, and prerequisites. Use this to confirm the user's language choice is supported and to suggest a default runtime version.
+Call `functions_language_list`. Returns supported languages with runtime versions, programming models, and prerequisites. Use this to confirm the user's language choice is supported and to suggest a default runtime version.
 
 #### A.3 Browse available templates
 
-Call `functions list or get template` with only the `language` parameter (omit `template`). This returns the list of available templates for the chosen language with descriptions. Present the templates to the user and let them pick.
+Call `functions_template_get` with only the `language` parameter (omit `template`). This returns the list of available templates for the chosen language with descriptions. Present the templates to the user and let them pick.
 
 Do **not** invent or guess template identifiers such as `HttpTrigger`. Azure MCP template IDs are versioned, language-specific strings returned by the template list. For example, the TypeScript HTTP trigger template is currently returned as `http-trigger-typescript-azd`.
 
@@ -78,14 +78,14 @@ When the user asks for a common trigger name, map it to one of the template IDs 
 | Blob trigger | `typescript` | `blob-eventgrid-trigger-typescript-azd` |
 | Queue / Service Bus trigger | `typescript` | `servicebus-trigger-typescript-azd` |
 
-If a template-get call fails with "template not found", immediately recover by calling `functions list or get template` again with only `language`, then select the closest returned template ID instead of retrying the failed alias.
+If a template-get call fails with "template not found", immediately recover by calling `functions_template_get` again with only `language`, then select the closest returned template ID instead of retrying the failed alias.
 
 #### A.4 Initialize the project
 
-Call `functions project get`:
+Call `functions_project_get`:
 
 ```
-Tool: functions project get
+Tool: functions_project_get
 language: <chosen language, e.g. typescript>
 ```
 
@@ -93,10 +93,10 @@ Returns project-level files (`host.json`, `local.settings.json`, `package.json` 
 
 #### A.5 Add the function
 
-Call `functions list or get template` with both `language` and `template`:
+Call `functions_template_get` with both `language` and `template`:
 
 ```
-Tool: functions list or get template
+Tool: functions_template_get
 language: <chosen language, e.g. typescript>
 template: <chosen returned template ID, e.g. http-trigger-typescript-azd>
 runtime-version: <optional, e.g. 22>
@@ -105,13 +105,25 @@ output: <optional, "New" (default) or "Add" for existing projects>
 
 Returns the full function source code plus any required app settings and additional package dependencies. Write the returned file(s) into the project and merge any extra settings into `local.settings.json` and any extra packages into the dependency manifest.
 
+> ⚠️ **Large template output**: Some templates (especially `*-azd` variants that include infrastructure files) can produce very large output (100KB+). If the tool output is truncated or saved to a temporary file, read the file, parse the JSON `files` array, and write each file individually. After writing files, run `npm install` (or the equivalent package manager command) to generate lock files rather than relying on lock files from the template output.
+
 #### A.6 Verify
+
+For TypeScript and other compiled-language projects, build first:
+
+```bash
+npm run build   # TypeScript / JavaScript
+# dotnet build  # C#
+# mvn package   # Java
+```
+
+Then start and test locally:
 
 ```bash
 func start
 ```
 
-Then invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<FunctionName>`).
+Invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<FunctionName>`).
 
 ---
 
@@ -178,7 +190,7 @@ func start
 
 If `host.json` already exists, do **not** re-initialize. Instead:
 
-- **MCP path**: call `functions list or get template` with the same language as the existing project and specify the desired template name. Write the returned file.
+- **MCP path**: call `functions_template_get` with the same language as the existing project and specify the desired template name. Write the returned file.
 - **Fallback path**: fetch the manifest, filter for the desired template by language and resource, download the template source, and merge the function files into the existing project.
 
 ## After Creation

--- a/templates/skills/azure-functions-deploy/SKILL.md
+++ b/templates/skills/azure-functions-deploy/SKILL.md
@@ -27,11 +27,28 @@ If any prerequisite is missing, suggest running **azure-functions-setup** first.
 
 Use Azure Skills as the deployment engine:
 
-1. If `.azure/deployment-plan.md` is missing, invoke `azure-prepare` first.
+1. If `.azure/deployment-plan.md` is missing, invoke `azure-prepare` first — **unless the shortcut path below applies**.
 2. If `.azure/deployment-plan.md` exists but is not `Validated`, invoke `azure-validate` before any deployment attempt.
 3. If `.azure/deployment-plan.md` exists and status is `Validated`, invoke `azure-deploy` directly.
 4. Never mark the plan as `Validated` from this skill. Only `azure-validate` may do that.
 5. Do not run `azd up`, `azd deploy`, `terraform apply`, `az deployment`, or `func azure functionapp publish` directly from this skill unless Azure Skills cannot handle the scenario and the user explicitly approves a fallback.
+
+### Shortcut path for MCP-template projects
+
+When a project was scaffolded from an Azure MCP template (e.g., via `azure-functions-create` Path A), it already contains complete infrastructure. Detect this by checking **all** of these conditions:
+
+1. `azure.yaml` exists in the project root
+2. `infra/main.bicep` or `infra/*.tf` exists
+3. `host.json` exists
+4. `azure.yaml` contains a `metadata.template` field (indicates MCP template origin)
+
+If all conditions are met, **skip `azure-prepare`** and proceed directly:
+
+1. Generate a lightweight `.azure/plan.md` noting the pre-existing infrastructure
+2. Invoke `azure-validate` (provisions preview, environment setup)
+3. Invoke `azure-deploy` (runs `azd up`)
+
+This avoids the redundant 5–10 minute analysis and planning phase for projects that already have production-ready infrastructure.
 
 The normal workflow is:
 
@@ -88,6 +105,27 @@ Let `azure-deploy` own post-deploy verification. Add Azure Functions-specific re
 - Test HTTP trigger endpoints with GET, not HEAD.
 - Suggest `azure-functions-health-status` for runtime health, metrics, and Application Insights checks.
 - Suggest `azure-functions-best-practices` for production readiness after successful deployment.
+
+## Monitoring `azd up` progress
+
+The `azd up` command uses animated progress bars that may not render correctly in agent terminal capture. If the output appears stuck on a spinner (e.g., repeated "Initialize bicep provider"), the deployment is likely still progressing normally in the background.
+
+To monitor deployment progress independently:
+
+```bash
+# Check resource group creation
+az group show --name rg-<env-name> -o json
+
+# Check deployment status
+az deployment group list --resource-group rg-<env-name> \
+  --query "[].{name:name, state:properties.provisioningState}" -o table
+
+# Check Function App status
+az functionapp list --resource-group rg-<env-name> \
+  --query "[].{name:name, state:state}" -o table
+```
+
+Do not kill and restart the `azd up` process based solely on lack of terminal output. Instead, use the commands above to verify whether the deployment is progressing.
 
 ## After Deployment
 

--- a/templates/skills/azure-functions-setup/SKILL.md
+++ b/templates/skills/azure-functions-setup/SKILL.md
@@ -32,6 +32,8 @@ Azure Functions deployment is proxied through the Azure Skills deployment workfl
 - `azure-validate`
 - `azure-deploy`
 
+**How to detect availability**: Check your current tool/skill list for the above skill names. If they appear in the list of available skills (e.g., in `<available_skills>` or equivalent plugin registry), they are installed. You do not need to run any commands — the presence of these skills in the agent's tool list is sufficient confirmation.
+
 If the Azure Skills plugin is missing, install it for the active host before using `azure-functions-deploy`.
 
 | Host | Install guidance |


### PR DESCRIPTION
## Summary

Fixes skill definition issues discovered during end-to-end testing (TypeScript HTTP Trigger: setup -> create -> deploy -> best-practices review).

## Changes

### azure-functions-create (Medium)
- **Fix MCP tool names**: Update tool names in skill definition to match actual MCP command names
  - `functions language list` -> `functions_language_list`
  - `functions project get` -> `functions_project_get`
  - `functions list or get template` -> `functions_template_get`
- **Large template output handling**: Add guidance for handling template output exceeding 100KB
- **Build verification step**: Add `npm run build` step before local verification for compiled-language projects (TypeScript, C#, Java)

### azure-functions-deploy (High)
- **Shortcut path for template projects**: Skip `azure-prepare` when the project was scaffolded from an MCP template (`azure.yaml` + `infra/` already exist). Eliminates 5-10 minutes of redundant analysis and planning
- **azd up output monitoring**: Add guidance for monitoring deployment progress when `azd up` progress bars don't render correctly in agent terminal capture

### azure-functions-best-practices (Low)
- **CLI fallback commands**: Add Azure CLI fallback commands when `azure-functions-inventory` skill is unavailable

### azure-functions-setup (Low)
- **Plugin detection clarification**: Document how to detect Azure Skills plugin availability

## Testing

All issues were reproduced and verified during a TypeScript HTTP Trigger end-to-end workflow.

## Priority

| Priority | Skill | Issue |
|----------|-------|-------|
| High | deploy | Shortcut path for template projects |
| High | deploy | azd up output monitoring |
| Medium | create | MCP tool name mismatch |
| Medium | create | Large template output handling |
| Low | create | Build verification step |
| Low | best-practices | CLI fallback commands |
| Low | setup | Plugin detection clarification |