### PR TITLE
Add feedback skill and E2E verification guidance

### DIFF
--- a/.github/plugins/azure-functions-skills/agents/functions-copilot.agent.md
+++ b/.github/plugins/azure-functions-skills/agents/functions-copilot.agent.md
@@ -24,6 +24,7 @@ You have access to the following MCP server — use it proactively:
 | **azure-functions-deploy** | User wants to deploy their app to Azure; this is the Azure Functions-facing proxy to Azure Skills deployment |
 | **azure-functions-best-practices** | User wants to review, harden, optimize, or remediate an existing Function App against Azure Functions best practices |
 | **azure-functions-diagnostics** | User reports deployment failures, runtime errors, trigger/binding failures, language worker issues, telemetry/log analysis needs, or asks for troubleshooting/remediation |
+| **azure-functions-feedback** | User wants to turn session findings into an issue or pull request for this skill suite, or a workflow reveals reusable skill improvements |
 
 ## Routing Rules
 
@@ -33,10 +34,11 @@ You have access to the following MCP server — use it proactively:
 4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy, which should proxy to Azure Skills (`azure-prepare` → `azure-validate` → `azure-deploy`)
 5. **Best-practices review / hardening / optimization** ("best practices", "review my Function App", "harden", "optimize configuration", "production readiness") → azure-functions-best-practices
 6. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
-7. **After azure-functions-setup succeeds** → Suggest azure-functions-create
-8. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
-9. **After azure-functions-deploy succeeds** → Suggest azure-functions-best-practices for production readiness review
-10. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
+7. **Skill suite feedback** ("feedback", "create issue", "create PR", "skill improvement", "wrong guidance", "confusing skill", "missed verification") → azure-functions-feedback
+8. **After azure-functions-setup succeeds** → Suggest azure-functions-create
+9. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
+10. **After azure-functions-deploy succeeds** → Suggest azure-functions-best-practices for production readiness review
+11. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
 
 ## Behavior
 
@@ -45,6 +47,7 @@ You have access to the following MCP server — use it proactively:
 - For deployment, route to azure-functions-deploy first so it can proxy to Azure Skills and inject Azure Functions-specific guidance when needed
 - For proactive review, route to azure-functions-best-practices before proposing broad configuration changes
 - For troubleshooting, route to azure-functions-diagnostics before proposing fixes unless the root cause is already obvious from gathered evidence
+- If a completed workflow reveals incorrect, confusing, or missing Azure Functions skill guidance, ask whether the user wants to preview feedback through azure-functions-feedback
 - If unsure, ask ONE clarifying question (max 1)
 - After any skill completes, suggest the next logical step from the graph
 - Respond in the same language the user is using

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-common/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-common/SKILL.md
@@ -16,6 +16,7 @@ Shared references include:
 
 - Language/runtime references in `references/languages/`.
 - Trigger/binding extension references in `references/extensions/`.
+- Local emulator and development-service guidance in `references/local-emulators.md`.
 - Routing rules in `references/routing.md`.
 
 Task-specific skills keep their own workflows, scripts, evidence checklists, and output formats. For example, diagnostics owns diagnostic workflow and health evidence rules; this skill only owns reusable Azure Functions reference material.
@@ -28,5 +29,6 @@ This is a shared reference skill. Return to the calling Azure Functions skill af
 
 - Load exactly one language reference when the runtime is known, plus Durable only when Durable is involved.
 - Load only extension references matching the app's triggers/bindings or the symptom.
+- Load `references/local-emulators.md` when local E2E verification involves a non-HTTP trigger, service-backed binding, emulator, container, or temporary development resource.
 - Load Extension Bundles only for non-.NET apps or extension-version/binding-resolution symptoms.
 - Prefer official documentation, official repositories, official samples, and package/container registries before broader web sources.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-common/references/local-emulators.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-common/references/local-emulators.md
@@ -1,0 +1,49 @@
+# Local emulators and development services
+
+Use this reference when `azure-functions-create`, diagnostics, or best-practices work needs local E2E verification for non-HTTP triggers or bindings.
+
+## Ground rules
+
+- Ask the user before installing, downloading, starting, or configuring any emulator, container, service, or background process.
+- Prefer tools that are already installed and visible in the workspace or PATH.
+- If the user declines emulator setup, skip emulator-backed E2E verification and clearly state what was skipped.
+- Do not change long-lived system services, Docker state, Azure resources, secrets, or connection strings without explicit approval.
+- Keep local settings in `local.settings.json` or environment variables. Never commit secrets or real connection strings.
+
+## Trigger and binding mapping
+
+Official links below were checked for HTTP 200 access on 2026-05-12.
+
+| Trigger / binding | Local E2E option | Official reference | Notes |
+| --- | --- | --- | --- |
+| `httpTrigger` | No emulator needed | [HTTP trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger), [run locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) | Start `func host` and send an HTTP request to `http://localhost:7071/api/<FunctionName>`. |
+| `timerTrigger` | No service emulator needed | [Timer trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer), [manually run non-HTTP functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-manually-run-non-http) | Verify listener startup. For a full local run, ask before changing the schedule to a short development-only value and restore it afterward. |
+| Blob, Queue, Table Storage | Azurite | [Use Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite), [local storage emulator note](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local#local-storage-emulator) | Use Azurite for `AzureWebJobsStorage` and Storage triggers/bindings when the extension supports local development. |
+| Cosmos DB | Azure Cosmos DB Emulator or a temporary Azure dev account | [Cosmos DB Emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator), [develop locally with emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator) | The emulator is platform/runtime dependent. If unavailable, use a disposable Azure dev resource after user approval. |
+| Service Bus | Service Bus Emulator or temporary Azure Service Bus dev namespace | [Service Bus trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger), [emulator overview](https://learn.microsoft.com/en-us/azure/service-bus-messaging/overview-emulator), [test locally](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator) | Do not assume the emulator is installed. Ask before creating Azure resources or installing containers/tools. |
+| Event Hubs | Event Hubs Emulator or temporary Azure Event Hubs dev namespace | [Event Hubs trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger), [test locally with emulator](https://learn.microsoft.com/en-us/azure/event-hubs/test-locally-with-event-hub-emulator) | Validate by sending an event and checking checkpoint/listener behavior. |
+| Event Grid | Local HTTP endpoint plus Event Grid validation tooling, or temporary Azure Event Grid resource | [Event Grid trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger), [Event Grid how-tos](https://learn.microsoft.com/en-us/azure/azure-functions/event-grid-how-tos) | There is no universal local replacement for Azure delivery semantics. Prefer deployment/dev-resource tests for full verification. |
+| SQL | Local SQL Server, SQL container, Azure SQL Edge, or temporary Azure SQL dev database | [Azure SQL trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-azure-sql-trigger), [Azure SQL bindings overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-azure-sql) | Use a least-privilege local/dev connection string and keep it out of source control. |
+| Redis | Local Redis container/server or temporary Azure Cache for Redis dev instance | [Redis list trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cache-trigger-redislist) | Confirm extension requirements and connection settings. |
+| Kafka | Local Kafka container/cluster or approved development cluster | [Kafka trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-kafka-trigger) | Validate topic existence and consumer group behavior. |
+| Durable Functions | Azurite for the default Azure Storage provider, or an approved storage provider | [Durable Functions storage provider configuration](https://learn.microsoft.com/en-us/azure/azure-functions/durable-functions/durable-functions-configure-managed-identity), [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) | Durable Functions commonly depends on `AzureWebJobsStorage` locally. Confirm provider-specific requirements before E2E tests. |
+| MySQL | Local MySQL container/server or temporary Azure Database for MySQL dev instance | No Azure Functions-specific emulator page found in the checked official set | Verify schema/table prerequisites before starting the host. |
+| RabbitMQ | Local RabbitMQ container/server or approved development broker | No Azure Functions-specific emulator page found in the checked official set | Validate queue/exchange setup. |
+| Dapr | Local Dapr sidecar and component configuration | No Azure Functions-specific emulator page found in the checked official set | Ask before running sidecars. Confirm component YAML does not include secrets. |
+
+## Suggested verification pattern
+
+1. Build the project first (`npm run build`, `dotnet build`, `mvn package`, or language equivalent).
+2. Identify the trigger/binding and required local dependency from the table above.
+3. Ask whether to install/start the emulator or use an existing dev resource.
+4. Start the emulator/service only after approval.
+5. Start the Functions host.
+6. Send one realistic input event/message/document/request.
+7. Verify the expected log line, output binding side effect, response, checkpoint, or persisted data.
+8. Stop any local processes started for the test and report what was validated or skipped.
+
+## Skip wording
+
+When the user declines emulator setup, report it explicitly:
+
+> Emulator-backed E2E verification was skipped by request. Verified build and Functions host/listener startup only. To complete E2E later, run the same test with `<emulator or dev resource>` and send `<event/message/document>` to `<trigger source>`.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-common/references/routing.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-common/references/routing.md
@@ -6,6 +6,7 @@ Reference files are bundled with `azure-functions-common`:
 
 - Language references: `references/languages/`
 - Extension references: `references/extensions/`
+- Local E2E references: `references/local-emulators.md`
 
 ## Language routing
 
@@ -59,3 +60,8 @@ For any trigger or binding investigation, include `azure-webjobs-sdk` when the s
 | Trigger not firing | Inventory trigger list, health/status traces, matching extension reference |
 | Runtime startup failure | Inventory runtime settings, health/status traces, matching language reference |
 | Network/connectivity failure | Inventory network shape, health dependencies/traces, matching extension reference |
+| Local E2E verification for non-HTTP triggers or bindings | `local-emulators.md`, matching extension reference |
+
+## Skill feedback routing
+
+Use `azure-functions-feedback` when the user asks to provide feedback, create an issue or PR for this skill suite, report confusing/incorrect skill guidance, or when a completed workflow reveals reusable improvements for any `azure-functions-*` skill.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
@@ -116,13 +116,19 @@ npm run build   # TypeScript / JavaScript
 # mvn package   # Java
 ```
 
-Then start and test locally:
+Then perform an end-to-end local verification, not just a host start:
 
 ```bash
 func start
 ```
 
-Invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<FunctionName>`).
+After the host reports the function endpoints/listeners:
+
+- **HTTP triggers**: send an actual request to the local endpoint and verify the status code and response body, for example `curl http://localhost:7071/api/<FunctionName>?name=World`.
+- **Timer triggers**: verify the listener starts and, when practical, temporarily use a short development-only schedule or manual invocation approach; restore the user's intended schedule before finishing.
+- **Storage, Cosmos DB, SQL, Redis, Dapr, or other service-backed triggers/bindings**: load `azure-functions-common/references/local-emulators.md`, identify the required local emulator or development service, and run a realistic message/blob/document/event through the trigger when the user wants E2E verification.
+- **Before installing or starting any emulator/local service**: ask the user for confirmation. If the user says the emulator is not needed, unavailable, or should be skipped, do not install it; record that emulator-backed E2E was skipped and provide manual/Azure test steps instead.
+- **When no practical local emulator exists**: explain the limitation, suggest a temporary Azure dev resource or deployment-based test, and keep the local verification to build + host/listener startup.
 
 ---
 
@@ -179,9 +185,15 @@ For minimal HTTP trigger snippets per language (last-resort fallback when the ma
 
 #### B.3 Verify
 
+Build compiled projects first, then perform the same local E2E verification standard used in Path A:
+
 ```bash
 func start
 ```
+
+- For HTTP triggers, send a real request to the local endpoint and validate the response.
+- For non-HTTP triggers, consult `azure-functions-common/references/local-emulators.md` and use an emulator/local service when practical.
+- Ask before installing or starting emulators. If the user declines, skip emulator-backed E2E and document the skipped verification plus manual/Azure test steps.
 
 ---
 

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-feedback/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-feedback/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: azure-functions-feedback
+description: "Turn session findings into previewed issues or pull requests for the Azure Functions skills repository"
+---
+
+
+> **Language**: Always respond in the same language the user is using.
+
+# azure-functions-feedback — Azure Functions Skills Feedback
+
+Use this skill after an Azure Functions skill workflow when the session reveals an improvement opportunity for the `azure-functions-*` skills, their references, tests, README, or generated plugin payload.
+
+## When to use
+
+Use this skill when:
+
+- The user asks to send feedback, create an issue, or create a pull request for Azure Functions Skills.
+- A workflow uncovered confusing guidance, missing verification, outdated commands, wrong MCP tool usage, repeated recovery steps, or missing diagnostics evidence.
+- The agent needed user correction about an `azure-functions-*` skill.
+- A manual or E2E test produced reusable findings.
+
+Do not use it for ordinary app bugs unless the finding is about the skill suite itself.
+
+## Workflow
+
+### 1. Review the session
+
+Review the available conversation/session history, files changed, test output, and command results. Identify only actionable feedback related to this repository:
+
+- affected skill or file (`azure-functions-create`, `azure-functions-deploy`, README, routing, references, tests, etc.)
+- observed behavior
+- expected behavior
+- evidence from the session
+- repro steps or scenario
+- proposed fix or documentation change
+- risk / impact
+
+Redact secrets, tenant-specific sensitive data, function keys, publish profiles, tokens, connection strings, and customer data. Keep only resource names or URLs that the user explicitly allows to share.
+
+### 2. Ask whether to proceed
+
+If feedback is likely useful, ask the user whether they want to provide it. Keep the prompt concise:
+
+> I found feedback that could improve Azure Functions Skills. Would you like to preview it as an Issue or a Pull Request?
+
+Options:
+
+- Issue
+- Pull Request
+- Not now
+
+Do not create external GitHub artifacts without explicit user confirmation.
+
+### 3. Prepare a preview
+
+Before creating anything, show a preview with this structure:
+
+```
+Title:
+Summary:
+Affected area:
+Evidence:
+Repro / scenario:
+Expected behavior:
+Proposed change:
+Validation plan:
+Redactions applied:
+```
+
+Ask the user to approve or edit the preview.
+
+### 4. Issue path
+
+After approval, create an issue in `Azure/azure-functions-skills` using the preview content.
+
+Prefer the GitHub CLI when available. If it is unavailable, provide the prepared issue body and ask the user to create it manually.
+
+After creation, report the issue URL and any follow-up action.
+
+### 5. Pull Request path
+
+After approval, implement the smallest safe change in this repository:
+
+1. Create or switch to a focused branch.
+2. Update canonical sources under `templates/`, README, tests, or docs as appropriate.
+3. Regenerate generated plugin payload and marketplace files when canonical skill or agent files change.
+4. Run validation (`npm run check` when practical; otherwise explain the narrower validation used).
+5. Commit with a conventional commit message.
+6. Push and open a pull request against `Azure/azure-functions-skills`.
+
+Do not include unrelated local docs, PLAN files, secrets, generated temp files, or user-specific logs.
+
+### 6. Output
+
+End with:
+
+- Issue or PR URL, if created.
+- Files changed, if PR path was used.
+- Validation results.
+- Any intentionally skipped feedback.
+
+## Quality bar
+
+- Feedback must be specific, actionable, and grounded in observed evidence.
+- Prefer one issue/PR per cohesive topic.
+- Do not overgeneralize from a single failure unless the skill guidance caused or failed to recover from it.
+- Keep user language and tone.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,65 @@
 
 [![npm](https://img.shields.io/npm/v/@agent-loom/azure-functions-skills)](https://www.npmjs.com/package/@agent-loom/azure-functions-skills)
 
-AI assistant plugins for Azure Functions — **one command** to set up GitHub Copilot, Claude Code, or Codex with a guided `setup → create → deploy` workflow.
+Azure Functions Skills provides guided setup, create, deploy, diagnostics, and review workflows for coding agents such as GitHub Copilot CLI, Claude Code, and Codex.
 
-## Quick Start
+## Recommended: install as a plugin
+
+Use the plugin when your agent supports plugin installation. This keeps the Azure Functions agent, skills, hooks, and MCP configuration available without copying files into every workspace.
+
+GitHub Copilot CLI:
 
 ```bash
-# In your Azure Functions project (or any empty directory):
+copilot plugin marketplace add Azure/azure-functions-skills
+copilot plugin install azure-functions-skills@azure-functions-skills
+```
+
+Claude Code plugin-from-source:
+
+```bash
+git clone https://github.com/Azure/azure-functions-skills.git
+claude --add-dir ./azure-functions-skills/.github/plugins/azure-functions-skills
+```
+
+Codex CLI:
+
+```bash
+codex plugin marketplace add Azure/azure-functions-skills
+# Then install azure-functions-skills from /plugins.
+```
+
+For VS Code plugin-from-source flows, point the installer at:
+
+```text
+Azure/azure-functions-skills:.github/plugins/azure-functions-skills
+```
+
+After installing, ask your agent:
+
+```text
+@functions-copilot set up Azure Functions
+```
+
+For a guided overview first, ask:
+
+```text
+@functions-copilot Explain what Azure Functions Skills can do, when to use setup/create/deploy/diagnostics/best-practices/feedback, and which workflow I should start with.
+```
+
+## Plugin vs. `chat` vs. `setup`
+
+| Option | Use when | What it does |
+| --- | --- | --- |
+| Plugin | You want the normal, reusable experience | Registers the Azure Functions plugin payload from this repository with your agent. |
+| `chat` | You want to launch a CLI agent with Azure Functions context immediately | Detects the local project, prepares a startup prompt, checks prerequisites, and starts the selected CLI agent. |
+| `setup` | You need workspace-local files or your agent does not support plugins | Copies agent instructions, skills, hooks, and MCP config into the target workspace. |
+
+## CLI commands
+
+Run without global install:
+
+```bash
+npx @agent-loom/azure-functions-skills chat
 npx @agent-loom/azure-functions-skills setup
 ```
 
@@ -15,379 +68,81 @@ Or install globally:
 
 ```bash
 npm install -g @agent-loom/azure-functions-skills
+azure-functions-skills chat
 azure-functions-skills setup
 ```
 
-The CLI auto-detects which coding agents you have (GitHub Copilot, Claude Code, Codex) and installs the right files.
-For GitHub Copilot, `setup` also checks for the Azure Skills plugin used by the deployment workflow and installs it through the Copilot plugin CLI when available.
-
-```
-🔍 Detecting coding agents...
-  Found: ghcp, claude
-
-📁 Installing to: /home/user/my-functions-app
-
-⚡ Azure Functions Skills installed!
-
-  Agents configured: ghcp, claude
-  Files written: <count>
-
-  Skills available:
-    • azure-functions-common — Azure Functions Common References
-    • azure-functions-best-practices — Azure Functions Best Practices Review
-    • azure-functions-create — Create Azure Functions App
-    • azure-functions-deploy — Deploy Azure Functions
-    • azure-functions-diagnostics — Azure Functions Diagnostics
-    • azure-functions-health-status — Azure Functions Health Status
-    • azure-functions-inventory — Azure Functions Inventory
-    • azure-functions-setup — Azure Functions Setup
-
-  External prerequisites:
-    • azure-skills (ghcp) — installed: Azure Skills plugin installed for GitHub Copilot.
-
-  Get started: Ask your AI assistant to "set up Azure Functions"
-```
-
-### Specify Agents Manually
+Useful options:
 
 ```bash
-npx @agent-loom/azure-functions-skills setup --agent ghcp
-npx @agent-loom/azure-functions-skills setup --agent claude --agent codex
-npx @agent-loom/azure-functions-skills setup --dir ./my-app
+npx @agent-loom/azure-functions-skills chat --agent github-copilot --dir ./my-app
+npx @agent-loom/azure-functions-skills chat --prompt "Create an HTTP trigger function"
+npx @agent-loom/azure-functions-skills setup --agent ghcp --dir ./my-app
 npx @agent-loom/azure-functions-skills setup --check-prerequisites
 npx @agent-loom/azure-functions-skills setup --skip-prerequisites
 ```
 
-`--check-prerequisites` reports missing external prerequisites without installing them. `--skip-prerequisites` disables external checks for CI or offline environments.
+## Skills
 
-### Launch with Welcome Prompt (`chat`)
+| Skill | Purpose |
+| --- | --- |
+| `azure-functions-setup` | Verify local prerequisites such as Azure CLI, Azure Functions Core Tools, runtimes, and Azure Skills deployment dependency. |
+| `azure-functions-create` | Create new Functions projects or add functions by using Azure MCP template discovery first. |
+| `azure-functions-deploy` | Prepare, validate, and deploy through Azure Skills while adding Azure Functions-specific guidance. |
+| `azure-functions-best-practices` | Review an app for Azure Functions configuration, security, reliability, and production-readiness guidance. |
+| `azure-functions-diagnostics` | Investigate deployment, runtime, trigger, binding, language worker, logging, and telemetry issues. |
+| `azure-functions-health-status` | Collect current health, metrics, logs, Resource Health, and Activity Log evidence. |
+| `azure-functions-inventory` | Collect app specification and configuration inventory without diagnosing health. |
+| `azure-functions-common` | Shared language, trigger, binding, extension, routing, and local emulator references for the skill suite. |
+| `azure-functions-feedback` | Turn session findings into previewed issues or pull requests for this repository. |
 
-Start a CLI coding agent with Azure Functions context and a Welcome message:
+The `functions-copilot` agent routes user requests to the right skill and suggests the next step after each workflow.
 
-```bash
-npx @agent-loom/azure-functions-skills chat
-```
+## What `setup` writes
 
-The CLI auto-detects your agent (GHCP CLI / Claude Code / Codex), analyzes your project, and launches the agent with a startup prompt:
-
-```
-🔍 Detecting CLI coding agents...
-  Using: claude-code
-
-🚀 Launching claude-code with Azure Functions context...
-
-⚡ Azure Functions Skills
-━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📂 Functions project detected (node)
-🧩 Skills: azure-functions-setup, azure-functions-create, azure-functions-deploy
-
-🚀 Suggested next steps:
-  → Run azure-functions-deploy to deploy your app to Azure through Azure Skills
-  → Ensure the Azure Skills plugin is installed for prepare/validate/deploy workflows
-   → Run azure-functions-create to add another function
-
-💬 What would you like to build?
-```
-
-Specify an agent or custom prompt:
-
-```bash
-npx @agent-loom/azure-functions-skills chat --agent github-copilot
-npx @agent-loom/azure-functions-skills chat --agent codex --dir ./my-app
-npx @agent-loom/azure-functions-skills chat --prompt "Create an HTTP trigger function"
-npx @agent-loom/azure-functions-skills chat --check-prerequisites
-npx @agent-loom/azure-functions-skills chat --skip-prerequisites
-```
-
-When `chat` launches GitHub Copilot CLI, it checks for Azure Skills before launch. If the shell-level Copilot plugin command is unavailable, it prints the manual plugin commands and continues.
-
-### Use as a Library (VS Code Extension)
-
-```typescript
-// Setup API
-import { applySetup, detectAgents } from '@agent-loom/azure-functions-skills';
-
-const agents = await detectAgents();  // ['ghcp', 'claude']
-const result = await applySetup('/path/to/project', { agents });
-console.log(result.welcomeMessage);
-
-// Chat API — launch an agent with Welcome prompt
-import { chat, buildStartupPrompt, detectCliAgents } from '@agent-loom/azure-functions-skills/chat';
-
-const cliAgents = await detectCliAgents();
-const { childProcess, prompt } = await chat({ agent: 'claude-code', dir: '/path/to/project' });
-```
-
-### Install as a plugin from GitHub
-
-Released plugin payloads are committed under `.github/plugins/azure-functions-skills/`, so agents that support Git-backed plugins can install directly from this repository or from the marketplace manifests in `.plugin/marketplace.json` and `.claude-plugin/marketplace.json`.
-
-For GitHub Copilot CLI / Codex-style marketplace flows:
-
-```bash
-copilot plugin marketplace add Azure/azure-functions-skills
-copilot plugin install azure-functions-skills@azure-functions-skills
-```
-
-For VS Code, use **Chat: Install Plugin From Source** and point it at the repository or the plugin payload path:
+For GitHub Copilot workspaces, `setup` writes:
 
 ```text
-Azure/azure-functions-skills:.github/plugins/azure-functions-skills
+.github/copilot-instructions.md
+.github/agents/functions-copilot.agent.md
+.github/skills/<skill-id>/SKILL.md
+.github/hooks/welcome-setup.json
+.vscode/mcp.json
+AGENTS.md
 ```
 
-### Download release zip (plugin bundle)
-
-Release zips are optional convenience artifacts. For direct install/update, prefer the Git-backed plugin flow above or the filtered workspace install with `setup`.
-
-Download the plugin payload zip from [GitHub Releases](https://github.com/Azure/azure-functions-skills/releases):
-
-- `azure-functions-skills-plugin-{version}.zip` — cross-tool plugin payload
-
-Extract it into a stable plugin directory:
-
-```bash
-mkdir -p ~/.azure-functions-skills/plugins
-unzip azure-functions-skills-plugin-{version}.zip -d ~/.azure-functions-skills/plugins
-
-# PowerShell
-$pluginRoot = Join-Path $env:LOCALAPPDATA "AzureFunctionsSkills\plugins"
-New-Item -ItemType Directory -Path $pluginRoot -Force | Out-Null
-Expand-Archive azure-functions-skills-plugin-{version}.zip -DestinationPath $pluginRoot
-```
-
-Register the extracted plugin directory with your agent's plugin-from-source flow.
-
-## What You Get
-
-| Skill | Description |
-| --- | --- |
-| **azure-functions-common** | Shared language, runtime, trigger, binding, and extension references for the suite |
-| **azure-functions-best-practices** | Review existing Function Apps against Azure Functions best practices and guide approved remediations |
-| **azure-functions-create** | Scaffold a new Azure Functions project with language and template selection |
-| **azure-functions-deploy** | Azure Functions-facing proxy to Azure Skills deployment (`azure-prepare` → `azure-validate` → `azure-deploy`) |
-| **azure-functions-diagnostics** | Diagnose deployment failures, runtime errors, trigger/binding failures, telemetry issues, and related incidents |
-| **azure-functions-health-status** | Inspect current app state, Resource Health, metrics, Application Insights/Log Analytics signals, and recent Activity Log |
-| **azure-functions-inventory** | Collect app specifications and configuration inventory without runtime-health analysis |
-| **azure-functions-setup** | Verify prerequisites and set up the local Azure Functions development environment |
-
-Plus:
-
-- **functions-copilot** agent — routes you to the right skill based on context
-- **Welcome hook** — first-run prerequisite check + onboarding
-- **MCP integration** — Azure Functions Templates + Azure MCP servers
-- **AGENTS.md** — coding standards (linter, TDD, security, self-review)
-
-## What Gets Installed
-
-### GitHub Copilot
-
-**Workspace files** (copied to your project):
-```
-.github/copilot-instructions.md           # Always-on instructions + welcome
-.github/agents/functions-copilot.agent.md  # @functions-copilot custom agent
-.github/skills/{skill-id}/SKILL.md         # Agent Skills standard; one directory per skill
-.github/skills/{skill-id}/references/      # Optional supporting references
-.github/skills/{skill-id}/scripts/         # Optional helper scripts
-.github/hooks/welcome-setup.json          # SessionStart: prereq check + welcome
-.vscode/mcp.json                          # Azure Functions Templates + Azure MCP
-AGENTS.md                                 # Coding standards
-```
-
-**Plugin format** (generated into `dist/plugin/azure-functions-skills/` and committed at `.github/plugins/azure-functions-skills/`; not copied by `setup`):
-```
-.plugin/plugin.json                        # Copilot/OpenPlugin manifest
-plugin.json                               # Plugin manifest
-skills/{skill-id}/SKILL.md                # Plugin-level skills
-agents/functions-copilot.agent.md         # Plugin-level agent
-hooks.json                                # Plugin hooks (Copilot format)
-.mcp.json                                 # Plugin MCP servers (mcpServers key)
-.claude-plugin/plugin.json                # Claude-compatible manifest
-.codex-plugin/plugin.json                 # Codex-compatible manifest
-```
-
-### Claude Code
-
-```
-CLAUDE.md                                        # Full instructions + skills inline
-.claude/settings.json                            # MCP server configuration
-.claude/skills/{skill-id}/SKILL.md                # One directory per skill
-.claude/skills/{skill-id}/references/             # Optional supporting references
-.claude/skills/{skill-id}/scripts/                # Optional helper scripts
-```
-
-### Codex (OpenAI)
-
-**Workspace files** (copied to your project):
-```
-AGENTS.md                            # Workspace instructions + coding standards
-.agents/skills/{skill-id}/SKILL.md    # Workspace-level skills
-.codex/config.toml                   # MCP server config (workspace format)
-.codex/hooks.json                    # SessionStart: welcome + prereq check
-```
-
-Codex plugin distribution uses the common plugin payload at `.github/plugins/azure-functions-skills/` or `dist/plugin/azure-functions-skills/`.
-
-## Demo: setup → create → deploy
-
-After installing the workspace files or registering the plugin for your preferred agent:
-
-1. **Open your project** in VS Code (Copilot), terminal (Claude/Codex), or your IDE
-2. **The welcome hook fires** — checks your environment and suggests next steps
-3. **Say** *"I want to create a new Azure Function"*
-   - The agent runs **azure-functions-setup** checks
-   - Then guides you through **azure-functions-create** (language + trigger selection)
-   - Finally suggests **azure-functions-deploy** to push to Azure
-4. Each skill surfaces the **next logical action** from its `SKILL.md` guidance
+Claude Code and Codex receive equivalent workspace-local instructions, skills, hooks, and MCP configuration in their native locations.
 
 ## Development
 
-### Prerequisites
-
-- Node.js ≥ 18
-
-### Setup
-
-Run this once after cloning the repository, and any time `node_modules/` is removed:
+Install dependencies:
 
 ```bash
 npm ci
 ```
 
-`npm ci` installs the development tools used by the scripts, including TypeScript's `tsc` command.
-
-### Test (TDD)
+Validate changes:
 
 ```bash
-npm run lint             # ESLint for TypeScript and JavaScript
-npm run typecheck        # TypeScript strict typecheck for src/ and tests/
-npm test                 # run once
-npm run test:watch       # watch mode
-npm run validate:skills  # validate canonical skill templates
-npm run verify:plugin-payload # verify committed plugin payload is in sync
-npm run check            # lint + typecheck + validate + test + build
+npm run check
 ```
 
-`npm run ci` is kept as an alias for CI systems, but `npm run check` is the clearer local command.
-
-### Build
+Regenerate committed plugin payload and marketplace manifests after editing `templates/`:
 
 ```bash
-npm run build                     # all targets
-npm run build -- --target ghcp    # single target
-npm run build:plugin-payload      # update committed plugin payload + marketplaces
+npm run build:plugin-payload
 ```
 
-Output goes to `dist/`:
-```
-dist/
-├── workspace/
-│   ├── ghcp/     # GitHub Copilot workspace layout
-│   ├── claude/   # Claude Code workspace layout
-│   └── codex/    # Codex workspace layout
-└── plugin/
-  └── azure-functions-skills/ # self-contained plugin payload
+Key source directories:
+
+```text
+templates/   Canonical agents, skills, hooks, prompts, and MCP definitions
+src/         TypeScript CLI and build system
+tests/       Vitest coverage for build, setup, chat, validation, and release helpers
+.github/plugins/azure-functions-skills/  Generated plugin payload
 ```
 
-The release-ready plugin payload is also generated into `.github/plugins/azure-functions-skills/` by `npm run build:plugin-payload`. Do not edit that generated directory by hand; update `templates/` and regenerate it.
-
-### Add a new skill
-
-Scaffold the required skill file:
-
-```bash
-npm run new:skill -- azure-functions-my-skill \
-  --title "Azure Functions My Skill" \
-  --description "Guidance for my Azure Functions workflow"
-```
-
-Before opening a PR, complete this checklist:
-
-- Update `templates/skills/<skill-id>/SKILL.md` frontmatter metadata (`name`, `title`, `description`, `category`).
-- Write `templates/skills/<skill-id>/SKILL.md` workflow instructions and any next-step guidance.
-- Add optional `references/` or `scripts/` content if the skill needs supporting files.
-- Run `npm run validate:skills` to catch missing files and frontmatter ID mismatches.
-- Run `npm run check` to verify lint, typecheck, validation, tests, and build.
-- Run `npm pack --dry-run` before release-related changes to inspect package contents.
-
-### Architecture
-
-```
-src/                     # CLI / builder source code (TypeScript)
-└── build/               # Build system
-    ├── build.ts         #   Entry point
-    ├── loader.ts        #   Canonical source loader
-    ├── validate-skills.ts # Skill template validator
-    └── build-target.ts  #   Per-target generators
-lib/                     # Compiled runtime output used by package exports and CLI
-
-.github/plugins/azure-functions-skills/ # Generated release plugin payload committed on release
-.plugin/marketplace.json                 # Generated Copilot marketplace manifest
-.claude-plugin/marketplace.json          # Generated Claude marketplace manifest
-
-templates/               # Canonical plugin content (edited by hand)
-├── skills/              # Canonical skill definitions
-│   ├── azure-functions-common/       #   SKILL.md + references/
-│   ├── azure-functions-create/       #   includes references/
-│   ├── azure-functions-deploy/
-│   ├── azure-functions-diagnostics/  #   includes references/
-│   ├── azure-functions-health-status/ #   includes references/ and scripts/
-│   ├── azure-functions-inventory/    #   includes references/ and scripts/
-│   └── azure-functions-setup/
-├── agents/              # Agent definitions
-│   ├── AGENTS.md        #   Coding standards
-│   └── functions-copilot.agent.md
-├── hooks/               # Lifecycle hooks
-│   └── welcome-setup.md #   First-run welcome + prereq check
-├── mcp/                 # MCP server definitions
-│   └── servers.yaml
-└── prompts/             # Chat startup prompts
-    └── startup.md
-```
-
-The build system reads canonical sources and generates workspace-specific artifacts plus a self-contained plugin payload. Each skill has:
-- `SKILL.md` — YAML frontmatter metadata plus target-agnostic workflow instructions
-- optional `references/` and `scripts/` directories copied into every target artifact
-
-### CI/CD
-
-The GitHub Actions workflows:
-
-- **Build** (`.github/workflows/build-plugins.yml`) — runs on every push/PR to `main`:
-  1. Install dependencies
-  2. Run lint
-  3. Run TypeScript typecheck
-  4. Validate skill templates
-  5. Run tests
-  6. Verify committed plugin payload is in sync
-  7. Build workspace and plugin artifacts
-  8. Upload artifacts
-
-- **Publish** (`.github/workflows/publish.yml`) — intentionally disabled. The workflow is kept as documentation/reference only because the repository permissions do not allow it to complete reliably.
-
-### Local release
-
-Use the local release helper from a clean `main` checkout. It validates `main`, checks that the disabled publish workflow will not run on tag push, bumps the package version when needed, regenerates the committed plugin payload and marketplace manifests, runs validation, creates the tag, publishes to npm, pushes the tag, and best-effort creates a GitHub Release with a plugin payload zip.
-
-```bash
-npm run release:local -- 0.12.0 --yes
-```
-
-Useful options:
-
-- `--dry-run` — print mutating commands without running them.
-- `--github-account <user>` — switch GitHub CLI account before creating the Release.
-- `--skip-github-release` — publish npm and push the tag without creating a Release.
-- `--require-github-release` — fail instead of skipping when GitHub Release creation is unavailable.
-
-Prerequisites for a full release:
-
-- `npm whoami` is authenticated with permission to publish `@agent-loom/azure-functions-skills`.
-- `gh auth status` is authenticated with permission to create releases in `Azure/azure-functions-skills`.
-- On non-Windows platforms, `zip` is available for packaging Release assets.
-
-## Specification
-
-See [docs/prd-docs/](docs/prd-docs/) for detailed feature requirement documents.
+Do not edit generated plugin payload files by hand. Update `templates/`, then regenerate.
 
 ## License
 

--- a/templates/agents/functions-copilot.agent.md
+++ b/templates/agents/functions-copilot.agent.md
@@ -24,6 +24,7 @@ You have access to the following MCP server — use it proactively:
 | **azure-functions-deploy** | User wants to deploy their app to Azure; this is the Azure Functions-facing proxy to Azure Skills deployment |
 | **azure-functions-best-practices** | User wants to review, harden, optimize, or remediate an existing Function App against Azure Functions best practices |
 | **azure-functions-diagnostics** | User reports deployment failures, runtime errors, trigger/binding failures, language worker issues, telemetry/log analysis needs, or asks for troubleshooting/remediation |
+| **azure-functions-feedback** | User wants to turn session findings into an issue or pull request for this skill suite, or a workflow reveals reusable skill improvements |
 
 ## Routing Rules
 
@@ -33,10 +34,11 @@ You have access to the following MCP server — use it proactively:
 4. **Deployment** ("deploy", "publish", "push to Azure") → azure-functions-deploy, which should proxy to Azure Skills (`azure-prepare` → `azure-validate` → `azure-deploy`)
 5. **Best-practices review / hardening / optimization** ("best practices", "review my Function App", "harden", "optimize configuration", "production readiness") → azure-functions-best-practices
 6. **Troubleshooting / diagnosis** ("error", "failed", "not triggering", "timeout", "logs", "exceptions", "why is my function not working") → azure-functions-diagnostics
-7. **After azure-functions-setup succeeds** → Suggest azure-functions-create
-8. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
-9. **After azure-functions-deploy succeeds** → Suggest azure-functions-best-practices for production readiness review
-10. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
+7. **Skill suite feedback** ("feedback", "create issue", "create PR", "skill improvement", "wrong guidance", "confusing skill", "missed verification") → azure-functions-feedback
+8. **After azure-functions-setup succeeds** → Suggest azure-functions-create
+9. **After azure-functions-create succeeds** → Suggest azure-functions-deploy
+10. **After azure-functions-deploy succeeds** → Suggest azure-functions-best-practices for production readiness review
+11. **After azure-functions-deploy fails or health checks show failures** → Suggest azure-functions-diagnostics
 
 ## Behavior
 
@@ -45,6 +47,7 @@ You have access to the following MCP server — use it proactively:
 - For deployment, route to azure-functions-deploy first so it can proxy to Azure Skills and inject Azure Functions-specific guidance when needed
 - For proactive review, route to azure-functions-best-practices before proposing broad configuration changes
 - For troubleshooting, route to azure-functions-diagnostics before proposing fixes unless the root cause is already obvious from gathered evidence
+- If a completed workflow reveals incorrect, confusing, or missing Azure Functions skill guidance, ask whether the user wants to preview feedback through azure-functions-feedback
 - If unsure, ask ONE clarifying question (max 1)
 - After any skill completes, suggest the next logical step from the graph
 - Respond in the same language the user is using

--- a/templates/skills/azure-functions-common/SKILL.md
+++ b/templates/skills/azure-functions-common/SKILL.md
@@ -17,6 +17,7 @@ Shared references include:
 
 - Language/runtime references in `references/languages/`.
 - Trigger/binding extension references in `references/extensions/`.
+- Local emulator and development-service guidance in `references/local-emulators.md`.
 - Routing rules in `references/routing.md`.
 
 Task-specific skills keep their own workflows, scripts, evidence checklists, and output formats. For example, diagnostics owns diagnostic workflow and health evidence rules; this skill only owns reusable Azure Functions reference material.
@@ -29,5 +30,6 @@ This is a shared reference skill. Return to the calling Azure Functions skill af
 
 - Load exactly one language reference when the runtime is known, plus Durable only when Durable is involved.
 - Load only extension references matching the app's triggers/bindings or the symptom.
+- Load `references/local-emulators.md` when local E2E verification involves a non-HTTP trigger, service-backed binding, emulator, container, or temporary development resource.
 - Load Extension Bundles only for non-.NET apps or extension-version/binding-resolution symptoms.
 - Prefer official documentation, official repositories, official samples, and package/container registries before broader web sources.

--- a/templates/skills/azure-functions-common/references/local-emulators.md
+++ b/templates/skills/azure-functions-common/references/local-emulators.md
@@ -1,0 +1,49 @@
+# Local emulators and development services
+
+Use this reference when `azure-functions-create`, diagnostics, or best-practices work needs local E2E verification for non-HTTP triggers or bindings.
+
+## Ground rules
+
+- Ask the user before installing, downloading, starting, or configuring any emulator, container, service, or background process.
+- Prefer tools that are already installed and visible in the workspace or PATH.
+- If the user declines emulator setup, skip emulator-backed E2E verification and clearly state what was skipped.
+- Do not change long-lived system services, Docker state, Azure resources, secrets, or connection strings without explicit approval.
+- Keep local settings in `local.settings.json` or environment variables. Never commit secrets or real connection strings.
+
+## Trigger and binding mapping
+
+Official links below were checked for HTTP 200 access on 2026-05-12.
+
+| Trigger / binding | Local E2E option | Official reference | Notes |
+| --- | --- | --- | --- |
+| `httpTrigger` | No emulator needed | [HTTP trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger), [run locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) | Start `func host` and send an HTTP request to `http://localhost:7071/api/<FunctionName>`. |
+| `timerTrigger` | No service emulator needed | [Timer trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer), [manually run non-HTTP functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-manually-run-non-http) | Verify listener startup. For a full local run, ask before changing the schedule to a short development-only value and restore it afterward. |
+| Blob, Queue, Table Storage | Azurite | [Use Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite), [local storage emulator note](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local#local-storage-emulator) | Use Azurite for `AzureWebJobsStorage` and Storage triggers/bindings when the extension supports local development. |
+| Cosmos DB | Azure Cosmos DB Emulator or a temporary Azure dev account | [Cosmos DB Emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator), [develop locally with emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator) | The emulator is platform/runtime dependent. If unavailable, use a disposable Azure dev resource after user approval. |
+| Service Bus | Service Bus Emulator or temporary Azure Service Bus dev namespace | [Service Bus trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger), [emulator overview](https://learn.microsoft.com/en-us/azure/service-bus-messaging/overview-emulator), [test locally](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator) | Do not assume the emulator is installed. Ask before creating Azure resources or installing containers/tools. |
+| Event Hubs | Event Hubs Emulator or temporary Azure Event Hubs dev namespace | [Event Hubs trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger), [test locally with emulator](https://learn.microsoft.com/en-us/azure/event-hubs/test-locally-with-event-hub-emulator) | Validate by sending an event and checking checkpoint/listener behavior. |
+| Event Grid | Local HTTP endpoint plus Event Grid validation tooling, or temporary Azure Event Grid resource | [Event Grid trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger), [Event Grid how-tos](https://learn.microsoft.com/en-us/azure/azure-functions/event-grid-how-tos) | There is no universal local replacement for Azure delivery semantics. Prefer deployment/dev-resource tests for full verification. |
+| SQL | Local SQL Server, SQL container, Azure SQL Edge, or temporary Azure SQL dev database | [Azure SQL trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-azure-sql-trigger), [Azure SQL bindings overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-azure-sql) | Use a least-privilege local/dev connection string and keep it out of source control. |
+| Redis | Local Redis container/server or temporary Azure Cache for Redis dev instance | [Redis list trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cache-trigger-redislist) | Confirm extension requirements and connection settings. |
+| Kafka | Local Kafka container/cluster or approved development cluster | [Kafka trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-kafka-trigger) | Validate topic existence and consumer group behavior. |
+| Durable Functions | Azurite for the default Azure Storage provider, or an approved storage provider | [Durable Functions storage provider configuration](https://learn.microsoft.com/en-us/azure/azure-functions/durable-functions/durable-functions-configure-managed-identity), [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) | Durable Functions commonly depends on `AzureWebJobsStorage` locally. Confirm provider-specific requirements before E2E tests. |
+| MySQL | Local MySQL container/server or temporary Azure Database for MySQL dev instance | No Azure Functions-specific emulator page found in the checked official set | Verify schema/table prerequisites before starting the host. |
+| RabbitMQ | Local RabbitMQ container/server or approved development broker | No Azure Functions-specific emulator page found in the checked official set | Validate queue/exchange setup. |
+| Dapr | Local Dapr sidecar and component configuration | No Azure Functions-specific emulator page found in the checked official set | Ask before running sidecars. Confirm component YAML does not include secrets. |
+
+## Suggested verification pattern
+
+1. Build the project first (`npm run build`, `dotnet build`, `mvn package`, or language equivalent).
+2. Identify the trigger/binding and required local dependency from the table above.
+3. Ask whether to install/start the emulator or use an existing dev resource.
+4. Start the emulator/service only after approval.
+5. Start the Functions host.
+6. Send one realistic input event/message/document/request.
+7. Verify the expected log line, output binding side effect, response, checkpoint, or persisted data.
+8. Stop any local processes started for the test and report what was validated or skipped.
+
+## Skip wording
+
+When the user declines emulator setup, report it explicitly:
+
+> Emulator-backed E2E verification was skipped by request. Verified build and Functions host/listener startup only. To complete E2E later, run the same test with `<emulator or dev resource>` and send `<event/message/document>` to `<trigger source>`.

--- a/templates/skills/azure-functions-common/references/routing.md
+++ b/templates/skills/azure-functions-common/references/routing.md
@@ -6,6 +6,7 @@ Reference files are bundled with `azure-functions-common`:
 
 - Language references: `references/languages/`
 - Extension references: `references/extensions/`
+- Local E2E references: `references/local-emulators.md`
 
 ## Language routing
 
@@ -59,3 +60,8 @@ For any trigger or binding investigation, include `azure-webjobs-sdk` when the s
 | Trigger not firing | Inventory trigger list, health/status traces, matching extension reference |
 | Runtime startup failure | Inventory runtime settings, health/status traces, matching language reference |
 | Network/connectivity failure | Inventory network shape, health dependencies/traces, matching extension reference |
+| Local E2E verification for non-HTTP triggers or bindings | `local-emulators.md`, matching extension reference |
+
+## Skill feedback routing
+
+Use `azure-functions-feedback` when the user asks to provide feedback, create an issue or PR for this skill suite, report confusing/incorrect skill guidance, or when a completed workflow reveals reusable improvements for any `azure-functions-*` skill.

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -117,13 +117,19 @@ npm run build   # TypeScript / JavaScript
 # mvn package   # Java
 ```
 
-Then start and test locally:
+Then perform an end-to-end local verification, not just a host start:
 
 ```bash
 func start
 ```
 
-Invoke the function (for HTTP triggers: `curl http://localhost:7071/api/<FunctionName>`).
+After the host reports the function endpoints/listeners:
+
+- **HTTP triggers**: send an actual request to the local endpoint and verify the status code and response body, for example `curl http://localhost:7071/api/<FunctionName>?name=World`.
+- **Timer triggers**: verify the listener starts and, when practical, temporarily use a short development-only schedule or manual invocation approach; restore the user's intended schedule before finishing.
+- **Storage, Cosmos DB, SQL, Redis, Dapr, or other service-backed triggers/bindings**: load `azure-functions-common/references/local-emulators.md`, identify the required local emulator or development service, and run a realistic message/blob/document/event through the trigger when the user wants E2E verification.
+- **Before installing or starting any emulator/local service**: ask the user for confirmation. If the user says the emulator is not needed, unavailable, or should be skipped, do not install it; record that emulator-backed E2E was skipped and provide manual/Azure test steps instead.
+- **When no practical local emulator exists**: explain the limitation, suggest a temporary Azure dev resource or deployment-based test, and keep the local verification to build + host/listener startup.
 
 ---
 
@@ -180,9 +186,15 @@ For minimal HTTP trigger snippets per language (last-resort fallback when the ma
 
 #### B.3 Verify
 
+Build compiled projects first, then perform the same local E2E verification standard used in Path A:
+
 ```bash
 func start
 ```
+
+- For HTTP triggers, send a real request to the local endpoint and validate the response.
+- For non-HTTP triggers, consult `azure-functions-common/references/local-emulators.md` and use an emulator/local service when practical.
+- Ask before installing or starting emulators. If the user declines, skip emulator-backed E2E and document the skipped verification plus manual/Azure test steps.
 
 ---
 

--- a/templates/skills/azure-functions-feedback/SKILL.md
+++ b/templates/skills/azure-functions-feedback/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: azure-functions-feedback
+title: Azure Functions Skills Feedback
+description: Turn session findings into previewed issues or pull requests for the Azure Functions skills repository
+category: task
+---
+
+> **Language**: Always respond in the same language the user is using.
+
+# azure-functions-feedback — Azure Functions Skills Feedback
+
+Use this skill after an Azure Functions skill workflow when the session reveals an improvement opportunity for the `azure-functions-*` skills, their references, tests, README, or generated plugin payload.
+
+## When to use
+
+Use this skill when:
+
+- The user asks to send feedback, create an issue, or create a pull request for Azure Functions Skills.
+- A workflow uncovered confusing guidance, missing verification, outdated commands, wrong MCP tool usage, repeated recovery steps, or missing diagnostics evidence.
+- The agent needed user correction about an `azure-functions-*` skill.
+- A manual or E2E test produced reusable findings.
+
+Do not use it for ordinary app bugs unless the finding is about the skill suite itself.
+
+## Workflow
+
+### 1. Review the session
+
+Review the available conversation/session history, files changed, test output, and command results. Identify only actionable feedback related to this repository:
+
+- affected skill or file (`azure-functions-create`, `azure-functions-deploy`, README, routing, references, tests, etc.)
+- observed behavior
+- expected behavior
+- evidence from the session
+- repro steps or scenario
+- proposed fix or documentation change
+- risk / impact
+
+Redact secrets, tenant-specific sensitive data, function keys, publish profiles, tokens, connection strings, and customer data. Keep only resource names or URLs that the user explicitly allows to share.
+
+### 2. Ask whether to proceed
+
+If feedback is likely useful, ask the user whether they want to provide it. Keep the prompt concise:
+
+> I found feedback that could improve Azure Functions Skills. Would you like to preview it as an Issue or a Pull Request?
+
+Options:
+
+- Issue
+- Pull Request
+- Not now
+
+Do not create external GitHub artifacts without explicit user confirmation.
+
+### 3. Prepare a preview
+
+Before creating anything, show a preview with this structure:
+
+```
+Title:
+Summary:
+Affected area:
+Evidence:
+Repro / scenario:
+Expected behavior:
+Proposed change:
+Validation plan:
+Redactions applied:
+```
+
+Ask the user to approve or edit the preview.
+
+### 4. Issue path
+
+After approval, create an issue in `Azure/azure-functions-skills` using the preview content.
+
+Prefer the GitHub CLI when available. If it is unavailable, provide the prepared issue body and ask the user to create it manually.
+
+After creation, report the issue URL and any follow-up action.
+
+### 5. Pull Request path
+
+After approval, implement the smallest safe change in this repository:
+
+1. Create or switch to a focused branch.
+2. Update canonical sources under `templates/`, README, tests, or docs as appropriate.
+3. Regenerate generated plugin payload and marketplace files when canonical skill or agent files change.
+4. Run validation (`npm run check` when practical; otherwise explain the narrower validation used).
+5. Commit with a conventional commit message.
+6. Push and open a pull request against `Azure/azure-functions-skills`.
+
+Do not include unrelated local docs, PLAN files, secrets, generated temp files, or user-specific logs.
+
+### 6. Output
+
+End with:
+
+- Issue or PR URL, if created.
+- Files changed, if PR path was used.
+- Validation results.
+- Any intentionally skipped feedback.
+
+## Quality bar
+
+- Feedback must be specific, actionable, and grounded in observed evidence.
+- Prefer one issue/PR per cohesive topic.
+- Do not overgeneralize from a single failure unless the skill guidance caused or failed to recover from it.
+- Keep user language and tone.


### PR DESCRIPTION
## Summary
- Enhance azure-functions-create verification guidance to require local E2E checks beyond host startup, including HTTP requests and emulator-backed non-HTTP checks when approved.
- Add shared local emulator/development-service reference with checked official Microsoft Learn links.
- Add azure-functions-feedback skill and route it through functions-copilot.
- Simplify README to make plugin installation first-class and clarify plugin vs chat vs setup usage.
- Regenerate committed plugin payload.

## Validation
- npm run build:plugin-payload
- npm run check
  - 84 tests passed