### PR TITLE
feat: add Azure Functions E2E test skill

### DIFF
--- a/.github/skills/azure-functions-e2e-tests/SKILL.md
+++ b/.github/skills/azure-functions-e2e-tests/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: azure-functions-e2e-tests
+title: Azure Functions Skills E2E Tests
+description: "Use in Agent mode when designing, running, or reporting real end-to-end tests for Azure Functions Skills across GitHub Copilot, Claude Code, and Codex plugin/setup/chat flows."
+category: task
+---
+
+> **Language**: Reply in the user's language. Default generated shareable E2E reports to English unless the user asks for another language.
+
+# Azure Functions Skills E2E Tests
+
+Use this skill in **Agent mode** to run and summarize real end-to-end validation of Azure Functions Skills across coding agents. When the user asks to test, run the safe local scenarios that are available in the current environment and report blocked, unsupported, and failed scenarios with evidence and root-cause analysis.
+
+## Agent mode requirement
+
+This skill is intended for Agent mode, not passive chat.
+
+- If the current chat cannot run terminal commands or edit/check files, tell the user to switch to Agent mode before continuing.
+- In Agent mode, run the workflow directly: inventory the current templates, create isolated temporary workspaces, invoke real coding-agent CLIs, inspect evidence, author a high-quality HTML report, and summarize results.
+- Do not merely print commands for the user to run unless tool execution is unavailable or the user explicitly asks for manual commands.
+
+## When to use
+
+- The user asks to run E2E tests for Azure Functions Skills.
+- The user asks whether GitHub Copilot, Claude Code, or Codex support plugin/setup/chat flows.
+- The user wants a scenario-by-agent support matrix or HTML report.
+- A plugin install, workspace setup, chat startup, hook, MCP, prompt, or skill visibility issue needs reproducible evidence.
+- The user wants to compare README guidance with actual agent behavior.
+
+## Core rules
+
+1. **Real agents, not fakes** — use real install commands and real coding-agent CLIs when available. Do not replace E2E validation with mocks, hard-coded template expectations, or generated-report scripts.
+2. **Dynamic inventory** — derive expected `skills`, `prompts`, `mcp`, `hooks`, `agents`, plugin payload files, and Azure Skills dependency checks from the current repository files and docs at run time. Do not hard-code today's template names.
+3. **Scenario references first** — select scenarios from [scenarios.md](references/scenarios.md) and keep a short `E2E-RUN-<timestamp>.md` checklist while running them.
+4. **Agent-visible proof required** — setup, chat, and plugin scenarios must prove that the target coding agent can see or use the installed `skills`, `prompts`, `mcp`, `hooks`, and `agents`; file existence alone is not enough.
+5. **Documented command contract** — plugin/setup/chat scenarios must use the documented command sequence from README or generated CLI help, then launch the target agent with an inspection prompt.
+6. **No false warnings** — if a required command was not run, exited non-zero, timed out, or did not prove required visibility, mark the scenario `fail` or `blocked`, not `warning`. Use `warning` only when every required check passed and only non-blocking concerns remain.
+7. **Evidence before judgment** — record command output, file evidence, agent version, package version, prompt transcript, and support status before concluding.
+8. **Redact aggressively** — never publish tokens, function keys, publish profiles, connection strings, secrets, or personal local paths.
+9. **Separate unsupported from failed** — mark a scenario `unsupported` when the agent or platform cannot support the flow; mark it `blocked` when local prerequisites, credentials, or safe isolation are missing; mark it `fail` when expected behavior is broken.
+10. **Beautiful report by the agent** — author the HTML report directly from evidence. Match the quality of the design report style: readable layout, summary cards, matrices, clear colors, failure analysis, and recommended fixes.
+11. **Review the review** — after drafting evidence and reports, perform a cross-check pass over commands, outputs, scenario statuses, and conclusions. Fix unsupported/blocked/fail classifications before presenting results.
+
+## Execution policy
+
+When the user asks to run or validate E2E tests:
+
+1. Build a dynamic inventory from the current repository:
+   - `templates/skills/*/SKILL.md` for expected Azure Functions skills.
+   - `templates/prompts/`, `templates/mcp/`, `templates/hooks/`, and `templates/agents/` for expected prompts, MCP, hooks, and agent definitions.
+   - `.github/plugins/azure-functions-skills/` and generated plugin manifests for plugin payload expectations.
+   - README and package scripts for documented setup/chat/plugin commands.
+2. Create one isolated temporary workspace per agent and install mode. Do not reuse the repository root as a test workspace.
+3. For each target agent (`ghcp`, `codex`, `claude`) and each mode (`plugin`, `setup`, `chat`):
+   - Start from a clean isolated workspace and, when safe, a clean isolated agent/plugin config location.
+   - If clearing real user-level plugin state would mutate the user's profile, ask for approval or mark the cleanup check `blocked`; never silently delete global config.
+   - Install or register `azure-functions-skills` using the documented flow for that mode.
+   - Verify whether the dependent `azure-skills` surfaces are present or whether clear install guidance is shown.
+   - Launch the actual coding-agent CLI with an inspection prompt. The prompt must ask it to report visible/usable `agents`, `skills`, `prompts`, `mcp`, `hooks`, plugin surfaces, and Azure Skills dependency surfaces. Treat missing agent-response evidence as `blocked` or `fail` according to the cause.
+   - For `chat`, also verify that startup loads the intended agent and welcome/startup message.
+4. For plugin scenarios, the command sequence is part of the test contract:
+   - GitHub Copilot CLI must follow README order: `copilot plugin marketplace add Azure/azure-functions-skills`, then `copilot plugin install azure-functions-skills@azure-functions-skills`, then run Copilot with the Functions agent, for example `copilot --agent functions-copilot -p "<inspection prompt>"`.
+   - Claude Code must follow the README plugin-from-source flow: clone or use the repo source, run `claude --add-dir <plugin-payload-dir>`, then run Claude with an inspection prompt in the isolated workspace.
+   - Codex must follow the README Codex plugin flow: `codex plugin marketplace add Azure/azure-functions-skills`, install/select `azure-functions-skills` from `/plugins` when supported, then run Codex with an inspection prompt in the isolated workspace.
+   - If a documented plugin command is unavailable, interactive-only, or contradicts current CLI help, record the command attempt and classify the scenario as `blocked` or `fail` with analysis; do not silently substitute setup-mode file checks.
+5. Capture every command used for evaluation:
+   - Command text, cwd, environment assumptions, start/end time, exit code, and redacted stdout/stderr excerpt.
+   - In the HTML report, put command details and output in collapsed `<details><summary>...</summary>...</details>` sections so readers can inspect them without overwhelming the summary.
+6. Workspace retention:
+   - Before cleanup, ask the user whether to keep failed scenario workspaces, keep all workspaces, or delete all temporary workspaces.
+   - If the user keeps workspaces, record retained paths in the evidence/report after redacting user-specific path segments where sharing externally.
+   - If no answer is available, keep failed workspaces when practical and delete passing workspaces.
+7. Authentication and local prerequisites:
+   - Because this starts as a local E2E workflow, it is acceptable to ask the user to authenticate, approve a CLI prompt, reload VS Code, or run a one-time login when a real agent/plugin flow is blocked by auth.
+   - Do not mark auth-blocked scenarios as fail unless authentication should already have been available according to the scenario contract; otherwise use `blocked` with clear next steps.
+8. If an agent or mode cannot support a surface, report `unsupported` with a reason. If a CLI hangs, lacks authentication, or cannot safely isolate plugin state, report `blocked`. If a surface should work but does not, report `fail` with failure analysis.
+9. Run local static checks as follow-up: `npm run check` when practical, or focused tests when the user asks for a narrow scope.
+10. Do not run live Azure scenarios unless the user explicitly asks and the protected Azure/OIDC environment is available.
+11. Always write structured evidence and a human-readable report, even when some scenarios are blocked or unsupported.
+
+## Report publishing
+
+The coding agent creates the report from collected evidence. When the user asks to publish or attach a report to a PR, copy or stage the reviewed `report.html` to the requested destination, such as `reports/e2e/current/report.html`. Do not rely on a report-generation or report-submission script as the source of truth.
+
+## Workflow
+
+1. **Create the run checklist**
+   - Include target agents, install modes, platform, package version, selected scenarios, dynamic inventory source paths, and expected surface counts.
+   - Track each scenario as `[ ]`, then update to `[x]`, `[blocked]`, `[unsupported]`, or `[failed]`.
+
+2. **Collect environment information**
+   - Agent CLI availability and versions.
+   - OS and shell.
+   - Current repository commit and package version.
+   - Whether plugin, setup, chat, and Azure Skills dependency flows are in scope.
+   - Current template inventory and generated plugin payload inventory.
+
+3. **Run scenarios**
+   - Run plugin, setup, and chat scenarios for GitHub Copilot, Codex, and Claude.
+   - Isolate each run in a temporary workspace unless the user intentionally targets an existing workspace.
+   - Capture evidence for every check in the scenario.
+   - Capture command details and redacted command output for every command that affects the result.
+   - When blocked by authentication or an interactive local approval, ask the user for help before marking the scenario.
+   - Continue through remaining scenarios after failures unless the failure indicates a safety risk.
+
+4. **Write structured evidence**
+   - Use the JSON shape in [report-schema.md](references/report-schema.md).
+   - Keep raw transcripts separate and redact before publishing.
+
+5. **Create the report**
+   - Include scenario x agent support status, versions, test datetime, platform, failure evidence, unsupported reasons, and recommended fixes.
+   - Include a capability surface matrix for GitHub Copilot, Claude Code, and Codex across `plugin`, `skills`, `prompts`, `mcp`, `hooks`, and `agents`.
+   - Include detailed evidence for how each surface was checked: dynamic inventory source, generated file path, launch command, agent response excerpt, and unsupported/block/fail reason.
+   - Include collapsed command logs with command, cwd, exit code, and redacted output.
+   - Include retained workspace paths or cleanup status for every scenario.
+   - Include failure analysis that explains why a failure occurred and what should be fixed next.
+   - HTML reports must be hand-authored by the agent from the JSON evidence and should be suitable for sharing.
+
+6. **Create the skill improvement report**
+   - Write a short companion report, for example `reports/e2e/<run-id>/skill-improvement.md`.
+   - Include places where the agent struggled while running the skill: command option discovery, unclear docs, missing scenario guidance, auth prompts, CLI non-interactive limitations, report-writing ambiguity, or tool limitations.
+   - Convert each struggle into a proposed improvement for `SKILL.md`, scenario references, README docs, or future automation.
+
+7. **Cross-check before final answer**
+   - Re-read `evidence.json`, `report.md`, `report.html`, retained workspace notes, and the skill improvement report.
+   - Check for contradictions such as a scenario marked `pass` while a command failed, unsupported plugin capability reported as supported, missing command logs, or missing failure analysis.
+   - If available, ask another model/agent or reviewer pass to critique the conclusion; otherwise perform an explicit self-review section in the report.
+   - Record the cross-check result in the HTML report and final chat summary.
+
+8. **README integration only when requested**
+   - Do not update README badges or report links unless the user explicitly asks or the run is in CI publishing mode.
+   - Badge status must be derived from latest evidence, not manually guessed.
+
+## References
+
+- Scenario catalog: [scenarios.md](references/scenarios.md)
+- Report and evidence schema: [report-schema.md](references/report-schema.md)
+- CI rollout and security boundaries: [ci-strategy.md](references/ci-strategy.md)
+- Support status definitions: [support-matrix.md](references/support-matrix.md)
+
+## Output summary
+
+End each run with:
+
+```text
+Run ID:
+Package version:
+Agents tested:
+Scenarios completed:
+Support summary:
+Failures / unsupported cases:
+Report path:
+Next recommended scenario:
+```

--- a/.github/skills/azure-functions-e2e-tests/references/ci-strategy.md
+++ b/.github/skills/azure-functions-e2e-tests/references/ci-strategy.md
@@ -1,0 +1,86 @@
+# E2E CI Strategy
+
+Use progressive CI levels. Do not expose real-agent tokens or Azure credentials to untrusted pull requests.
+
+## Level 1: static E2E contract CI
+
+Trigger:
+
+- `pull_request`
+- `push`
+
+Allowed:
+
+- Scenario catalog validation.
+- Evidence schema validation.
+- Redaction rule tests.
+- README/docs consistency checks.
+- Report HTML contract checks using fixture JSON.
+
+Not allowed:
+
+- Real coding-agent tokens.
+- Azure login.
+- Live plugin installation against user accounts.
+- Network operations that require secrets.
+
+## Level 2: protected real-agent E2E
+
+Trigger:
+
+- `workflow_dispatch`
+- Maintainer-approved label or comment workflow in a later phase.
+
+Requirements:
+
+- Protected GitHub Environment.
+- Required reviewer.
+- Exact branch or SHA input.
+- Redacted artifacts.
+
+Allowed:
+
+- Real GitHub Copilot CLI, Claude Code, and Codex execution when configured.
+- Plugin/setup/chat validation.
+- HTML artifact publishing.
+
+Not allowed:
+
+- Running on untrusted fork PRs with secrets.
+- Live Azure resource creation.
+- Publishing unredacted transcripts.
+
+## Level 3: live Azure E2E
+
+Trigger:
+
+- `workflow_dispatch`
+- `schedule`
+- Post-merge only after the flow is stable.
+
+Requirements:
+
+- Reuse `functions-skills-live-e2e` protected Environment.
+- Use Azure OIDC, not client secrets.
+- Scope Azure RBAC to the test resource group.
+- Add TTL tags and cleanup with `if: always()`.
+
+Allowed:
+
+- Deploy/invoke/cleanup scenarios.
+- Diagnostics against known test apps.
+
+Not allowed:
+
+- Production resources.
+- Fork PR execution.
+- Secret or Function key leakage.
+
+## Recommended rollout
+
+1. Add static scenario and schema tests.
+2. Add local real-agent setup/chat scenarios.
+3. Add plugin scenarios.
+4. Add protected workflow and publish HTML as artifact.
+5. Add README report link and badges after the report format stabilizes.
+6. Add live Azure deploy/diagnostics scenarios last.

--- a/.github/skills/azure-functions-e2e-tests/references/report-schema.md
+++ b/.github/skills/azure-functions-e2e-tests/references/report-schema.md
@@ -1,0 +1,189 @@
+# E2E Evidence and Report Schema
+
+Use this schema as the stable contract for E2E evidence. HTML can be authored from this data by an agent; a deterministic HTML renderer is optional.
+
+## Scenario result record
+
+Each scenario run should emit one JSON object.
+
+```json
+{
+  "runId": "20260516-001",
+  "scenarioId": "chat-welcome-ghcp",
+  "agent": "github-copilot",
+  "installMode": "chat",
+  "platform": "windows",
+  "status": "pass",
+  "support": "supported",
+  "agentVersion": "...",
+  "packageVersion": "...",
+  "startedAt": "2026-05-16T00:00:00Z",
+  "completedAt": "2026-05-16T00:03:00Z",
+  "inventory": {
+    "skills": ["templates/skills/azure-functions-create/SKILL.md"],
+    "prompts": ["templates/prompts/startup.md"],
+    "mcp": ["templates/mcp/servers.yaml"],
+    "hooks": ["templates/hooks/welcome-setup.md"],
+    "agents": ["templates/agents/functions-copilot.agent.md"]
+  },
+  "commandLog": [
+    {
+      "command": "codex exec --sandbox read-only ...",
+      "cwd": "<redacted-temp-workspace>",
+      "startedAt": "2026-05-16T00:01:00Z",
+      "completedAt": "2026-05-16T00:01:20Z",
+      "exitCode": 0,
+      "stdoutExcerpt": "...",
+      "stderrExcerpt": "..."
+    }
+  ],
+  "workspaceRetention": {
+    "policy": "keep-failed",
+    "retainedPath": "<redacted-temp-workspace>",
+    "cleanupStatus": "retained for debugging"
+  },
+  "crossCheck": {
+    "status": "pass",
+    "reviewer": "self-review",
+    "findings": []
+  },
+  "checks": [
+    {
+      "name": "welcome message",
+      "surface": "prompts",
+      "status": "pass",
+      "support": "supported",
+      "evidence": "Startup prompt mentions Azure Functions Skills."
+    }
+  ],
+  "issues": [],
+  "artifacts": {
+    "transcript": "reports/e2e/latest/transcripts/chat-welcome-ghcp.md",
+    "workspaceDir": "<redacted-temp-workspace>"
+  }
+}
+```
+
+## Required fields
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `runId` | Yes | Stable identifier for the whole run. |
+| `scenarioId` | Yes | Must match an ID in `scenarios.md`. |
+| `agent` | Yes | `github-copilot`, `claude-code`, `codex`, or `all` for static checks. |
+| `installMode` | Yes | `plugin`, `setup`, `chat`, or `docs`. |
+| `platform` | Yes | `windows`, `linux`, or another explicit platform value. |
+| `status` | Yes | `pass`, `warning`, `fail`, `blocked`, or `unsupported`. |
+| `support` | Yes | `supported`, `partial`, `unsupported`, or `unknown`. |
+| `agentVersion` | Yes for real-agent runs | Use `unavailable` when the CLI is missing. |
+| `packageVersion` | Yes | Package version or commit SHA under test. |
+| `startedAt` / `completedAt` | Yes | ISO-8601 timestamps. |
+| `inventory` | Yes | Dynamic inventory paths used to derive expected skills/prompts/MCP/hooks/agents/plugin payload checks. |
+| `commandLog` | Yes | Commands used to evaluate the scenario, cwd, timing, exit code, and redacted stdout/stderr excerpts. |
+| `workspaceRetention` | Yes | Whether the temporary workspace was deleted or retained for debugging. |
+| `crossCheck` | Yes | Review result for this scenario or the overall report. |
+| `checks` | Yes | One or more check records. |
+| `issues` | Yes | Empty array when no issues are found. |
+| `artifacts` | No | Paths to redacted artifacts. |
+
+## Check record
+
+```json
+{
+  "name": "plugin installed",
+  "surface": "plugin",
+  "status": "pass",
+  "support": "supported",
+  "evidence": "copilot plugin list includes azure-functions-skills"
+}
+```
+
+`surface` must be one of `plugin`, `skills`, `prompts`, `mcp`, `hooks`, `agents`, `agent-launch`, `agent-inspection`, `setup-files`, or `general`.
+Use `support: "unsupported"` for surfaces that the package or agent cannot support today. For example, Claude Code native plugin support must not be reported as passing unless the test actually launches Claude with the plugin loaded and proves the plugin surfaces are visible.
+Checks should cite dynamic inventory paths instead of assuming a fixed template list. If a template changes, the next run should discover the new inventory and update expectations automatically.
+
+For plugin scenarios, command logs must prove the documented install sequence was attempted before any plugin visibility result is marked `pass` or `warning`. For example, GitHub Copilot plugin evidence must include `copilot plugin marketplace add Azure/azure-functions-skills`, `copilot plugin install azure-functions-skills@azure-functions-skills`, and a post-install `copilot --agent functions-copilot ...` inspection command. If those required commands are missing, fail, time out, or do not prove visibility, classify the scenario as `fail` or `blocked`, not `warning`.
+
+## Issue record
+
+```json
+{
+  "severity": "high",
+  "summary": "Plugin installed but functions-copilot was not discoverable.",
+  "recommendedFix": "Verify plugin manifest agents path and regenerate plugin payload."
+}
+```
+
+Severity values:
+
+- `critical`
+- `high`
+- `medium`
+- `low`
+
+## Command log display
+
+HTML reports should expose command logs in collapsed sections, for example with `<details><summary>Command and output</summary>...</details>`.
+Include the command text, cwd, exit code, timing, and redacted stdout/stderr excerpts. Keep the high-level report readable while making the raw evaluation path available for debugging.
+
+## Workspace retention record
+
+Ask the user whether to keep failed workspaces, keep all workspaces, or delete all temporary workspaces. Record the selected policy and cleanup status. If retained paths are included in shareable reports, redact user-specific path segments.
+
+## Skill improvement report
+
+Each run should produce a companion skill-improvement report that lists where the agent struggled while running the skill, such as command option discovery, unclear documentation, authentication prompts, unsupported non-interactive CLI behavior, or report-writing ambiguity. Each item should include a proposed change to this skill or its references.
+
+## Cross-check record
+
+Before finalizing, review evidence, report text, status classifications, command logs, and failure analysis. Record whether the review found contradictions or missing evidence. If another model/agent/reviewer is available, use it for the critique; otherwise record an explicit self-review.
+
+## Redaction requirements
+
+Never publish these values in JSON, HTML, transcripts, or logs:
+
+- GitHub tokens and personal access tokens.
+- Azure access tokens and OIDC tokens.
+- Function keys.
+- Publish profiles.
+- Connection strings.
+- API keys and passwords.
+- Tenant-specific secrets.
+- Customer data.
+- Personal local paths such as user profile directories.
+
+Recommended redaction placeholders:
+
+| Sensitive value | Placeholder |
+| --- | --- |
+| GitHub token | `<redacted-github-token>` |
+| Azure token | `<redacted-azure-token>` |
+| Function key | `<redacted-function-key>` |
+| Connection string | `<redacted-connection-string>` |
+| Local temp path | `<redacted-temp-workspace>` |
+| User profile path | `<redacted-user-home>` |
+
+## HTML report content contract
+
+A human-readable HTML report should include:
+
+- Test datetime.
+- Package version or commit SHA.
+- Agent versions.
+- Platform.
+- Scenario x agent matrix.
+- Capability surface matrix for every tested agent across `plugin`, `skills`, `prompts`, `mcp`, `hooks`, and `agents`.
+- Status legend.
+- Support status per agent.
+- Failures and unsupported scenarios.
+- Evidence summaries for every check, including file path, expected marker, launcher command, and agent response excerpt when available.
+- Collapsed command and output sections for every command that contributed to the result.
+- Workspace retention policy and retained workspace paths when applicable.
+- Dynamic inventory counts and source paths used to decide what should be visible.
+- Failure analysis for each `fail`, `blocked`, or `unsupported` result.
+- Skill-improvement findings from agent execution friction.
+- Cross-check/re-review results.
+- Recommended fixes.
+- Links to redacted raw artifacts when available.
+
+The HTML does not need to be generated by a deterministic script. It must be grounded in the JSON evidence.

--- a/.github/skills/azure-functions-e2e-tests/references/scenarios.md
+++ b/.github/skills/azure-functions-e2e-tests/references/scenarios.md
@@ -1,0 +1,238 @@
+# E2E Scenario Catalog
+
+Use this catalog to select scenarios for Azure Functions Skills E2E validation. Prefer running a small, focused set first, then expanding to the full matrix. Expected skills/prompts/MCP/hooks/agents must be discovered dynamically from the current repository files at run time, not hard-coded into a runner.
+
+## Matrix dimensions
+
+| Dimension | Values |
+| --- | --- |
+| Agent | `github-copilot`, `claude-code`, `codex` |
+| Install mode | `plugin`, `setup`, `chat` |
+| Platform | `windows`, `linux` |
+| Scenario group | `discovery`, `visibility`, `startup`, `azure-skills-dependency`, `docs-consistency`, `basic-task` |
+
+## Dynamic inventory requirements
+
+Before running scenarios, inspect the current repository and record:
+
+- All template skills from `templates/skills/*/SKILL.md`.
+- Prompt templates from `templates/prompts/`.
+- MCP definitions from `templates/mcp/` and generated target-specific MCP files.
+- Hook templates from `templates/hooks/` and generated target-specific hook files.
+- Agent definitions from `templates/agents/` and generated target-specific agent files.
+- Plugin payload manifests and directories from `.github/plugins/azure-functions-skills/` or the built plugin output.
+- Azure Skills dependency expectations from README, setup guidance, and generated skills text.
+
+The report should include the inventory counts and paths used for each run. If a template is added or removed, the E2E expectations should change automatically because they come from this inventory.
+
+## Status values
+
+| Status | Meaning |
+| --- | --- |
+| `pass` | All required checks passed. |
+| `warning` | All required checks passed, but there are non-blocking usability, documentation, or partial-support concerns. Do not use `warning` when a required command was skipped, failed, timed out, or did not prove the required behavior. |
+| `fail` | Required behavior is broken or contradicts documentation. |
+| `blocked` | The scenario could not run because local prerequisites, credentials, or approvals are missing. |
+| `unsupported` | The agent/platform does not support the scenario by design or current capability. |
+
+## Agent-visible proof for setup and chat
+
+Setup and chat scenarios must prove both installation and runtime visibility:
+
+1. Install or prepare the workspace with the documented setup/chat command.
+2. Check the expected files from the dynamic inventory were written to the isolated workspace.
+3. Launch the real target coding-agent CLI with an inspection prompt.
+4. Require the agent response to report visible or usable `skills`, `prompts`, `mcp`, `hooks`, and `agents` surfaces, or explicitly classify unsupported surfaces.
+
+File checks alone are insufficient for `pass` because they do not prove the coding agent can load or use the installed surfaces. If the files exist but the agent cannot be launched or cannot confirm visibility, classify the scenario as `blocked` or `fail` with evidence.
+
+## Initial scenarios
+
+### `setup-workspace-ghcp`
+
+- Agent: `github-copilot`
+- Install mode: `setup`
+- Priority: P0
+- Purpose: verify workspace-local GitHub Copilot files are installed.
+- Required checks:
+  - `.github/copilot-instructions.md` exists.
+  - `.github/agents/functions-copilot.agent.md` exists.
+  - `.github/skills/<skill-id>/SKILL.md` exists for every template skill.
+  - `.github/hooks/welcome-setup.json` exists.
+  - `.vscode/mcp.json` exists.
+  - `AGENTS.md` exists.
+  - A real GitHub Copilot CLI inspection prompt confirms the visible/usable skills, prompts/instructions, MCP config, hooks, and `functions-copilot` agent, or records a blocked/fail reason.
+
+### `setup-workspace-claude`
+
+- Agent: `claude-code`
+- Install mode: `setup`
+- Priority: P0
+- Purpose: verify workspace-local Claude Code files are installed.
+- Required checks:
+  - `CLAUDE.md` exists.
+  - `.claude/settings.json` exists.
+  - `.claude/skills/<skill-id>/SKILL.md` exists for every template skill.
+  - A real Claude Code inspection prompt confirms the visible/usable skills, prompts/guidance, MCP settings, and agent guidance, or records a blocked/fail reason.
+
+### `setup-workspace-codex`
+
+- Agent: `codex`
+- Install mode: `setup`
+- Priority: P0
+- Purpose: verify workspace-local Codex files are installed.
+- Required checks:
+  - `AGENTS.md` exists.
+  - `.codex/config.toml` exists.
+  - `.codex/hooks.json` exists.
+  - `.agents/skills/<skill-id>/SKILL.md` exists for every template skill.
+  - A real Codex inspection prompt confirms the visible/usable skills, prompts/guidance, MCP config, hooks, and agent guidance, or records a blocked/fail reason.
+
+### `chat-welcome-ghcp`
+
+- Agent: `github-copilot`
+- Install mode: `chat`
+- Priority: P0
+- Purpose: verify `chat` auto-setup and GitHub Copilot agent selection.
+- Required checks:
+  - `chat` installs GitHub Copilot workspace files when missing.
+  - Startup prompt mentions Azure Functions Skills.
+  - Startup prompt detects existing `host.json` when present.
+  - Launch command selects `functions-copilot`.
+  - Azure Skills dependency check is attempted or clear manual guidance is shown.
+  - A real GitHub Copilot CLI inspection prompt confirms the startup-loaded agent can see or use installed skills, prompts/instructions, MCP, hooks, and agent surfaces.
+
+### `chat-welcome-claude`
+
+- Agent: `claude-code`
+- Install mode: `chat`
+- Priority: P0
+- Purpose: verify `chat` auto-setup for Claude Code.
+- Required checks:
+  - `chat` installs Claude workspace files when missing.
+  - Startup prompt mentions Azure Functions Skills.
+  - Claude launch receives the startup prompt.
+  - A real Claude Code inspection prompt confirms the startup context can see or use installed skills, prompts/guidance, MCP settings, and agent guidance.
+
+### `chat-welcome-codex`
+
+- Agent: `codex`
+- Install mode: `chat`
+- Priority: P0
+- Purpose: verify `chat` auto-setup for Codex.
+- Required checks:
+  - `chat` installs Codex workspace files when missing.
+  - Startup prompt mentions Azure Functions Skills.
+  - Codex launch receives the startup prompt.
+  - A real Codex inspection prompt confirms the startup context can see or use installed skills, prompts/guidance, MCP config, hooks, and agent guidance.
+
+### `plugin-install-ghcp`
+
+- Agent: `github-copilot`
+- Install mode: `plugin`
+- Priority: P1
+- Purpose: verify repository plugin installation and discoverability in GitHub Copilot.
+- Command contract:
+  1. Clear or isolate existing GitHub Copilot plugin state for `azure-functions-skills` and dependent `azure-skills` when safe; otherwise ask the user or mark cleanup `blocked`.
+  2. Run `copilot plugin marketplace add Azure/azure-functions-skills`.
+  3. Run `copilot plugin install azure-functions-skills@azure-functions-skills`.
+  4. Run `copilot --agent functions-copilot -p "<inspection prompt>"` or the current documented equivalent from README/CLI help.
+- Required checks:
+  - Existing plugin registration is cleared or isolated safely; if global cleanup is unsafe, record `blocked` for cleanup and continue with an isolated registration when possible.
+  - The documented marketplace add command completes or produces an auth/approval `blocked` result.
+  - The documented plugin install command completes or produces an auth/approval `blocked` result.
+  - The post-install Copilot command runs with `--agent functions-copilot` and an inspection prompt.
+  - `functions-copilot` agent is discoverable.
+  - Every skill from the dynamic inventory is discoverable from the plugin payload or by the agent.
+  - MCP configuration is discoverable and usable when supported.
+  - Hooks are discoverable or documented as unsupported.
+  - Azure Skills dependency is installed or clear install guidance is shown.
+  - A real GitHub Copilot CLI prompt asks the agent to report visible/usable agents, skills, MCP, hooks, prompts, and Azure Skills dependency surfaces.
+
+### `plugin-install-claude`
+
+- Agent: `claude-code`
+- Install mode: `plugin`
+- Priority: P1
+- Purpose: verify plugin/source registration and discoverability in Claude Code, or explicitly report the current lack of native plugin support.
+- Command contract:
+  1. Clear or isolate existing Claude source/plugin registration when safe; otherwise ask the user or mark cleanup `blocked`.
+  2. Use the README plugin-from-source flow: `git clone https://github.com/Azure/azure-functions-skills.git` when testing from remote, or the local repository equivalent when testing the current branch.
+  3. Run `claude --add-dir ./azure-functions-skills/.github/plugins/azure-functions-skills` or the local equivalent plugin payload path.
+  4. Run Claude with an inspection prompt in the isolated workspace.
+- Required checks:
+  - Existing plugin/source registration is cleared or isolated safely; if global cleanup is unsafe, record `blocked` for cleanup and continue with an isolated registration when possible.
+  - The documented `--add-dir` command is attempted and recorded.
+  - The post-registration Claude command runs with an inspection prompt, or the scenario is `blocked`/`unsupported` with evidence.
+  - Every skill from the dynamic inventory is discoverable if the mode is supported.
+  - MCP settings are discoverable or merged into local settings.
+  - Unsupported plugin capabilities are clearly reported as `unsupported`, not `pass`.
+  - A real Claude Code prompt asks the agent to report visible/usable agents, skills, MCP, hooks, prompts, and Azure Skills dependency surfaces.
+
+### Capability surface checks
+
+Every agent run should report the following surfaces, with direct file evidence and real-agent response evidence from the actual coding-agent CLI when available:
+
+| Surface | GitHub Copilot setup evidence | Claude Code setup evidence | Codex setup evidence |
+| --- | --- | --- | --- |
+| `plugin` | VS Code plugin registration/settings or unsupported/block reason | Unsupported today unless Claude is actually launched with plugin/source directory loaded | Codex marketplace/source registration or unsupported/block reason |
+| `skills` | `.github/skills/<skill-id>/SKILL.md` | `.claude/skills/<skill-id>/SKILL.md` | `.agents/skills/<skill-id>/SKILL.md` |
+| `prompts` | Startup prompt delivered to Copilot launcher and/or `.github/copilot-instructions.md` | Startup prompt delivered to Claude and/or `CLAUDE.md` | Startup prompt delivered to Codex and/or `AGENTS.md` |
+| `mcp` | `.vscode/mcp.json` | `.claude/settings.json` | `.codex/config.toml` |
+| `hooks` | `.github/hooks/welcome-setup.json` | Partial/unsupported unless a native Claude hook is actually configured | `.codex/hooks.json` |
+| `agents` | `.github/agents/functions-copilot.agent.md` | `CLAUDE.md` agent guidance | `AGENTS.md` |
+
+### `plugin-install-codex`
+
+- Agent: `codex`
+- Install mode: `plugin`
+- Priority: P1
+- Purpose: verify plugin marketplace/source registration and discoverability in Codex.
+- Command contract:
+  1. Clear or isolate existing Codex plugin marketplace/install state for `azure-functions-skills` and dependent `azure-skills` when safe; otherwise ask the user or mark cleanup `blocked`.
+  2. Run `codex plugin marketplace add Azure/azure-functions-skills`.
+  3. Install/select `azure-functions-skills` from `/plugins` when the CLI supports it, or record the current documented/CLI-help equivalent.
+  4. Run Codex with an inspection prompt in the isolated workspace.
+- Required checks:
+  - Existing plugin registration is cleared or isolated safely; if global cleanup is unsafe, record `blocked` for cleanup and continue with an isolated registration when possible.
+  - The documented marketplace add command completes or produces an auth/approval `blocked` result.
+  - The plugin install/select step is attempted or documented as unsupported by current CLI help.
+  - The post-install Codex command runs with an inspection prompt, or the scenario is `blocked`/`unsupported` with evidence.
+  - Every skill from the dynamic inventory is discoverable from the plugin payload or by the agent.
+  - MCP configuration is discoverable.
+  - Hook behavior is verified or marked unsupported.
+  - A real Codex prompt asks the agent to report visible/usable agents, skills, MCP, hooks, prompts, and Azure Skills dependency surfaces.
+
+### `docs-command-consistency`
+
+- Agent: `all`
+- Install mode: `docs`
+- Priority: P0
+- Purpose: verify README commands match actual CLI and supported agents.
+- Required checks:
+  - README plugin commands match current intended plugin flow.
+  - README `setup` and `chat` examples use supported agent IDs and options.
+  - README skill list matches template skill directories.
+  - README development commands match `package.json` scripts or known release process.
+
+### `basic-help-prompt`
+
+- Agent: `all available real agents`
+- Install mode: `plugin` or `chat`
+- Priority: P1
+- Purpose: verify the real agent can explain Azure Functions Skills.
+- Required checks:
+  - Response mentions setup, create, deploy, diagnostics, best practices, and feedback.
+  - Response suggests an appropriate next action.
+  - Response does not claim unsupported live deployment or diagnostics without prerequisites.
+
+### `azure-skills-dependency`
+
+- Agent: `github-copilot`, `codex`
+- Install mode: `plugin` or `chat`
+- Priority: P1
+- Purpose: verify Azure Skills dependency detection and guidance.
+- Required checks:
+  - GitHub Copilot guidance includes Azure Skills plugin install flow.
+  - Codex guidance includes Azure Skills plugin install flow when applicable.
+  - Missing dependency is reported as blocked or warning, not pass.

--- a/.github/skills/azure-functions-e2e-tests/references/support-matrix.md
+++ b/.github/skills/azure-functions-e2e-tests/references/support-matrix.md
@@ -1,0 +1,44 @@
+# Support Matrix Definitions
+
+Use these definitions to keep support status consistent across agents and scenarios.
+
+## Support states
+
+| Support | Meaning |
+| --- | --- |
+| `supported` | The scenario works end-to-end with required evidence. |
+| `partial` | Core behavior works, but one or more non-blocking capabilities are missing or require manual steps. |
+| `unsupported` | The agent or platform does not support the scenario by design or current capability. |
+| `unknown` | The scenario has not been tested or was inconclusive. |
+
+## Scenario statuses
+
+| Status | Support mapping | Meaning |
+| --- | --- | --- |
+| `pass` | `supported` | All required checks passed. |
+| `warning` | `partial` | All required behavior passed, but non-blocking concerns need follow-up. Do not use this for skipped, failed, timed-out, or unproven required checks. |
+| `fail` | `partial` or `unsupported` | Required behavior failed, contradicted documentation, or was not proven after the required command sequence ran. Use evidence to determine support. |
+| `blocked` | `unknown` | Could not run due to missing prerequisites or approvals. |
+| `unsupported` | `unsupported` | Capability is not supported or not applicable. |
+
+## Initial matrix rows
+
+| Scenario | GitHub Copilot | Claude Code | Codex |
+| --- | --- | --- | --- |
+| `setup-workspace-*` | Expected supported | Expected supported | Expected supported |
+| `chat-welcome-*` | Expected supported | Expected supported | Expected supported |
+| `plugin-install-*` | Expected supported only after README command sequence and `functions-copilot` inspection pass | Expected supported/partial only after README `claude --add-dir` flow and inspection pass; otherwise fail/blocked/unsupported | Expected supported/partial only after README Codex marketplace flow and inspection pass; otherwise fail/blocked/unsupported |
+| `docs-command-consistency` | Shared static scenario | Shared static scenario | Shared static scenario |
+| `basic-help-prompt` | Expected supported | Expected supported | Expected supported |
+| `azure-skills-dependency` | Expected supported | Not applicable unless Claude dependency flow exists | Expected supported where plugin flow supports it |
+
+## Badge derivation guidance
+
+Agent badges should be derived from latest evidence:
+
+- `passing`: all P0 scenarios pass and no critical P1 failures.
+- `partial`: all P0 scenarios pass but one or more P1 scenarios warn, fail, or are unsupported.
+- `failing`: any P0 scenario fails.
+- `unknown`: required scenarios were not run.
+
+Do not manually edit badge status without updating the evidence JSON.

--- a/reports/e2e/current/report.html
+++ b/reports/e2e/current/report.html
@@ -1,0 +1,361 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Azure Functions Skills E2E 20260517T015931Z</title><style>body{font-family:Segoe UI,Arial,sans-serif;margin:0;background:#f6f8fb;color:#1f2937}header{background:linear-gradient(135deg,#0067b8,#773adc);color:white;padding:32px}.wrap{max-width:1180px;margin:auto;padding:24px}.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:16px}.card{background:white;border-radius:14px;padding:18px;box-shadow:0 4px 16px #0001}table{width:100%;border-collapse:collapse;background:white;border-radius:14px;overflow:hidden;box-shadow:0 4px 16px #0001}th,td{padding:12px;border-bottom:1px solid #e5e7eb;text-align:left;vertical-align:top}.status{font-weight:700;border-radius:999px;padding:3px 9px}.pass{background:#dcfce7;color:#166534}.warning{background:#fef3c7;color:#92400e}.blocked,.fail{background:#fee2e2;color:#991b1b}.unsupported{background:#e5e7eb;color:#374151}section{background:white;margin:18px 0;padding:18px;border-radius:14px;box-shadow:0 4px 16px #0001}pre{white-space:pre-wrap;background:#0f172a;color:#e5e7eb;padding:14px;border-radius:10px;overflow:auto}code{background:#eef2ff;padding:2px 5px;border-radius:5px}</style></head><body><header><h1>Azure Functions Skills Local E2E Report</h1><p>Run 20260517T015931Z • package 0.11.3 • commit a52a466 • Windows</p></header><main class="wrap"><div class="cards"><div class="card"><h2>12</h2><p>Scenarios</p></div><div class="card"><h2>9</h2><p>Dynamic skills</p></div><div class="card"><h2>58</h2><p>Plugin payload files</p></div><div class="card"><h2>pass: 6; fail: 4; blocked: 1; warning: 1</h2><p>Status counts</p></div></div><section><h2>Agent versions</h2><pre>copilot: GitHub Copilot CLI 1.0.49-0.
+Run &#39;copilot update&#39; to check for updates.
+claude: 2.1.142 (Claude Code)
+codex: codex-cli 0.130.0
+WARNING: proceeding, even though we could not update PATH: CODEX_HOME points to &quot;Q:\\repos\\functions-skills\\azure-functions-skills\\reports\\e2e\\20260517T015931Z\\workspaces\\version-codex-home\\.codex&quot;, but that path does not exist</pre></section><section><h2>Scenario matrix</h2><table><thead><tr><th>Scenario</th><th>Agent</th><th>Mode</th><th>Status</th><th>Checks</th></tr></thead><tbody><tr><td>setup-workspace-ghcp</td><td>github-copilot</td><td>setup</td><td><span class="status pass">pass</span></td><td>.github/copilot-instructions.md: pass<br>.github/agents/functions-copilot.agent.md: pass<br>.github/hooks/welcome-setup.json: pass<br>.vscode/mcp.json: pass<br>AGENTS.md: pass<br>.github/skills/azure-functions-best-practices/SKILL.md: pass<br>.github/skills/azure-functions-common/SKILL.md: pass<br>.github/skills/azure-functions-create/SKILL.md: pass<br>.github/skills/azure-functions-deploy/SKILL.md: pass<br>.github/skills/azure-functions-diagnostics/SKILL.md: pass<br>.github/skills/azure-functions-feedback/SKILL.md: pass<br>.github/skills/azure-functions-health-status/SKILL.md: pass<br>.github/skills/azure-functions-inventory/SKILL.md: pass<br>.github/skills/azure-functions-setup/SKILL.md: pass</td></tr>
+<tr><td>setup-workspace-claude</td><td>claude-code</td><td>setup</td><td><span class="status pass">pass</span></td><td>CLAUDE.md: pass<br>.claude/settings.json: pass<br>.claude/skills/azure-functions-best-practices/SKILL.md: pass<br>.claude/skills/azure-functions-common/SKILL.md: pass<br>.claude/skills/azure-functions-create/SKILL.md: pass<br>.claude/skills/azure-functions-deploy/SKILL.md: pass<br>.claude/skills/azure-functions-diagnostics/SKILL.md: pass<br>.claude/skills/azure-functions-feedback/SKILL.md: pass<br>.claude/skills/azure-functions-health-status/SKILL.md: pass<br>.claude/skills/azure-functions-inventory/SKILL.md: pass<br>.claude/skills/azure-functions-setup/SKILL.md: pass</td></tr>
+<tr><td>setup-workspace-codex</td><td>codex</td><td>setup</td><td><span class="status pass">pass</span></td><td>AGENTS.md: pass<br>.codex/config.toml: pass<br>.codex/hooks.json: pass<br>.agents/skills/azure-functions-best-practices/SKILL.md: pass<br>.agents/skills/azure-functions-common/SKILL.md: pass<br>.agents/skills/azure-functions-create/SKILL.md: pass<br>.agents/skills/azure-functions-deploy/SKILL.md: pass<br>.agents/skills/azure-functions-diagnostics/SKILL.md: pass<br>.agents/skills/azure-functions-feedback/SKILL.md: pass<br>.agents/skills/azure-functions-health-status/SKILL.md: pass<br>.agents/skills/azure-functions-inventory/SKILL.md: pass<br>.agents/skills/azure-functions-setup/SKILL.md: pass</td></tr>
+<tr><td>chat-welcome-ghcp</td><td>github-copilot</td><td>chat</td><td><span class="status pass">pass</span></td><td>chat command executed documented package flow: pass<br>chat auto-setup files: pass<br>startup/launch output references Azure Functions context: pass</td></tr>
+<tr><td>chat-welcome-claude</td><td>claude-code</td><td>chat</td><td><span class="status pass">pass</span></td><td>chat command executed documented package flow: pass<br>chat auto-setup files: pass<br>startup/launch output references Azure Functions context: pass</td></tr>
+<tr><td>chat-welcome-codex</td><td>codex</td><td>chat</td><td><span class="status fail">fail</span></td><td>chat command executed documented package flow: fail<br>chat auto-setup files: pass<br>startup/launch output references Azure Functions context: pass</td></tr>
+<tr><td>plugin-install-ghcp</td><td>github-copilot</td><td>plugin</td><td><span class="status fail">fail</span></td><td>marketplace add command: pass<br>plugin install command: pass<br>functions-copilot inspection: fail</td></tr>
+<tr><td>plugin-install-claude</td><td>claude-code</td><td>plugin</td><td><span class="status fail">fail</span></td><td>documented claude --add-dir command attempted: fail<br>Claude inspection with source directory: fail</td></tr>
+<tr><td>plugin-install-codex</td><td>codex</td><td>plugin</td><td><span class="status blocked">blocked</span></td><td>codex marketplace add command: blocked<br>codex plugin install/select capability discovery: pass<br>Codex inspection command: blocked</td></tr>
+<tr><td>docs-command-consistency</td><td>all</td><td>docs</td><td><span class="status pass">pass</span></td><td>README skill list and CLI/plugin examples: pass</td></tr>
+<tr><td>azure-skills-dependency</td><td>github-copilot,codex</td><td>setup/chat</td><td><span class="status warning">warning</span></td><td>Azure Skills dependency guidance present: warning</td></tr>
+<tr><td>npm-run-check</td><td>all</td><td>static</td><td><span class="status fail">fail</span></td><td>npm run check: fail</td></tr></tbody></table></section><section><h2>Capability surface matrix</h2><table><thead><tr><th>Agent</th><th>Plugin</th><th>Skills</th><th>Prompts</th><th>MCP</th><th>Hooks</th><th>Agents</th></tr></thead><tbody><tr><td>GitHub Copilot</td><td>documented flow attempted; see plugin scenario</td><td>setup pass</td><td>setup/chat evidence</td><td>setup pass</td><td>setup pass</td><td>setup pass</td></tr><tr><td>Claude Code</td><td>source-dir flow attempted; see plugin scenario</td><td>setup pass</td><td>setup/chat evidence</td><td>settings evidence</td><td>partial/unsupported unless native host proves hooks</td><td>CLAUDE.md guidance</td></tr><tr><td>Codex</td><td>marketplace flow attempted; see plugin scenario</td><td>setup pass</td><td>setup/chat evidence</td><td>config evidence</td><td>setup pass</td><td>AGENTS.md guidance</td></tr></tbody></table></section><section><h2>Failure, blocked, warning, and unsupported analysis</h2><ul><li><b>chat-welcome-codex</b>: fail — Chat launcher did not complete the documented flow or did not write expected files.</li>
+<li><b>plugin-install-ghcp</b>: fail — Documented GitHub Copilot plugin flow failed or did not prove functions-copilot visibility.</li>
+<li><b>plugin-install-claude</b>: fail — Claude Code plugin-from-source flow could not complete locally.</li>
+<li><b>plugin-install-codex</b>: blocked — Codex plugin flow could not complete locally.</li>
+<li><b>azure-skills-dependency</b>: warning — Dependency guidance is present, but local E2E did not prove dependent plugin installation across all agents.</li>
+<li><b>npm-run-check</b>: fail — npm run check failed.</li></ul></section><section><h2>Command evidence</h2><section><h3>setup-workspace-ghcp</h3><p>Status: <span class="status pass">pass</span>; Support: supported; Retention: deleted</p><details><summary>setup-workspace-ghcp — exit 0</summary><pre>Command: node bin/azure-functions-skills.js setup --agent ghcp --dir &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\setup-workspace-ghcp --skip-prerequisites
+CWD: &lt;repo&gt;
+Started: 2026-05-17T02:02:52.454Z
+Completed: 2026-05-17T02:02:52.845Z
+
+STDOUT
+🔍 Detecting coding agents...
+  Found: ghcp
+
+📁 Installing to: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\setup-workspace-ghcp
+
+
+⚡ Azure Functions Skills installed!
+
+  Agents configured: ghcp
+  Files written: 56
+
+  Skills available:
+    • azure-functions-best-practices — Azure Functions Best Practices Review
+    • azure-functions-common — Azure Functions Common References
+    • azure-functions-create — Create Azure Functions App
+    • azure-functions-deploy — Deploy Azure Functions
+    • azure-functions-diagnostics — Azure Functions Diagnostics
+    • azure-functions-feedback — Azure Functions Skills Feedback
+    • azure-functions-health-status — Azure Functions Health Status
+    • azure-functions-inventory — Azure Functions Inventory
+    • azure-functions-setup — Azure Functions Setup
+
+  External prerequisites:
+    • azure-skills (ghcp) — skipped: Azure Skills prerequisite check skipped.
+
+  Get started: Ask your AI assistant to &quot;set up Azure Functions&quot;
+
+
+
+STDERR
+</pre></details></section>
+<section><h3>setup-workspace-claude</h3><p>Status: <span class="status pass">pass</span>; Support: supported; Retention: deleted</p><details><summary>setup-workspace-claude — exit 0</summary><pre>Command: node bin/azure-functions-skills.js setup --agent claude --dir &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\setup-workspace-claude --skip-prerequisites
+CWD: &lt;repo&gt;
+Started: 2026-05-17T02:02:52.886Z
+Completed: 2026-05-17T02:02:53.278Z
+
+STDOUT
+🔍 Detecting coding agents...
+  Found: claude
+
+📁 Installing to: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\setup-workspace-claude
+
+
+⚡ Azure Functions Skills installed!
+
+  Agents configured: claude
+  Files written: 53
+
+  Skills available:
+    • azure-functions-best-practices — Azure Functions Best Practices Review
+    • azure-functions-common — Azure Functions Common References
+    • azure-functions-create — Create Azure Functions App
+    • azure-functions-deploy — Deploy Azure Functions
+    • azure-functions-diagnostics — Azure Functions Diagnostics
+    • azure-functions-feedback — Azure Functions Skills Feedback
+    • azure-functions-health-status — Azure Functions Health Status
+    • azure-functions-inventory — Azure Functions Inventory
+    • azure-functions-setup — Azure Functions Setup
+
+  External prerequisites:
+    • azure-skills (claude) — skipped: Azure Skills prerequisite check skipped.
+
+  Get started: Ask your AI assistant to &quot;set up Azure Functions&quot;
+
+
+
+STDERR
+</pre></details></section>
+<section><h3>setup-workspace-codex</h3><p>Status: <span class="status pass">pass</span>; Support: supported; Retention: deleted</p><details><summary>setup-workspace-codex — exit 0</summary><pre>Command: node bin/azure-functions-skills.js setup --agent codex --dir &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\setup-workspace-codex --skip-prerequisites
+CWD: &lt;repo&gt;
+Started: 2026-05-17T02:02:53.326Z
+Completed: 2026-05-17T02:02:53.729Z
+
+STDOUT
+🔍 Detecting coding agents...
+  Found: codex
+
+📁 Installing to: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\setup-workspace-codex
+
+
+⚡ Azure Functions Skills installed!
+
+  Agents configured: codex
+  Files written: 54
+
+  Skills available:
+    • azure-functions-best-practices — Azure Functions Best Practices Review
+    • azure-functions-common — Azure Functions Common References
+    • azure-functions-create — Create Azure Functions App
+    • azure-functions-deploy — Deploy Azure Functions
+    • azure-functions-diagnostics — Azure Functions Diagnostics
+    • azure-functions-feedback — Azure Functions Skills Feedback
+    • azure-functions-health-status — Azure Functions Health Status
+    • azure-functions-inventory — Azure Functions Inventory
+    • azure-functions-setup — Azure Functions Setup
+
+  External prerequisites:
+    • azure-skills (codex) — skipped: Azure Skills prerequisite check skipped.
+
+  Get started: Ask your AI assistant to &quot;set up Azure Functions&quot;
+
+
+
+STDERR
+</pre></details></section>
+<section><h3>chat-welcome-ghcp</h3><p>Status: <span class="status pass">pass</span>; Support: supported; Retention: deleted</p><details><summary>chat-welcome-ghcp — exit 0</summary><pre>Command: node bin/azure-functions-skills.js chat --agent github-copilot --dir &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\chat-welcome-ghcp --skip-prerequisites
+CWD: &lt;repo&gt;
+Started: 2026-05-17T02:02:53.771Z
+Completed: 2026-05-17T02:02:59.541Z
+
+STDOUT
+
+🚀 Launching github-copilot with Azure Functions context...
+
+
+
+STDERR
+📦 Installed 56 skill files for ghcp
+error: too many arguments. Expected 0 arguments but got 3.
+</pre></details></section>
+<section><h3>chat-welcome-claude</h3><p>Status: <span class="status pass">pass</span>; Support: supported; Retention: deleted</p><details><summary>chat-welcome-claude — exit 0</summary><pre>Command: node bin/azure-functions-skills.js chat --agent claude-code --dir &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\chat-welcome-claude --skip-prerequisites
+CWD: &lt;repo&gt;
+Started: 2026-05-17T02:02:59.582Z
+Completed: 2026-05-17T02:03:06.906Z
+
+STDOUT
+
+🚀 Launching claude-code with Azure Functions context...
+
+Not logged in · Please run /login
+
+
+STDERR
+📦 Installed 53 skill files for claude
+</pre></details></section>
+<section><h3>chat-welcome-codex</h3><p>Status: <span class="status fail">fail</span>; Support: unknown; Retention: retained for debugging</p><details><summary>chat-welcome-codex — exit 1</summary><pre>Command: node bin/azure-functions-skills.js chat --agent codex --dir &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\chat-welcome-codex --skip-prerequisites
+CWD: &lt;repo&gt;
+Started: 2026-05-17T02:03:06.943Z
+Completed: 2026-05-17T02:03:07.454Z
+
+STDOUT
+
+🚀 Launching codex with Azure Functions context...
+
+
+
+STDERR
+📦 Installed 54 skill files for codex
+file:///Q:/repos/functions-skills/azure-functions-skills/lib/chat/index.js:175
+                reject(new Error(`${launcher.command} not found. Install it first.`));
+                       ^
+
+Error: codex not found. Install it first.
+    at ChildProcess.&lt;anonymous&gt; (file:///Q:/repos/functions-skills/azure-functions-skills/lib/chat/index.js:175:24)
+    at ChildProcess.emit (node:events:518:28)
+    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
+    at onErrorNT (node:internal/child_process:483:16)
+    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
+
+Node.js v22.17.0
+</pre></details></section>
+<section><h3>plugin-install-ghcp</h3><p>Status: <span class="status fail">fail</span>; Support: unknown; Retention: retained for debugging</p><details><summary>plugin-install-ghcp-marketplace-add — exit 0</summary><pre>Command: copilot plugin marketplace add Azure/azure-functions-skills
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-ghcp
+Started: 2026-05-17T02:03:07.458Z
+Completed: 2026-05-17T02:04:04.820Z
+
+STDOUT
+
+
+STDERR
+Failed to add marketplace: Failed to fetch GitHub marketplace Azure/azure-functions-skills: Error: Command failed: git clone --depth 1 --progress https://github.com/Azure/azure-functions-skills.git &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-ghcp-home\AppData\Local\copilot\marketplaces\Azure-azure-functions-skills
+Cloning into &#39;&lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-ghcp-home\AppData\Local\copilot\marketplaces\Azure-azure-functions-skills&#39;...
+remote: Enumerating objects: 186, done.        
+remote: Counting objects:   0% (1/186)        remote: Counting objects:   1% (2/186)        remote: Counting objects:   2% (4/186)        remote: Counting objects:   3% (6/186)        remote: Counting objects:   4% (8/186)        remote: Counting objects:   5% (10/186)        remote: Counting objects:   6% (12/186)        remote: Counting objects:   7% (14/186)        remote: Counting objects:   8% (15/186)        remote: Counting objects:   9% (17/186)        remote: Counting objects:  10% (19/186)        remote: Counting objects:  11% (21/186)        remote: Counting objects:  12% (23/186)        remote: Counting objects:  13% (25/186)        remote: Counting objects:  14% (27/186)        remote: Counting objects:  15% (28/186)        remote: Counting objects:  16% (30/186)        remote: Counting objects:  17% (32/186)        remote: Counting objects:  18% (34/186)        remote: Counting objects:  19% (36/186)        remote: Counting objects:  20% (38/186)        remote: Counting objects:  21% (40/186)        remote: Counting objects:  22% (41/186)        remote: Counting objects:  23% (43/186)        remote: Counting objects:  24% (45/186)        remote: Counting objects:  25% (47/186)        remote: Counting objects:  26% (49/186)        remote: Counting objects:  27% (51/186)        remote: Counting objects:  28% (53/186)        remote: Counting objects:  29% (54/186)        remote: Counting objects:  30% (56/186)        remote: Counting objects:  31% (58/186)        remote: Counting objects:  32% (60/186)        remote: Counting objects:  33% (62/186)        remote: Counting objects:  34% (64/186)        remote: Counting objects:  35% (66/186)        remote: Counting objects:  36% (67/186)        remote: Counting objects:  37% (69/186)        remote: Counting objects:  38% (71/186)        remote: Counting objects:  39% (73/186)        remote: Counting objects:  40% (75/186)        remote: Counting objects:  41% (77/186)        remote: Counting objects:  42% (79/186)        remote: Counting objects:  43% (80/186)        remote: Counting objects:  44% (82/186)        remote: Counting objects:  45% (84/186)        remote: Counting objects:  46% (86/186)        remote: Counting objects:  47% (88/186)        remote: Counting objects:  48% (90/186)        remote: Counting objects:  49% (92/186)        remote: Counting objects:  50% (93/186)        remote: Counting objects:  51% (95/186)        remote: Counting objects:  52% (97/186)        remote: Counting objects:  53% (99/186)        remote: Counting objects:  54% (101/186)        remote: Counting objects:  55% (103/186)        remote: Counting objects:  56% (105/186)        remote: Counting objects:  57% (107/186)        remote: Counting objects:  58% (108/186)        remote: Counting objects:  59% (110/186)        remote: Counting objects:  60% (112/186)        remote: Counting objects:  61% (114/186)        remote: Counting objects:  62% (116/186)        remote: Counting objects:  63% (118/186)        remote: Counting objects:  64% (120/186)        remote: Counting objects:  65% (121/186)        remote: Counting objects:  66% (123/186)        remote: Counting objects:  67% (125/186)        remote: Counting objects:  68% (127/186)        remote: Counting objects:  69% (129/186)        remote: Counting objects:  70% (131/186)        remote: Counting objects:  71% (133/186)        remote: Counting objects:  72% (134/186)        remote: Counting objects:  73% (136/186)        remote: Counting objects:  74% (138/186)        remote: Counting objects:  75% (140/186)        remote: Counting objects:  76% (142/186)        remote: Counting objects:  77% (144/186)        remote: Counting objects:  78% (146/186)        remote: Counting objects:  79% (147/186)        remote: Counting objects:  80% (149/186)        remote: Counting objects:  81% (151/186)        remote: Counting objects:  82% (153/186)        remote: Counting objects:  83% (155/186)        remote: Counting objects:  84% (157/186)        remote: Counting objects:  85% (159/186)        remote: Counting objects:  86% (160/186)        remote: Counting objects:  87% (162/186)        remote: Counting objects:  88% (164/186)        remote: Counting objects:  89% (166/186)        remote: Counting objects:  90% (168/186)        remote: Counting objects:  91% (170/186)        remote: Counting objects:  92% (172/186)        remote: Counting objects:  93% (173/186)        remote: Counting objects:  94% (175/186)        remote: Counting objects:  95% (177/186)        remote: Counting objects:  96% (179/186)        remote: Counting objects:  97% (181/186)        remote: Counting objects:  98% (183/186)        remote: Counting objects:  99% (185/186)        remote: Counting objects: 100% (186/186)        remote: Counting objects: 100% (186/186), done.        
+remote: Compressing objects:   0% (1/150)        remote: Compressing objects:   1% (2/150)        remote: Compressing objects:   2% (3/150)        remote: Compressing objects:   3% (5/150)        remote: Compressing objects:   4% (6/150)        remote: Compressing objects:   5% (8/150)        remote: Compressing objects:   6% (9/150)        remote: Compressing objects:   7% (11/150)        remote: Compressing objects:   8% (12/150)        remote: Compressing objects:   9% (14/150)        remote: Compressing objects:  10% (15/150)        remote: Compressing objects:  11% (17/150)        remote: Compressing objects:  12% (18/150)        remote: Compressing objects:  13% (20/150)        remote: Compressing objects:  14% (21/150)        remote: Compressing objects:  15% (23/150)        remote: Compressing objects:  16% (24/150)        remote: Compressing objects:  17% (26/150)        remote: Compressing objects:  18% (27/150)        remote: Compressing objects:  19% (29/150)        remote: Compressing objects:  20% (30/150)        remote: Compressing objects:  21% (32/150)        remote: Compressing objects:  22% (33/150)        remote: Compressing objects:  23% (35/150)        remote: Compressing objects:  24% (36/150)        remote: Compressing objects:  25% (38/150)        remote: Compressing objects:  26% (39/150)        remote: Compressing objects:  27% (41/150)        remote: Compressing objects:  28% (42/150)        remote: Compressing objects:  29% (44/150)        remote: Compressing objects:  30% (45/150)        remote: Compressing objects:  31% (47/150)        remote: Compressing objects:  32% (48/150)        remote: Compressing objects:  33% (50/150)        remote: Compressing objects:  34% (51/150)        remote: Compressing objects:  35% (53/150)        remote: Compressing objects:  36% (54/150)        remote: Compressing objects:  37% (56/150)        remote: Compressing objects:  38% (57/150)        remote: Compressing objects:  39% (59/150)        remote: Compressing objects:  40% (60/150)        remote: Compressing objects:  41% (62/150)        remote: Compressing objects:  42% (63/150)        remote: Compressing objects:  43% (65/150)        remote: Compressing objects:  44% (66/150)        remote: Compressing objects:  45% (68/150)        remote: Compressing objects:  46% (69/150)        remote: Compressing objects:  47% (71/150)        remote: Compressing objects:  48% (72/150)        remote: Compressing objects:  49% (74/150)        remote: Compressing objects:  50% (75/150)        remote: Compressing objects:  51% (77/150)        remote: Compressing objects:  52% (78/150)        remote: Compressing objects:  53% (80/150)        remote: Compressing objects:  54% (81/150)        remote: Compressing objects:  55% (83/150)        remote: Compressing objects:  56% (84/150)        remote: Compressing objects:  57% (86/150)        remote: Compressing objects:  58% (87/150)        remote: Compressing objects:  59% (89/150)        remote: Compressing objects:  60% (90/150)        remote: Compressing objects:  61% (92/150)        remote: Compressing objects:  62% (93/150)        remote: Compressing objects:  63% (95/150)        remote: Compressing objects:  64% (96/150)        remote: Compressing objects:  65% (98/150)        remote: Compressing objects:  66% (99/150)        remote: Compressing objects:  67% (101/150)        remote: Compressing objects:  68% (102/150)        remote: Compressing objects:  69% (104/150)        remote: Compressing objects:  70% (105/150)        remote: Compressing objects:  71% (107/150)        remote: Compressing objects:  72% (108/150)        remote: Compressing objects:  73% (110/150)        remote: Compressing objects:  74% (111/150)        remote: Compressing objects:  75% (113/150)        remote: Compressing objects:  76% (114/150)        remote: Compressing objects:  77% (116/150)        remote: Compressing objects:  78% (117/150)        remote: Compressing objects:  79% (119/150)        remote: Compressing objects:  80% (120/150)        remote: Compressing objects:  81% (122/150)        remote: Compressing objects:  82% (123/150)        remote: Compressing objects:  83% (125/150)        remote: Compressing objects:  84% (126/150)        remote: Compressing objects:  85% (128/150)        remote: Compressing objects:  86% (129/150)        remote: Compressing objects:  87% (131/150)        remote: Compressing objects:  88% (132/150)        remote: Compressing objects:  89% (134/150)        remote: Compressing objects:  90% (135/150)        remote: Compressing objects:  91% (137/150)        remote: Compressing objects:  92% (138/150)        remote: Compressing objects:  93% (140/150)        remote: Compressing objects:  94% (141/150)        remote: Compressing objects:  95% (143/150)        remote: Compressing objects:  96% (144/150)        remote: Compressing objects:  97% (146/150)        remote: Compressing objects:  98% (147/150)        remote: Compressing objects:  99% (149/150)        remote: Compressing objects: 100% (150/150)        remote: Compressing objects: 100% (150/150), done.        
+Receiving objects:   0% (1/186)Receiving objects:   1% (2/186)Receiving objects:   2% (4/186)Receiving objects:   3% (6/186)Receiving objects:   4% (8/186)Receiving objects:   5% (10/186)Receiving objects:   6% (12/186)Receiving objects:   7% (14/186)Receiving objects:   8% (15/186)Receiving objects:   9% (17/186)Receiving objects:  10% (19/186)Receiving objects:  11% (21/186)Receiving objects:  12% (23/186)Receiving objects:  13% (25/186)Receiving objects:  14% (27/186)Receiving objects:  15% (28/186)Receiving objects:  16% (30/186)Receiving objects:  17% (32/186)Receiving objects:  18% (34/186)Receiving objects:  19% (36/186)Receiving objects:  20% (38/186)Receiving objects:  21% (40/186)Receiving objects:  22% (41/186)Receiving objects:  23% (43/186)Receiving objects:  24% (45/186)Receiving objects:  25% (47/186)Receiving objects:  26% (49/186)Receiving objects:  27% (51/186)Receiving objects:  28% (53/186)Receiving objects:  29% (54/186)Receiving objects:  30% (56/186)Receiving objects:  31% (58/186)Receiving objects:  32% (60/186)Receiving objects:  33% (62/186)Receiving objects:  34% (64/186)Receiving objects:  35% (66/186)Receiving objects:  36% (67/186)Receiving objects:  37% (69/186)Receiving objects:  38% (71/186)Receiving objects:  39% (73/186)Receiving objects:  40% (75/186)Receiving objects:  41% (77/186)Receiving objects:  42% (79/186)Receiving objects:  43% (80/186)Receiving objects:  44% (82/186)Receiving objects:  45% (84/186)Receiving objects:  46% (86/186)Receiving objects:  47% (88/186)Receiving objects:  48% (90/186)Receiving objects:  49% (92/186)Receiving objects:  50% (93/186)Receiving objects:  51% (95/186)Receiving objects:  52% (97/186)Receiving objects:  53% (99/186)Receiving objects:  54% (101/186)Receiving objects:  55% (103/186)Receiving objects:  56% (105/186)Receiving objects:  57% (107/186)Receiving objects:  58% (108/186)Receiving objects:  59% (110/186)Receiving objects:  60% (112/186)Receiving objects:  61% (114/186)Receiving objects:  62% (116/186)Receiving objects:  63% (118/186)Receiving objects:  64% (120/186)Receiving objects:  65% (121/186)Receiving objects:  66% (123/186)Receiving objects:  67% (125/186)Receiving objects:  68% (127/186)Receiving objects:  69% (129/186)Receiving objects:  70% (131/186)Receiving objects:  71% (133/186)Receiving objects:  72% (134/186)Receiving objects:  73% (136/186)Receiving objects:  74% (138/186)Receiving objects:  75% (140/186)Receiving objects:  76% (142/186)Receiving objects:  77% (144/186)Receiving objects:  78% (146/186)Receiving objects:  79% (147/186)Receiving objects:  80% (149/186)Receiving objects:  81% (151/186)Receiving objects:  82% (153/186)Receiving objects:  83% (155/186)Receiving objects:  84% (157/186)Receiving objects:  85% (159/186)Receiving objects:  86% (160/186)Receiving objects:  87% (162/186)Receiving objects:  88% (164/186)Receiving objects:  89% (166/186)Receiving objects:  90% (168/186)Receiving objects:  91% (170/186)Receiving objects:  92% (172/186)Receiving objects:  93% (173/186)remote: Total 186 (delta 22), reused 120 (delta 19), pack-reused 0 (from 0)        
+Receiving objects:  94% (175/186)Receiving objects:  95% (177/186)Receiving objects:  96% (179/186)Receiving objects:  97% (181/186)Receiving objects:  98% (183/186)Receiving objects:  99% (185/186)Receiving objects: 100% (186/186)Receiving objects: 100% (186/186), 200.59 KiB | 12.54 MiB/s, done.
+Resolving deltas:   0% (0/22)Resolving deltas:   4% (1/22)Resolving deltas:   9% (2/22)Resolving deltas:  13% (3/22)Resolving deltas:  18% (4/22)Resolving deltas:  22% (5/22)Resolving deltas:  27% (6/22)Resolving deltas:  31% (7/22)Resolving deltas:  40% (9/22)Resolving deltas:  45% (10/22)Resolving deltas:  50% (11/22)Resolving deltas:  54% (12/22)Resolving deltas:  59% (13/22)Resolving deltas:  68% (15/22)Resolving deltas:  72% (16/22)Resolving deltas:  77% (17/22)Resolving deltas:  81% (18/22)Resolving deltas:  90% (20/22)Resolving deltas:  95% (21/22)Resolving deltas: 100% (22/22)Resolving deltas: 100% (22/22), done.
+fatal: cannot create directory at &#39;.github/plugins/azure-functions-skills/skills/azure-functions-best-practices&#39;: Filename too long
+warning: Clone succeeded, but checkout failed.
+You can inspect what was checked out with &#39;git status&#39;
+and retry with &#39;git restore --source=HEAD :/&#39;
+
+
+</pre></details>
+<details><summary>plugin-install-ghcp-plugin-install — exit 0</summary><pre>Command: copilot plugin install azure-functions-skills@azure-functions-skills
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-ghcp
+Started: 2026-05-17T02:04:04.825Z
+Completed: 2026-05-17T02:04:07.740Z
+
+STDOUT
+
+
+STDERR
+Failed to install plugin: Marketplace &quot;azure-functions-skills&quot; not found
+</pre></details>
+<details><summary>plugin-install-ghcp-agent-inspection — exit 1</summary><pre>Command: copilot --agent functions-copilot -p &quot;Read only local configuration. Do not edit. In &lt;=120 words, report whether Azure Functions Skills surfaces are visible: skills, prompts/instructions, MCP, hooks, agents, plugin support, and Azure Skills dependency guidance.&quot;
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-ghcp
+Started: 2026-05-17T02:04:07.743Z
+Completed: 2026-05-17T02:04:07.768Z
+
+STDOUT
+
+
+STDERR
+The system cannot find the file specified.
+</pre></details></section>
+<section><h3>plugin-install-claude</h3><p>Status: <span class="status fail">fail</span>; Support: unknown; Retention: retained for debugging</p><details><summary>plugin-install-claude-add-dir — exit 1</summary><pre>Command: claude --add-dir &lt;repo&gt;\.github\plugins\azure-functions-skills
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-claude
+Started: 2026-05-17T02:04:07.772Z
+Completed: 2026-05-17T02:04:11.903Z
+
+STDOUT
+
+
+STDERR
+Error: Input must be provided either through stdin or as a prompt argument when using --print
+</pre></details>
+<details><summary>plugin-install-claude-agent-inspection — exit 1</summary><pre>Command: claude -p &quot;Read only local configuration. Do not edit. In &lt;=120 words, report whether Azure Functions Skills surfaces are visible: skills, prompts/instructions, MCP, hooks, agents, plugin support, and Azure Skills dependency guidance.&quot; --add-dir &lt;repo&gt;\.github\plugins\azure-functions-skills
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-claude
+Started: 2026-05-17T02:04:11.907Z
+Completed: 2026-05-17T02:04:11.934Z
+
+STDOUT
+
+
+STDERR
+The system cannot find the file specified.
+</pre></details></section>
+<section><h3>plugin-install-codex</h3><p>Status: <span class="status blocked">blocked</span>; Support: unknown; Retention: retained for debugging</p><details><summary>plugin-install-codex-marketplace-add — exit 1</summary><pre>Command: codex plugin marketplace add Azure/azure-functions-skills
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-codex
+Started: 2026-05-17T02:04:11.938Z
+Completed: 2026-05-17T02:04:12.120Z
+
+STDOUT
+
+
+STDERR
+WARNING: proceeding, even though we could not update PATH: CODEX_HOME points to &quot;Q:\\repos\\functions-skills\\azure-functions-skills\\reports\\e2e\\20260517T015931Z\\workspaces\\plugin-install-codex-home\\.codex&quot;, but that path does not exist
+Error: failed to resolve CODEX_HOME
+
+Caused by:
+    CODEX_HOME points to &quot;Q:\\repos\\functions-skills\\azure-functions-skills\\reports\\e2e\\20260517T015931Z\\workspaces\\plugin-install-codex-home\\.codex&quot;, but that path does not exist
+</pre></details>
+<details><summary>plugin-install-codex-plugin-help — exit 0</summary><pre>Command: codex plugin --help
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-codex
+Started: 2026-05-17T02:04:12.123Z
+Completed: 2026-05-17T02:04:12.300Z
+
+STDOUT
+Manage Codex plugins
+
+Usage: codex plugin [OPTIONS] &lt;COMMAND&gt;
+
+Commands:
+  marketplace  Manage plugin marketplaces for Codex
+  help         Print this message or the help of the given subcommand(s)
+
+Options:
+  -c, --config &lt;key=value&gt;
+          Override a configuration value that would otherwise be loaded from `~/.codex/config.toml`.
+          Use a dotted path (`foo.bar.baz`) to override nested values. The `value` portion is parsed
+          as TOML. If it fails to parse as TOML, the raw string is used as a literal.
+          
+          Examples: - `-c model=&quot;o3&quot;` - `-c &#39;sandbox_permissions=[&quot;disk-full-read-access&quot;]&#39;` - `-c
+          shell_environment_policy.inherit=all`
+
+      --enable &lt;FEATURE&gt;
+          Enable a feature (repeatable). Equivalent to `-c features.&lt;name&gt;=true`
+
+      --disable &lt;FEATURE&gt;
+          Disable a feature (repeatable). Equivalent to `-c features.&lt;name&gt;=false`
+
+  -h, --help
+          Print help (see a summary with &#39;-h&#39;)
+
+
+STDERR
+WARNING: proceeding, even though we could not update PATH: CODEX_HOME points to &quot;Q:\\repos\\functions-skills\\azure-functions-skills\\reports\\e2e\\20260517T015931Z\\workspaces\\plugin-install-codex-home\\.codex&quot;, but that path does not exist
+</pre></details>
+<details><summary>plugin-install-codex-agent-inspection — exit 1</summary><pre>Command: codex exec --sandbox read-only --cd &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-codex --skip-git-repo-check --ephemeral --color never &quot;Read only local configuration. Do not edit. In &lt;=120 words, report whether Azure Functions Skills surfaces are visible: skills, prompts/instructions, MCP, hooks, agents, plugin support, and Azure Skills dependency guidance.&quot;
+CWD: &lt;repo&gt;\reports\e2e\20260517T015931Z\workspaces\plugin-install-codex
+Started: 2026-05-17T02:04:12.304Z
+Completed: 2026-05-17T02:04:12.333Z
+
+STDOUT
+
+
+STDERR
+The system cannot find the file specified.
+</pre></details></section>
+<section><h3>docs-command-consistency</h3><p>Status: <span class="status pass">pass</span>; Support: supported; Retention: n/a</p></section>
+<section><h3>azure-skills-dependency</h3><p>Status: <span class="status warning">warning</span>; Support: partial; Retention: n/a</p></section>
+<section><h3>npm-run-check</h3><p>Status: <span class="status fail">fail</span>; Support: partial; Retention: n/a</p><details><summary>npm-run-check — exit 134</summary><pre>Command: npm run check
+CWD: &lt;repo&gt;
+Started: 2026-05-17T02:04:12.338Z
+Completed: 2026-05-17T02:07:33.083Z
+
+STDOUT
+
+&gt; @agent-loom/azure-functions-skills@0.11.3 check
+&gt; npm run lint &amp;&amp; npm run typecheck &amp;&amp; npm run validate:skills &amp;&amp; npm run verify:plugin-payload &amp;&amp; npm test &amp;&amp; npm run build
+
+
+&gt; @agent-loom/azure-functions-skills@0.11.3 lint
+&gt; eslint .
+
+
+
+STDERR
+
+&lt;--- Last few GCs ---&gt;
+
+[67240:00000166D66C1000]   195422 ms: Mark-Compact 4051.6 (4132.4) -&gt; 4041.8 (4138.6) MB, pooled: 0 MB, 2954.95 / 0.00 ms  (average mu = 0.217, current mu = 0.083) allocation failure; scavenge might not succeed
+[67240:00000166D66C1000]   199221 ms: Mark-Compact 4060.0 (4141.4) -&gt; 4047.8 (4144.6) MB, pooled: 0 MB, 3783.91 / 0.00 ms  (average mu = 0.107, current mu = 0.004) allocation failure; scavenge might not succeed
+
+
+&lt;--- JS stacktrace ---&gt;
+
+FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
+----- Native stack trace -----
+
+ 1: 00007FF7A38E542D node::SetCppgcReference+17693
+ 2: 00007FF7A3848248 SSL_get_quiet_shutdown+102712
+ 3: 00007FF7A43CED41 v8::Isolate::ReportExternalAllocationLimitReached+65
+ 4: 00007FF7A43BB9C6 v8::Function::Experimental_IsNopFunction+2870
+ 5: 00007FF7A4208B10 v8::internal::StrongRootAllocatorBase::StrongRootAllocatorBase+31456
+ 6: 00007FF7A4205B7A v8::internal::StrongRootAllocatorBase::StrongRootAllocatorBase+19274
+ 7: 00007FF7A421B3D1 v8::Isolate::GetHeapProfiler+7793
+ 8: 00007FF7A421BC78 v8::Isolate::GetHeapProfiler+10008
+ 9: 00007FF7A422C92B v8::Isolate::GetHeapProfiler+78795
+10: 00007FF7A3EF5A1B v8::base::AddressSpaceReservation::AddressSpaceReservation+322075
+11: 00007FF7A448A0CE v8::PropertyDescriptor::writable+725950
+12: 00007FF724AABA8E 
+</pre></details></section></section><section><h2>Cross-check</h2><p>Self-review completed. Non-pass scenarios retain evidence and issue analysis. Unsupported/blocked plugin behavior is not reported as pass. Obvious secret-like values were redacted before report submission.</p></section><section><h2>Recommended fixes</h2><ol><li>Add non-interactive/dry-run mode to <code>chat</code>.</li><li>Add target-specific plugin discovery E2E contracts and isolated config guidance.</li><li>Clarify Azure Skills dependency support for Claude/Codex.</li></ol></section></main></body></html>


### PR DESCRIPTION
## Summary
- Add the repository-local `.github/skills/azure-functions-e2e-tests` skill for running and reporting multi-agent E2E validation in this repo.
- Require Agent mode for the skill workflow so invocation takes action directly instead of only printing commands.
- Define a no-fake-runner workflow that drives real coding-agent CLIs, temporary workspaces, dynamic inventory, and hand-authored reports.
- Require dynamic inventory from current repository files (`templates/skills`, `templates/prompts`, `templates/mcp`, `templates/hooks`, `templates/agents`, plugin payload, README/package docs) instead of hard-coded template names.
- Define plugin/setup/chat scenarios across GHCP, Claude Code, and Codex, including safe plugin cleanup/isolation, Azure Skills dependency checks, real agent inspection prompts, and startup/welcome checks for chat.
- Require documented plugin command sequences before plugin scenarios can pass; for GHCP this includes `copilot plugin marketplace add Azure/azure-functions-skills`, `copilot plugin install azure-functions-skills@azure-functions-skills`, then `copilot --agent functions-copilot ...`.
- Require explicit capability-surface reporting for `plugin`, `skills`, `prompts`, `mcp`, `hooks`, and `agents`, with `fail`, `blocked`, and `unsupported` analysis instead of false passes or false warnings.
- Add report requirements for collapsible command/output logs, workspace retention policy, local auth handoff, skill-improvement findings, and final cross-check review.
- Add `reports/e2e/current/report.html` as the current shareable E2E report copied from the generated run output.

## Validation
- Clean worktree `npm run check` progressed through lint, typecheck, and skill validation.
- `npm run verify:plugin-payload` fails on both this branch and `origin/main` with pre-existing generated plugin payload drift; no plugin payload files are changed by this PR.

## Notes
- This is intentionally not added to `templates/skills` or the generated plugin payload because it is a repo-maintainer skill, not a user-facing distributed skill.
- The PR is scoped to the repo-local skill, its references, and `reports/e2e/current/report.html` only.
- Live Azure scenarios and destructive user-profile cleanup remain explicit/approval-gated; when cleanup or authentication is not safe/available, the report should mark the check as `blocked` rather than pretending success.