### PR TITLE
docs: publish E2E report with GitHub Pages

### DIFF
--- a/.github/workflows/publish-e2e-report.yml
+++ b/.github/workflows/publish-e2e-report.yml
@@ -1,0 +1,46 @@
+name: Publish E2E Report
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/publish-e2e-report.yml'
+      - 'reports/e2e/current/report.html'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare site
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f reports/e2e/current/report.html
+          mkdir -p _site
+          cp reports/e2e/current/report.html _site/index.html
+          cp reports/e2e/current/report.html _site/report.html
+          touch _site/.nojekyll
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Azure Functions Skills
 
 [![npm](https://img.shields.io/npm/v/@agent-loom/azure-functions-skills)](https://www.npmjs.com/package/@agent-loom/azure-functions-skills)
+[![E2E report](https://github.com/Azure/azure-functions-skills/actions/workflows/publish-e2e-report.yml/badge.svg)](https://azure.github.io/azure-functions-skills/)
+
+Latest E2E status: [HTML report](https://azure.github.io/azure-functions-skills/)
 
 Azure Functions Skills provides guided setup, create, deploy, diagnostics, and review workflows for coding agents such as GitHub Copilot CLI, Claude Code, and Codex.
 


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that publishes reports/e2e/current/report.html as the latest E2E report
- expose the report as both index.html and report.html in the Pages artifact
- add a README badge and latest E2E status link to the published report

## Notes
- GitHub Pages must be configured to use GitHub Actions as the source for the first deployment.
- After this lands on main, the report should be available at https://azure.github.io/azure-functions-skills/.

## Validation
- VS Code diagnostics found no errors in the new workflow or README