### PR TITLE
Fix chat pass-through for agent CLIs

### DIFF
--- a/.github/skills/azure-functions-e2e-tests/SKILL.md
+++ b/.github/skills/azure-functions-e2e-tests/SKILL.md
@@ -33,6 +33,7 @@ This skill is intended for Agent mode, not passive chat.
 2. **Dynamic inventory** — derive expected `skills`, `prompts`, `mcp`, `hooks`, `agents`, plugin payload files, and Azure Skills dependency checks from the current repository files and docs at run time. Do not hard-code today's template names.
 3. **Scenario references first** — select scenarios from [scenarios.md](references/scenarios.md) and keep the run checklist inside `reports/e2e/<run-id>/`, not in the repository root.
 4. **Agent-visible proof required** — setup, chat, and plugin scenarios must prove that the target coding agent can see or use the installed `skills`, `prompts`, `mcp`, `hooks`, and `agents`; file existence alone is not enough.
+   Prefer a machine-readable inspection artifact for this proof. The artifact may be written by the runner from the agent's noninteractive output; do not require the agent itself to write the file when that would trigger local write approval.
 5. **Documented command contract** — plugin/setup/chat scenarios must use the documented command sequence from README or generated CLI help, then launch the target agent with an inspection prompt.
 6. **No silent scope reduction** — do not omit GitHub Copilot, Claude Code, Codex, setup, chat, plugin, docs consistency, basic help, or Azure Skills dependency scenarios unless the user explicitly narrows scope in the current request. If a scenario cannot run, execute the discovery/version/help command needed to prove why and record it as `blocked`, `unsupported`, or `fail`; never leave it out of the matrix.
 7. **Fresh plugin install semantics** — plugin scenarios test installation, not reuse. Before installing, inspect existing plugin state, uninstall/remove the target `azure-functions-skills` plugin with the official CLI when approved and supported, then reinstall through the documented flow. If cleanup is unsafe, denied, unsupported, or interactive-only, record the cleanup check and classify the plugin scenario as `blocked` unless an isolated config location proves a fresh install.
@@ -43,6 +44,52 @@ This skill is intended for Agent mode, not passive chat.
 12. **Beautiful report by the agent** — author the HTML report directly from evidence. Match the quality of the design report style: readable layout, summary cards, matrices, clear colors, failure analysis, and recommended fixes.
 13. **Review the review** — after drafting evidence and reports, perform a cross-check pass over commands, outputs, scenario statuses, and conclusions. Fix omitted scenarios and unsupported/blocked/fail classifications before presenting results.
 14. **No repository-root setup pollution** — never run `setup`, `chat`, agent inspection prompts, or generated help/discovery commands from the repository root when they can create files. Commands that may write agent files must run only inside `reports/e2e/<run-id>/workspaces/<scenario-id>/` or another explicitly isolated workspace. If checking CLI help, use command forms that cannot trigger setup/chat side effects, or run them from a disposable scenario workspace.
+15. **Final command list required** — every HTML report must include a `Command Evidence` section with the final execution command sequence for every scenario in the matrix, including pass, warning, blocked, unsupported, and failed scenarios. Do not collapse this down to generic patterns only; readers must be able to see exactly which command shape worked or did not work for each scenario.
+
+## Manual-first execution guidance
+
+When CLI behavior is uncertain, the user asks for a fresh manual run, or a prior automated runner has hidden failures, execute scenarios one at a time instead of batching the matrix behind a custom runner.
+
+- Create `reports/e2e/<run-id>/checklist.md` and `reports/e2e/<run-id>/evidence.md` first.
+- Run exactly one scenario in `reports/e2e/<run-id>/workspaces/<scenario-id>/`.
+- Immediately record the command, exit status, agent-visible response, and what made the scenario work before starting the next scenario.
+- Do not use a custom runner as the source of truth until the manual command shape is proven for that agent and scenario type.
+- If a command hangs, times out, or produces confusing output, stop that scenario, capture the failure, simplify the command, and rerun only that scenario.
+- Keep inspection prompts in a PowerShell variable so the prompt is passed as one argument on Windows.
+
+Stable Windows command shapes observed in manual E2E runs:
+
+```powershell
+# GitHub Copilot setup/plugin inspection
+copilot -C <workspace> --agent functions-copilot -p <inspection-prompt> --output-format json -s --allow-all --no-ask-user
+
+# GitHub Copilot chat inspection. The -p inspection prompt overrides chat startup prompt delivery,
+# so verify buildStartupPrompt(<workspace>) separately for startup-template assertions.
+azure-functions-skills chat --agent github-copilot --dir . --skip-prerequisites -p <inspection-prompt> --output-format json -s --allow-all --no-ask-user
+
+# Claude setup inspection
+claude -p <inspection-prompt> --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
+
+# Claude chat inspection. The wrapper inserts --prompt content after Claude's -p.
+azure-functions-skills chat --agent claude-code --dir . --skip-prerequisites --prompt <inspection-prompt> -p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
+
+# Claude plugin/source inspection. Validate the payload separately.
+claude plugin validate <plugin-payload-dir>
+claude -p <inspection-prompt> --plugin-dir <plugin-payload-dir> --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
+
+# Codex setup inspection
+codex exec --sandbox read-only --json --output-last-message <workspace>\e2e-agent-inspection.json --ephemeral --skip-git-repo-check --cd <workspace> <inspection-prompt>
+
+# Codex chat inspection. The wrapper appends --prompt content as the final Codex prompt.
+azure-functions-skills chat --agent codex --dir . --skip-prerequisites --prompt <inspection-prompt> exec --sandbox workspace-write --json --output-last-message e2e-chat-inspection.json --ephemeral --skip-git-repo-check --cd .
+```
+
+Current CLI caveats to record in reports:
+
+- `azure-functions-skills setup --help` and `azure-functions-skills chat --help` may execute the subcommand rather than displaying subcommand help. Run those probes only in disposable workspaces, or use top-level `azure-functions-skills --help` for read-only discovery.
+- Claude Code may load a plugin with `--plugin-dir` even when `claude plugin validate` reports manifest errors. Treat validation failure as a warning or failure according to the scenario contract; do not let session-scoped load alone hide packaging issues.
+- Codex CLI 0.130.0 supports `codex plugin marketplace add/remove`, but exposes no noninteractive plugin install/list/select command. Marketplace registration alone is not enough for a plugin scenario pass.
+- Generated SessionStart hooks currently check `az`, `func`, and `node`; if a scenario evaluates deployment readiness, separately verify or report `azd` availability because deployment guidance depends on Azure Developer CLI.
 
 ## Execution policy
 
@@ -65,7 +112,7 @@ When the user asks to run or validate E2E tests:
    - Install or register `azure-functions-skills` using the documented flow for that mode.
    - Verify whether the dependent `azure-skills` surfaces are present or whether clear install guidance is shown.
    - Launch the actual coding-agent CLI with an inspection prompt. The prompt must ask it to report visible/usable `agents`, `skills`, `prompts`, `mcp`, `hooks`, plugin surfaces, and Azure Skills dependency surfaces. Treat missing agent-response evidence as `blocked` or `fail` according to the cause.
-   - For `chat`, also verify that startup loads the intended agent and welcome/startup message.
+   - For `chat`, use the `azure-functions-skills chat` command itself as the launcher under test and pass agent-specific noninteractive options through to the selected coding-agent CLI. Verify `chat` auto-setup, startup prompt delivery, launcher selection, and the resulting agent-visible artifact from the same command. Do not bypass `chat` with a direct `copilot`, `claude`, or `codex` command unless the pass-through command is unavailable or fails and you are collecting follow-up diagnosis.
 4. For plugin scenarios, the command sequence is part of the test contract:
    - Every plugin scenario must begin with pre-state discovery (`plugin list`, `marketplace list`, `plugin details`, or the closest current CLI help/list command), then a cleanup step, then install/register, then post-install state, then agent inspection.
    - GitHub Copilot CLI must follow README order after cleanup: `copilot plugin marketplace add Azure/azure-functions-skills`, then `copilot plugin install azure-functions-skills@azure-functions-skills`, then run Copilot with the Functions agent, for example `copilot --agent functions-copilot -p "<inspection prompt>"`.
@@ -78,6 +125,7 @@ When the user asks to run or validate E2E tests:
    - Command text, cwd, environment assumptions, start/end time, exit code, and redacted stdout/stderr excerpt.
    - The recorded `cwd` for setup/chat/agent-inspection commands must be the scenario workspace under `reports/e2e/<run-id>/workspaces/<scenario-id>/`. If a command is intentionally run from another directory, record why it was safe and why it could not write repository-root agent files.
    - In the HTML report, put command details and output in collapsed `<details><summary>...</summary>...</details>` sections so readers can inspect them without overwhelming the summary.
+   - Also include a scenario-by-scenario final command list in the HTML report's `Command Evidence` section. This list must cover every selected scenario, even when the result is `blocked`, `unsupported`, or `fail`, and must show the final command sequence used after any manual iteration or recovery.
 6. Workspace retention:
    - Before cleanup, ask the user whether to keep failed scenario workspaces, keep all workspaces, or delete all temporary workspaces.
    - If the user keeps workspaces, record retained paths in the evidence/report after redacting user-specific path segments where sharing externally.
@@ -86,10 +134,19 @@ When the user asks to run or validate E2E tests:
    - Because this starts as a local E2E workflow, it is acceptable to ask the user to authenticate, approve a CLI prompt, reload VS Code, or run a one-time login when a real agent/plugin flow is blocked by auth.
    - Do not mark auth-blocked scenarios as fail unless authentication should already have been available according to the scenario contract; otherwise use `blocked` with clear next steps.
 8. Prefer automation-friendly CLI options before asking the user for manual interaction:
+   - **Inspection artifacts**: require each setup/chat/plugin inspection prompt to produce or be captured into a parseable JSON artifact such as `e2e-chat-inspection.json`. The artifact should include `agent`, `workspaceRoot`, `startupContextVisible`, `skills`, `mcpServers`, `hooks`, `agents`, `passed`, and `notes`. The runner must parse this artifact and compare the reported surfaces against the dynamic inventory before marking the scenario `pass`.
+    - **Agent file writes**: for chat scenarios, prefer proving the new `chat` pass-through path by letting the real agent create `e2e-chat-inspection.json` or by using the agent's output-file option through `chat`. Grant write permissions only inside the isolated scenario workspace. For setup/plugin visibility checks that do not need to prove file editing, capture the noninteractive response to a file outside the agent, for example with shell redirection or an output-file CLI option.
+   - **Workspace root verification**: ask the agent to report the workspace root it inspected. If the reported root is the repository root or any directory outside the isolated scenario workspace, mark the inspection `fail` or rerun from a safer external disposable workspace and record the reason.
+    - **Chat pass-through inspection**: pass agent-specific headless options after the `chat` options. The `chat` command intentionally forwards unrecognized options to the selected agent CLI. Use this as the primary chat E2E path so the same command proves launcher behavior and agent-visible proof. If a pass-through command fails, record the exact command and stderr, then use a direct agent command only as a diagnostic comparison.
+       - GitHub Copilot example: `azure-functions-skills chat --agent github-copilot --dir <workspace> --skip-prerequisites -p "<inspection prompt>" --yolo --no-ask-user --output-format json --silent`.
+       - Claude Code example: `azure-functions-skills chat --agent claude-code --dir <workspace> --prompt "<inspection prompt>" --skip-prerequisites -p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob,Write`.
+       - Codex example: `azure-functions-skills chat --agent codex --dir <workspace> --prompt "<inspection prompt>" --skip-prerequisites exec --sandbox workspace-write --json --output-last-message e2e-chat-inspection.txt --ephemeral --skip-git-repo-check --cd <workspace>`.
    - **Claude Code prompt runs**: use `claude -p` / `claude --print` so the command prints and exits. Prefer `--output-format json`, `--no-session-persistence`, `--permission-mode dontAsk`, and a minimal `--tools Read,LS,Grep,Glob` tool set for inspection prompts. Use `--include-hook-events` only with `--output-format=stream-json` when hook evidence is required.
+     For parseable inspection artifacts, `--output-format text` with a prompt that requires raw JSON can be easier to validate than Claude's wrapper JSON. For setup scenarios, use the installer target name `claude`; reserve `claude-code` for the `chat` launcher agent id unless CLI help documents otherwise.
    - **Claude Code plugin/source runs**: prefer session-scoped `--plugin-dir <plugin-payload-dir>` when the CLI supports it because it loads a plugin for the current run without mutating global plugin state. If the README still documents `--add-dir`, record both the README command contract and the current `--plugin-dir` automation equivalent, and classify any docs mismatch in `docs-command-consistency`.
    - **Claude Code installed plugin cleanup**: use `claude plugin list --json` for pre/post-state, `claude plugin install <plugin> --scope local|project|user` when testing installed plugin flows, and `claude plugin uninstall|remove <plugin> --scope <scope> -y` for approved cleanup. Use `--keep-data` when preserving plugin data matters.
    - **Codex prompt runs**: use `codex exec` for noninteractive inspection. Prefer `--sandbox read-only` for visibility checks, `--json` for machine-readable transcripts, `--output-last-message <file>` for concise report excerpts, `--ephemeral` to avoid session persistence, `--skip-git-repo-check` for empty isolated workspaces, and `--cd <workspace>` instead of relying on inherited cwd. Use `--dangerously-bypass-approvals-and-sandbox` only inside an external sandbox and only when the scenario explicitly requires write/execute behavior.
+       For visibility artifacts, combine `--output-last-message e2e-chat-inspection.json` with a prompt that requires raw JSON only, then parse that file and keep the full `--json` transcript as separate evidence.
    - **Codex plugin marketplace cleanup**: use `codex plugin marketplace remove <name>` and `codex plugin marketplace add <source>` for approved marketplace cleanup/re-registration. As of Codex CLI 0.130.0, `codex plugin --help` exposes marketplace management but no noninteractive plugin install/select/list command; if `/plugins` is required, record the help output and mark install/select `blocked` unless the user completes the interactive step.
    - **Alternate screen/TUI capture**: when a CLI still launches an interactive TUI, look for options such as Codex `--no-alt-screen` or a print/exec mode before asking the user to operate the UI. If no noninteractive route exists, record the TUI limitation as evidence.
 9. If an agent or mode cannot support a surface, report `unsupported` with a reason. If a CLI hangs, lacks authentication, or cannot safely isolate plugin state, report `blocked`. If a surface should work but does not, report `fail` with failure analysis.
@@ -138,6 +195,7 @@ At the end of every run, after cross-checking the report, overwrite `reports/e2e
    - Include scenario x agent support status, versions, test datetime, platform, failure evidence, unsupported reasons, and recommended fixes.
    - Include a capability surface matrix for GitHub Copilot, Claude Code, and Codex across `plugin`, `skills`, `prompts`, `mcp`, `hooks`, and `agents`.
    - Include detailed evidence for how each surface was checked: dynamic inventory source, generated file path, launch command, agent response excerpt, and unsupported/block/fail reason.
+   - Include the final execution commands for every scenario in `Command Evidence`. The section must show the actual scenario command sequence, not only reusable command patterns or examples.
    - Include collapsed command logs with command, cwd, exit code, and redacted output.
    - Include retained workspace paths or cleanup status for every scenario.
    - Include failure analysis that explains why a failure occurred and what should be fixed next.

--- a/.github/skills/azure-functions-e2e-tests/references/report-schema.md
+++ b/.github/skills/azure-functions-e2e-tests/references/report-schema.md
@@ -75,6 +75,7 @@ Each scenario run should emit one JSON object.
   "issues": [],
   "artifacts": {
     "transcript": "reports/e2e/<run-id>/transcripts/chat-welcome-ghcp.md",
+    "inspectionJson": "reports/e2e/<run-id>/workspaces/chat-welcome-ghcp/e2e-chat-inspection.json",
     "workspaceDir": "<redacted-temp-workspace>"
   }
 }
@@ -119,6 +120,32 @@ Each scenario run should emit one JSON object.
 `surface` must be one of `plugin`, `skills`, `prompts`, `mcp`, `hooks`, `agents`, `agent-launch`, `agent-inspection`, `setup-files`, or `general`.
 Use `support: "unsupported"` for surfaces that the package or agent cannot support today. For example, Claude Code native plugin support must not be reported as passing unless the test actually launches Claude with the plugin loaded and proves the plugin surfaces are visible.
 Checks should cite dynamic inventory paths instead of assuming a fixed template list. If a template changes, the next run should discover the new inventory and update expectations automatically.
+
+## Inspection artifact record
+
+Agent-visible setup, chat, and plugin checks should include a parseable inspection artifact. The artifact can be the agent's raw JSON response captured by the runner; it does not have to be written by the agent with edit tools.
+
+```json
+{
+  "agent": "codex",
+  "workspaceRoot": "<redacted-temp-workspace>",
+  "startupContextVisible": true,
+  "skills": ["azure-functions-create"],
+  "mcpServers": [{ "name": "azure", "configPath": ".codex/config.toml" }],
+  "hooks": [{ "path": ".codex/hooks.json", "support": "supported" }],
+  "agents": [{ "name": "AGENTS.md guidance", "path": "AGENTS.md" }],
+  "passed": true,
+  "notes": []
+}
+```
+
+Validation rules:
+
+- The artifact file must exist, be non-empty, and parse as JSON.
+- `workspaceRoot` must identify the isolated scenario workspace or an explicitly documented external disposable workspace.
+- `skills`, `mcpServers`, `hooks`, and `agents` must be checked against the dynamic inventory and agent support matrix.
+- Missing surfaces require an explicit unsupported, blocked, or fail reason in `notes` or the scenario checks.
+- A scenario cannot be `pass` when the inspection artifact is missing, invalid, or only proves generated files without real-agent visibility.
 
 For plugin scenarios, command logs must prove the documented install sequence was attempted before any plugin visibility result is marked `pass` or `warning`. For example, GitHub Copilot plugin evidence must include `copilot plugin marketplace add Azure/azure-functions-skills`, `copilot plugin install azure-functions-skills@azure-functions-skills`, and a post-install `copilot --agent functions-copilot ...` inspection command. If those required commands are missing, fail, time out, or do not prove visibility, classify the scenario as `fail` or `blocked`, not `warning`.
 

--- a/.github/skills/azure-functions-e2e-tests/references/scenarios.md
+++ b/.github/skills/azure-functions-e2e-tests/references/scenarios.md
@@ -56,6 +56,50 @@ Setup and chat scenarios must prove both installation and runtime visibility:
 
 File checks alone are insufficient for `pass` because they do not prove the coding agent can load or use the installed surfaces. If the files exist but the agent cannot be launched or cannot confirm visibility, classify the scenario as `blocked` or `fail` with evidence.
 
+### Inspection artifact requirement
+
+Setup, chat, and plugin scenarios should capture the real-agent inspection response into a parseable JSON artifact, normally `e2e-chat-inspection.json` or `e2e-agent-inspection.json`, in the scenario workspace. For chat scenarios, prefer producing the artifact through `azure-functions-skills chat` pass-through arguments so the test exercises the real chat launcher and the target agent in one command. The runner may write this artifact from noninteractive agent output when the scenario is not specifically testing write behavior.
+
+The inspection prompt should require raw JSON with these fields:
+
+```json
+{
+  "agent": "codex",
+  "workspaceRoot": "<scenario-workspace>",
+  "startupContextVisible": true,
+  "skills": [],
+  "mcpServers": [],
+  "hooks": [],
+  "agents": [],
+  "passed": true,
+  "notes": []
+}
+```
+
+The runner must parse the artifact, verify `workspaceRoot` is the isolated scenario workspace, and compare reported surfaces with the dynamic inventory. If the artifact is missing, invalid JSON, empty, reports the repository root instead of the scenario workspace, or omits required surfaces without an unsupported/block reason, classify the inspection check as `fail` or `blocked`.
+
+Do not rely on an interactive `chat` command to write this file. Use the `chat` command's pass-through behavior to select each agent's noninteractive mode instead. If pass-through fails, record that as chat evidence and use a direct agent command only as a diagnostic follow-up, not as a substitute for passing the chat scenario.
+
+Recommended chat inspection command shapes:
+
+```powershell
+# GitHub Copilot: pass noninteractive prompt and permission flags through chat.
+azure-functions-skills chat --agent github-copilot --dir <workspace> --skip-prerequisites `
+  -p "<inspection prompt>" --yolo --no-ask-user --output-format json --silent
+
+# Claude Code: chat inserts --prompt content after -p/--print and forwards the rest.
+azure-functions-skills chat --agent claude-code --dir <workspace> --skip-prerequisites `
+  --prompt "<inspection prompt>" -p --output-format text --no-session-persistence `
+  --permission-mode bypassPermissions --tools Read,LS,Grep,Glob,Write
+
+# Codex: pass the exec subcommand and output-file options through chat.
+azure-functions-skills chat --agent codex --dir <workspace> --skip-prerequisites `
+  --prompt "<inspection prompt>" exec --sandbox workspace-write --json `
+  --output-last-message e2e-chat-inspection.txt --ephemeral --skip-git-repo-check --cd <workspace>
+```
+
+For GitHub Copilot, parse JSONL stdout and preserve the `session.skills_loaded` and final assistant message events as evidence. For Claude Code, parse the requested raw JSON artifact or stdout text. For Codex, parse the `--output-last-message` file and keep the full `--json` transcript as command evidence.
+
 ## Fresh plugin install requirements
 
 Plugin scenarios validate the installation flow, not reuse of a plugin that happened to be installed before the run. Every plugin scenario must capture these phases:
@@ -75,9 +119,11 @@ If cleanup would mutate user-level state and approval is unavailable, mark the c
 Use noninteractive CLI modes whenever they can preserve the scenario contract:
 
 - Claude Code inspection prompts should use `claude -p` / `claude --print` with `--output-format json` when practical, `--no-session-persistence`, `--permission-mode dontAsk`, and a small tool allowlist such as `--tools Read,LS,Grep,Glob`.
+- Claude Code parseable artifact prompts may use `--output-format text` plus shell redirection to `e2e-chat-inspection.json` when the prompt requires raw JSON only. For chat scenarios, pass `-p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob,Write` through `azure-functions-skills chat`; use `--prompt "<inspection prompt>"` for the inspection text. Use `setup --agent claude` for setup-mode installation; `claude-code` is the chat launcher id unless current CLI help says otherwise.
 - Claude Code session-scoped plugin tests should prefer `--plugin-dir <plugin-payload-dir>` when available. This loads a plugin for the current run only and avoids manual/global install state. If the README command is still `--add-dir`, record whether `--add-dir` and `--plugin-dir` are equivalent or whether README needs to be updated.
 - Claude Code installed plugin tests should use `claude plugin list --json`, `claude plugin install <plugin> --scope local|project|user`, and `claude plugin uninstall|remove <plugin> --scope <scope> -y` for approved fresh-install cleanup.
 - Codex inspection prompts should use `codex exec --sandbox read-only --json --output-last-message <file> --ephemeral --skip-git-repo-check --cd <workspace> <prompt>` when practical.
+- For Codex, keep the `--json` transcript as command evidence and parse the `--output-last-message` file as the concise inspection artifact. For chat scenarios, pass `exec --sandbox read-only|workspace-write --json --output-last-message <file> --ephemeral --skip-git-repo-check --cd <workspace>` through `azure-functions-skills chat`; do not use bare `codex <prompt>` for non-TTY E2E.
 - Codex marketplace cleanup can use `codex plugin marketplace remove <name>` followed by `codex plugin marketplace add <source>` when approved. Current Codex CLI 0.130.0 exposes marketplace management but no noninteractive plugin install/select/list command; plugin activation from `/plugins` remains `blocked` unless the user completes the interaction or a newer CLI exposes an automation option.
 - If a TUI opens despite these options, capture the help output showing the missing noninteractive path and classify the scenario instead of waiting indefinitely.
 

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -39,6 +39,8 @@ if (!command || command === '--help' || command === '-h') {
     --as-plugin        Ensure plugin is registered before launching agent
     --check-prerequisites  Check external prerequisites without installing them
     --skip-prerequisites   Skip external prerequisite checks
+    -- <args...>       Pass remaining arguments through to the selected agent CLI
+    Other unrecognized chat arguments are also passed through to the agent CLI
 
   Options (build):
     --target <name>    Build target: ghcp, claude, codex
@@ -135,6 +137,7 @@ if (command === 'setup') {
   let dir = process.cwd();
   let asPlugin = false;
   let prerequisites = 'auto';
+  const passthroughArgs = [];
 
   for (let i = 1; i < args.length; i++) {
     if (args[i] === '--agent' && args[i + 1]) agent = args[++i];
@@ -143,6 +146,12 @@ if (command === 'setup') {
     else if (args[i] === '--as-plugin') asPlugin = true;
     else if (args[i] === '--check-prerequisites') prerequisites = 'check-only';
     else if (args[i] === '--skip-prerequisites') prerequisites = 'skip';
+    else if (args[i] === '--') {
+      passthroughArgs.push(...args.slice(i + 1));
+      break;
+    } else {
+      passthroughArgs.push(args[i]);
+    }
   }
 
   // If --as-plugin, ensure plugin is registered first
@@ -188,6 +197,7 @@ if (command === 'setup') {
 
   const options = { agent, dir };
   if (prompt) options.prompt = prompt;
+  if (passthroughArgs.length > 0) options.passthroughArgs = passthroughArgs;
   options.prerequisites = prerequisites;
   await chat(options);
 } else if (command === 'build') {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default [
       'lib/**',
       'node_modules/**',
       'coverage/**',
+      'reports/e2e/**',
     ],
   },
   js.configs.recommended,

--- a/reports/e2e/current/report.html
+++ b/reports/e2e/current/report.html
@@ -3,216 +3,176 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Azure Functions Skills E2E Report - 20260517T184312Z</title>
+  <title>Azure Functions Skills E2E Report - 20260519T-manual</title>
   <style>
-    :root {
-      color-scheme: light;
-      --bg: #f6f8fb;
-      --panel: #ffffff;
-      --ink: #172033;
-      --muted: #5b6577;
-      --line: #d9e0ea;
-      --pass: #147d52;
-      --warn: #9a6700;
-      --fail: #c7352a;
-      --blocked: #6b4bb8;
-      --unsupported: #596579;
-      --accent: #1769aa;
-    }
-    body { margin: 0; font: 14px/1.5 system-ui, -apple-system, Segoe UI, sans-serif; color: var(--ink); background: var(--bg); }
-    header { background: #15395b; color: white; padding: 28px 32px; }
-    header h1 { margin: 0 0 8px; font-size: 28px; letter-spacing: 0; }
-    header p { margin: 0; color: #d8e8f7; }
-    main { max-width: 1180px; margin: 0 auto; padding: 24px; }
-    section { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 18px; margin: 16px 0; }
-    h2 { margin: 0 0 12px; font-size: 20px; }
-    h3 { margin: 18px 0 8px; font-size: 15px; }
-    .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
-    .card { border: 1px solid var(--line); border-radius: 8px; padding: 14px; background: #fbfcfe; }
-    .metric { font-size: 24px; font-weight: 700; }
-    .muted { color: var(--muted); }
-    table { width: 100%; border-collapse: collapse; margin-top: 8px; }
-    th, td { border: 1px solid var(--line); padding: 8px 10px; text-align: left; vertical-align: top; }
-    th { background: #eef3f8; }
-    .status { display: inline-block; padding: 2px 8px; border-radius: 999px; color: white; font-weight: 700; font-size: 12px; }
-    .pass { background: var(--pass); }
-    .warning { background: var(--warn); }
-    .fail { background: var(--fail); }
-    .blocked { background: var(--blocked); }
-    .unsupported { background: var(--unsupported); }
-    code, pre { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
-    pre { white-space: pre-wrap; background: #101828; color: #f4f7fb; border-radius: 8px; padding: 12px; overflow: auto; }
-    details { border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; margin: 10px 0; background: #fbfcfe; }
-    summary { cursor: pointer; font-weight: 700; }
-    ul { padding-left: 20px; }
-    @media (max-width: 800px) { .grid { grid-template-columns: 1fr 1fr; } main { padding: 12px; } }
+    :root { --ok:#137333; --warn:#b06000; --block:#7b1fa2; --fail:#b3261e; --ink:#1f2937; --muted:#5f6b7a; --line:#d7dde5; --bg:#f7f9fc; --card:#fff; }
+    body { margin:0; font-family:Segoe UI, Arial, sans-serif; color:var(--ink); background:var(--bg); }
+    header { background:#0f172a; color:white; padding:28px 36px; }
+    main { max-width:1160px; margin:0 auto; padding:28px 24px 48px; }
+    h1 { margin:0 0 8px; font-size:28px; }
+    h2 { margin:28px 0 12px; font-size:20px; }
+    h3 { margin:18px 0 8px; font-size:16px; }
+    p { line-height:1.55; }
+    .meta { color:#cbd5e1; margin:0; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:12px; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:8px; padding:16px; }
+    .metric { font-size:28px; font-weight:700; }
+    .ok { color:var(--ok); } .warn { color:var(--warn); } .block { color:var(--block); } .fail { color:var(--fail); }
+    table { width:100%; border-collapse:collapse; background:white; border:1px solid var(--line); }
+    th, td { border-bottom:1px solid var(--line); padding:10px 12px; text-align:left; vertical-align:top; }
+    th { background:#eef2f7; font-weight:600; }
+    tr:last-child td { border-bottom:none; }
+    .badge { display:inline-block; border-radius:999px; padding:2px 9px; font-size:12px; font-weight:700; border:1px solid currentColor; }
+    .small { color:var(--muted); font-size:13px; }
+    code { background:#eef2f7; padding:1px 4px; border-radius:4px; }
+    pre { white-space:pre-wrap; overflow:auto; background:#111827; color:#e5e7eb; padding:12px; border-radius:8px; }
+    details { background:white; border:1px solid var(--line); border-radius:8px; padding:10px 12px; margin:10px 0; }
+    summary { cursor:pointer; font-weight:600; }
   </style>
 </head>
 <body>
-  <header>
-    <h1>Azure Functions Skills E2E Report</h1>
-    <p>Run ID 20260517T184312Z - fresh local matrix on Windows - package 0.11.3 - commit 330629ea</p>
-  </header>
-  <main>
-    <section>
-      <h2>Executive Summary</h2>
-      <div class="grid">
-        <div class="card"><div class="metric">12</div><div class="muted">Scenario records</div></div>
-        <div class="card"><div class="metric">3</div><div class="muted">Setup scenarios passed or warned</div></div>
-        <div class="card"><div class="metric">2</div><div class="muted">Chat launch failures</div></div>
-        <div class="card"><div class="metric">3</div><div class="muted">Plugin scenarios blocked/unsupported</div></div>
-      </div>
-      <p>The setup path is the strongest result: GitHub Copilot, Claude Code, and Codex all received workspace-local Azure Functions skill files, and real-agent inspection confirmed visibility. Chat and plugin paths need work: Windows PowerShell shim launch fails for Copilot/Codex chat, Claude chat blocks on MCP selection, and plugin installation is not automation-friendly enough to prove a fresh lifecycle.</p>
-    </section>
+<header>
+  <h1>Azure Functions Skills E2E Report</h1>
+  <p class="meta">Run ID: 20260519T-manual | Package: @agent-loom/azure-functions-skills 0.11.3 | OS: Windows | Method: manual one-scenario-at-a-time</p>
+</header>
+<main>
+  <section class="grid">
+    <div class="card"><div class="metric ok">8</div><div>Pass</div></div>
+    <div class="card"><div class="metric warn">3</div><div>Warning</div></div>
+    <div class="card"><div class="metric block">1</div><div>Blocked</div></div>
+    <div class="card"><div class="metric fail">0</div><div>Fail</div></div>
+  </section>
 
-    <section>
-      <h2>Environment</h2>
-      <table>
-        <tr><th>Item</th><th>Value</th></tr>
-        <tr><td>Platform</td><td>Windows / PowerShell</td></tr>
-        <tr><td>Package</td><td>@agent-loom/azure-functions-skills 0.11.3</td></tr>
-        <tr><td>Node/npm</td><td>Node v22.17.0, npm 10.9.2</td></tr>
-        <tr><td>GitHub Copilot CLI</td><td>1.0.49-1</td></tr>
-        <tr><td>Claude Code</td><td>2.1.143</td></tr>
-        <tr><td>Codex CLI</td><td>0.130.0</td></tr>
-      </table>
-    </section>
+  <h2>Executive Summary</h2>
+  <div class="card">
+    <p>The full local E2E matrix was rerun from scratch without using previous result files or a custom runner. Each scenario was executed manually in its own workspace under <code>reports/e2e/20260519T-manual/workspaces/</code>, then recorded immediately in the checklist and evidence log.</p>
+    <p>Workspace setup and chat flows passed for GitHub Copilot, Claude Code, and Codex. GitHub Copilot plugin installation passed after target-only cleanup and fresh reinstall. Claude plugin loading worked through <code>--plugin-dir</code>, but native plugin validation failed. Codex marketplace registration worked, but plugin activation is blocked because Codex CLI 0.130.0 has no noninteractive plugin install/select/list command.</p>
+  </div>
 
-    <section>
-      <h2>Dynamic Inventory</h2>
-      <p>Expected surfaces were derived from current repository files, not previous reports.</p>
-      <table>
-        <tr><th>Surface</th><th>Count</th><th>Source</th></tr>
-        <tr><td>Skills</td><td>9</td><td><code>templates/skills/*/SKILL.md</code></td></tr>
-        <tr><td>Prompts</td><td>1</td><td><code>templates/prompts/startup.md</code></td></tr>
-        <tr><td>MCP</td><td>1</td><td><code>templates/mcp/servers.yaml</code></td></tr>
-        <tr><td>Hooks</td><td>1</td><td><code>templates/hooks/welcome-setup.md</code></td></tr>
-        <tr><td>Agents</td><td>2</td><td><code>templates/agents/functions-copilot.agent.md</code>, <code>templates/agents/AGENTS.md</code></td></tr>
-        <tr><td>Plugin payload</td><td>present</td><td><code>.github/plugins/azure-functions-skills/</code></td></tr>
-      </table>
-    </section>
+  <h2>Scenario Matrix</h2>
+  <table>
+    <thead><tr><th>Scenario</th><th>Status</th><th>Evidence Summary</th></tr></thead>
+    <tbody>
+      <tr><td>setup-workspace-ghcp</td><td><span class="badge ok">pass</span></td><td>56 GitHub Copilot workspace files installed; real Copilot saw all 9 skills, MCP, hook, and functions-copilot agent.</td></tr>
+      <tr><td>setup-workspace-claude</td><td><span class="badge ok">pass</span></td><td>53 Claude files installed; real Claude saw all 9 skills and Azure MCP settings.</td></tr>
+      <tr><td>setup-workspace-codex</td><td><span class="badge ok">pass</span></td><td>54 Codex files installed; real Codex saw all 9 skills, MCP config, hooks, and AGENTS.md guidance.</td></tr>
+      <tr><td>chat-welcome-ghcp</td><td><span class="badge ok">pass</span></td><td>Chat auto-setup installed GHCP files and launched functions-copilot; separate startup prompt check detected host.json and deploy suggestion.</td></tr>
+      <tr><td>chat-welcome-claude</td><td><span class="badge ok">pass</span></td><td>Chat auto-setup installed Claude files; real Claude saw all 9 skills and Azure MCP context.</td></tr>
+      <tr><td>chat-welcome-codex</td><td><span class="badge ok">pass</span></td><td>Chat auto-setup installed Codex files; real Codex wrote parseable inspection JSON with all surfaces visible.</td></tr>
+      <tr><td>plugin-install-ghcp</td><td><span class="badge ok">pass</span></td><td>Target plugin and marketplace were removed, re-added, and reinstalled; Copilot reported pluginInstalled true and all 9 skills.</td></tr>
+      <tr><td>plugin-install-claude</td><td><span class="badge warn">warning</span></td><td><code>claude plugin validate</code> failed with manifest errors, but session-scoped <code>--plugin-dir</code> loading exposed all 9 skills.</td></tr>
+      <tr><td>plugin-install-codex</td><td><span class="badge block">blocked</span></td><td>Marketplace remove/add succeeded, but Codex CLI exposes no noninteractive install/list/select command.</td></tr>
+      <tr><td>docs-command-consistency</td><td><span class="badge warn">warning</span></td><td>README mostly matches real CLI behavior; subcommand <code>setup --help</code>/<code>chat --help</code> execute behavior, and Claude docs should consider <code>--plugin-dir</code>.</td></tr>
+      <tr><td>basic-help-prompt</td><td><span class="badge ok">pass</span></td><td>GHCP, Claude, and Codex all explained setup, create, deploy, diagnostics, best practices, and feedback without unsupported claims.</td></tr>
+      <tr><td>azure-skills-dependency</td><td><span class="badge warn">warning</span></td><td>GHCP confirmed Azure Skills present; Codex correctly reported dependency availability as blocked/warning rather than pass.</td></tr>
+    </tbody>
+  </table>
 
-    <section>
-      <h2>Scenario Matrix</h2>
-      <table>
-        <tr><th>Scenario</th><th>Agent</th><th>Mode</th><th>Status</th><th>Key evidence</th></tr>
-        <tr><td>setup-workspace-ghcp</td><td>GitHub Copilot</td><td>setup</td><td><span class="status pass">pass</span></td><td>Copilot reported 9 skills, functions-copilot agent, instructions, MCP, and hook.</td></tr>
-        <tr><td>setup-workspace-claude</td><td>Claude Code</td><td>setup</td><td><span class="status pass">pass</span></td><td>Claude reported 9 skills, CLAUDE.md, and MCP settings.</td></tr>
-        <tr><td>setup-workspace-codex</td><td>Codex</td><td>setup</td><td><span class="status warning">warning</span></td><td>Codex reported surfaces; hook omits azd check.</td></tr>
-        <tr><td>chat-welcome-ghcp</td><td>GitHub Copilot</td><td>chat</td><td><span class="status fail">fail</span></td><td>Auto-setup wrote files, but launcher failed with copilot not found on Windows.</td></tr>
-        <tr><td>chat-welcome-claude</td><td>Claude Code</td><td>chat</td><td><span class="status blocked">blocked</span></td><td>Claude opened interactive MCP server selection.</td></tr>
-        <tr><td>chat-welcome-codex</td><td>Codex</td><td>chat</td><td><span class="status fail">fail</span></td><td>Auto-setup wrote files, but launcher failed with codex not found on Windows.</td></tr>
-        <tr><td>plugin-install-ghcp</td><td>GitHub Copilot</td><td>plugin</td><td><span class="status blocked">blocked</span></td><td>Plugin marketplace/install flow entered interactive or alternate-screen behavior.</td></tr>
-        <tr><td>plugin-install-claude</td><td>Claude Code</td><td>plugin</td><td><span class="status unsupported">unsupported</span></td><td>Current help did not expose documented plugin/add-dir support.</td></tr>
-        <tr><td>plugin-install-codex</td><td>Codex</td><td>plugin</td><td><span class="status blocked">blocked</span></td><td>Marketplace management exists, but install/select remains interactive.</td></tr>
-        <tr><td>docs-command-consistency</td><td>All</td><td>docs</td><td><span class="status fail">fail</span></td><td>README skill list matches; Claude plugin docs and Windows chat launch behavior do not.</td></tr>
-        <tr><td>basic-help-prompt</td><td>All</td><td>setup</td><td><span class="status warning">warning</span></td><td>Copilot and Codex help evidence passed; Claude durable transcript capture was incomplete.</td></tr>
-        <tr><td>azure-skills-dependency</td><td>Copilot/Codex</td><td>chat/plugin</td><td><span class="status pass">pass</span></td><td>Setup/deploy skills include Azure Skills install guidance and deployment dependency details.</td></tr>
-      </table>
-    </section>
+  <h2>Capability Surface</h2>
+  <table>
+    <thead><tr><th>Agent</th><th>Plugin</th><th>Setup</th><th>Chat</th><th>Skills</th><th>MCP</th><th>Hooks</th><th>Agents/Guidance</th></tr></thead>
+    <tbody>
+      <tr><td>GitHub Copilot</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">9/9</td><td class="ok">azure</td><td class="ok">SessionStart</td><td class="ok">functions-copilot</td></tr>
+      <tr><td>Claude Code</td><td class="warn">warning</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">9/9</td><td class="ok">azure</td><td class="warn">plugin hook visible; native setup hook partial</td><td class="ok">CLAUDE.md/functions-copilot payload</td></tr>
+      <tr><td>Codex</td><td class="block">blocked</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">9/9 via setup/chat</td><td class="ok">azure via setup/chat</td><td class="ok">.codex/hooks.json</td><td class="ok">AGENTS.md</td></tr>
+    </tbody>
+  </table>
 
-    <section>
-      <h2>Capability Surface Matrix</h2>
-      <table>
-        <tr><th>Agent</th><th>Plugin</th><th>Skills</th><th>Prompts</th><th>MCP</th><th>Hooks</th><th>Agents</th></tr>
-        <tr><td>GitHub Copilot</td><td><span class="status blocked">blocked</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td></tr>
-        <tr><td>Claude Code</td><td><span class="status unsupported">unsupported</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td><td><span class="status unsupported">unsupported</span></td><td><span class="status pass">pass</span></td></tr>
-        <tr><td>Codex</td><td><span class="status blocked">blocked</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td><td><span class="status pass">pass</span></td><td><span class="status warning">warning</span></td><td><span class="status pass">pass</span></td></tr>
-      </table>
-    </section>
+  <h2>Key Findings</h2>
+  <div class="card">
+    <h3>Warnings</h3>
+    <p><strong>Claude plugin validation:</strong> <code>claude plugin validate</code> failed with <code>agents: Invalid input</code> and <code>root: Unrecognized key: "interface"</code>. Session-scoped loading still worked, so packaging validation should be fixed.</p>
+    <p><strong>Docs/help behavior:</strong> <code>azure-functions-skills setup --help</code> and <code>chat --help</code> executed setup/chat behavior in the isolated workspace. Use top-level help for read-only discovery until subcommand help is fixed.</p>
+    <p><strong>Azure Skills dependency:</strong> GitHub Copilot had <code>azure@azure-skills</code> installed. Codex correctly reported dependency availability as blocked/warning because noninteractive plugin activation is unavailable.</p>
+    <h3>Blocked</h3>
+    <p><strong>Codex plugin activation:</strong> Codex CLI 0.130.0 supports marketplace add/remove but not noninteractive plugin install/list/select. Marketplace registration alone cannot prove plugin activation.</p>
+  </div>
 
-    <section>
-      <h2>Failure Analysis</h2>
-      <h3>Windows chat launcher failures</h3>
-      <p><code>src/chat/index.ts</code> resolves launchers with <code>where</code>. On this machine, direct PowerShell discovery finds <code>copilot.ps1</code> and <code>codex.ps1</code>, but <code>chat</code> fails with <code>copilot not found</code> and <code>codex not found</code>. The resolver only treats <code>.cmd</code> and <code>.bat</code> as shell-backed commands, so PowerShell shims are not launched correctly.</p>
-      <h3>Claude chat blocks on MCP selection</h3>
-      <p>The chat command installs Claude files and launches Claude, but Claude displays an interactive MCP server selection prompt for <code>azure-functions-templates</code> and <code>azure</code>. That blocks unattended E2E completion.</p>
-      <h3>Plugin lifecycle cannot be proven</h3>
-      <p>Fresh plugin install semantics require pre-state, cleanup/isolation, install/register, post-state, and agent inspection. None of the plugin scenarios reached that full lifecycle noninteractively, so none are marked pass.</p>
-      <h3>Docs mismatch</h3>
-      <p>README skill and setup/chat examples mostly match the repository, but the Claude plugin-from-source command is not supported by the current CLI help observed in this run. README also does not warn about Windows PowerShell shim launch behavior for chat.</p>
-    </section>
+  <h2>Command Evidence</h2>
+  <p class="small">These are the final commands used for each scenario after manual iteration. They include both passing and warning/blocked flows so the working and non-working shapes are visible.</p>
+  <details open><summary>setup-workspace-ghcp - pass</summary>
+<pre>node bin/azure-functions-skills.js setup --agent ghcp --dir reports/e2e/20260519T-manual/workspaces/setup-workspace-ghcp --skip-prerequisites
+copilot -C reports/e2e/20260519T-manual/workspaces/setup-workspace-ghcp --agent functions-copilot -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user</pre>
+  </details>
+  <details><summary>setup-workspace-claude - pass</summary>
+<pre>node bin/azure-functions-skills.js setup --agent claude --dir reports/e2e/20260519T-manual/workspaces/setup-workspace-claude --skip-prerequisites
+claude -p &lt;inspection prompt&gt; --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</pre>
+  </details>
+  <details><summary>setup-workspace-codex - pass</summary>
+<pre>node bin/azure-functions-skills.js setup --agent codex --dir reports/e2e/20260519T-manual/workspaces/setup-workspace-codex --skip-prerequisites
+codex exec --sandbox read-only --json --output-last-message reports/e2e/20260519T-manual/workspaces/setup-workspace-codex/e2e-agent-inspection.json --ephemeral --skip-git-repo-check --cd reports/e2e/20260519T-manual/workspaces/setup-workspace-codex &lt;inspection prompt&gt;</pre>
+  </details>
+  <details><summary>chat-welcome-ghcp - pass</summary>
+<pre>node bin/azure-functions-skills.js chat --agent github-copilot --dir . --skip-prerequisites -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user
+node --input-type=module -e "import('./lib/chat/index.js').then(async m =&gt; console.log(await m.buildStartupPrompt(process.argv[1])))" &lt;workspace&gt;</pre>
+  </details>
+  <details><summary>chat-welcome-claude - pass</summary>
+<pre>node bin/azure-functions-skills.js chat --agent claude-code --dir . --skip-prerequisites --prompt &lt;inspection prompt&gt; -p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
+node --input-type=module -e "import('./lib/chat/index.js').then(async m =&gt; console.log(await m.buildStartupPrompt(process.argv[1])))" &lt;workspace&gt;</pre>
+  </details>
+  <details><summary>chat-welcome-codex - pass</summary>
+<pre>node bin/azure-functions-skills.js chat --agent codex --dir . --skip-prerequisites --prompt &lt;inspection prompt&gt; exec --sandbox workspace-write --json --output-last-message e2e-chat-inspection.json --ephemeral --skip-git-repo-check --cd .
+node --input-type=module -e "import('./lib/chat/index.js').then(async m =&gt; console.log(await m.buildStartupPrompt(process.argv[1])))" &lt;workspace&gt;</pre>
+  </details>
+  <details><summary>plugin-install-ghcp - pass</summary>
+<pre>copilot plugin --help
+copilot plugin marketplace --help
+copilot plugin list
+copilot plugin marketplace list
+copilot plugin uninstall azure-functions-skills
+copilot plugin marketplace remove azure-functions-skills
+copilot plugin marketplace add Azure/azure-functions-skills
+copilot plugin install azure-functions-skills@azure-functions-skills
+copilot plugin list
+copilot plugin marketplace list
+copilot --agent functions-copilot -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user</pre>
+  </details>
+  <details><summary>plugin-install-claude - warning</summary>
+<pre>claude plugin --help
+claude plugin list
+claude --help | Select-String -Pattern "plugin|add-dir" -Context 0,2
+claude plugin marketplace --help
+claude plugin validate &lt;plugin-payload-dir&gt;
+claude -p &lt;inspection prompt&gt; --plugin-dir &lt;plugin-payload-dir&gt; --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</pre>
+  </details>
+  <details><summary>plugin-install-codex - blocked</summary>
+<pre>codex plugin --help
+codex plugin marketplace --help
+codex exec --help
+codex plugin marketplace list
+codex plugin marketplace remove azure-functions-skills
+codex plugin marketplace add Azure/azure-functions-skills
+codex exec --sandbox read-only --json --output-last-message e2e-plugin-inspection.json --ephemeral --skip-git-repo-check --cd . &lt;inspection prompt&gt;</pre>
+  </details>
+  <details><summary>docs-command-consistency - warning</summary>
+<pre>README.md command sections
+package.json scripts
+templates/skills/*/SKILL.md inventory
+copilot --help | Select-String -Pattern "yolo|allow-all|silent|output-format|agent|no-ask-user"
+node bin/azure-functions-skills.js --help
+node bin/azure-functions-skills.js setup --help
+node bin/azure-functions-skills.js chat --help</pre>
+  </details>
+  <details><summary>basic-help-prompt - pass</summary>
+<pre>copilot --agent functions-copilot -p &lt;basic-help prompt&gt; --output-format json -s --allow-all --no-ask-user
+claude -p &lt;basic-help prompt&gt; --plugin-dir &lt;plugin-payload-dir&gt; --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
+node bin/azure-functions-skills.js setup --agent codex --dir &lt;workspace&gt; --skip-prerequisites
+codex exec --sandbox read-only --json --output-last-message e2e-basic-help.json --ephemeral --skip-git-repo-check --cd &lt;workspace&gt; &lt;basic-help prompt&gt;</pre>
+  </details>
+  <details><summary>azure-skills-dependency - warning</summary>
+<pre>copilot --agent functions-copilot -p &lt;dependency prompt&gt; --output-format json -s --allow-all --no-ask-user
+node bin/azure-functions-skills.js setup --agent codex --dir &lt;workspace&gt; --skip-prerequisites
+codex exec --sandbox read-only --json --output-last-message e2e-azure-skills-dependency.json --ephemeral --skip-git-repo-check --cd &lt;workspace&gt; &lt;dependency prompt&gt;</pre>
+  </details>
+  <details><summary>Retained workspaces</summary>
+    <p>All scenario workspaces were retained under <code>reports/e2e/20260519T-manual/workspaces/</code> for review. Date-stamped run directories are analysis artifacts; only this reviewed HTML is copied to <code>reports/e2e/current/report.html</code>.</p>
+  </details>
 
-    <section>
-      <h2>Command Evidence</h2>
-      <details open><summary>Environment and inventory</summary><pre>Get-Date
-  2026-05-17 18:43:12Z
-
-git rev-parse HEAD
-  330629ea...
-
-node --version; npm --version; npm pkg get version
-  v22.17.0
-  10.9.2
-  "0.11.3"
-
-Get-ChildItem templates/skills/**/SKILL.md
-  9 skill templates discovered
-
-Get-Command copilot, claude, codex
-  copilot 1.0.49-1
-  claude 2.1.143
-  codex 0.130.0</pre></details>
-      <details><summary>Setup inspection excerpts</summary><pre>copilot --agent functions-copilot -p "Inspect this workspace..."
-  Reported 9 skills, functions-copilot, .github/copilot-instructions.md, AGENTS.md, .vscode/mcp.json, and welcome-setup hook.
-
-claude -p "Inspect this workspace..." --output-format json --no-session-persistence
-  Reported 9 skills in .claude/skills, CLAUDE.md, and Azure MCP settings.
-
-codex exec --sandbox read-only --json --cd setup-codex "Inspect this workspace..."
-  Reported AGENTS.md, 9 skills, .codex/config.toml, .codex/hooks.json, and Azure Skills dependency guidance.</pre></details>
-      <details><summary>Chat excerpts</summary><pre>node bin/azure-functions-skills.js chat --agent github-copilot --dir .../chat-ghcp --prompt "Inspect startup context..."
-  Installed 56 skill files for ghcp
-  Error: copilot not found. Install it first.
-
-node bin/azure-functions-skills.js chat --agent claude-code --dir .../chat-claude --prompt "Inspect startup context..."
-  Installed 53 skill files for claude
-  Claude displayed interactive MCP server selection for azure-functions-templates and azure.
-
-node bin/azure-functions-skills.js chat --agent codex --dir .../chat-codex --prompt "Inspect startup context..."
-  Installed 54 skill files for codex
-  Error: codex not found.</pre></details>
-      <details><summary>Plugin excerpts</summary><pre>copilot plugin list / marketplace help/list
-  azure-functions-skills and azure-skills marketplaces observed; no completed fresh install lifecycle.
-
-copilot plugin marketplace add Azure/azure-functions-skills; copilot plugin install ...
-  Attempt entered interactive or alternate-screen behavior.
-
-claude --help; claude plugin --help
-  Current help did not expose the README-documented plugin/add-dir support.
-
-codex plugin --help; codex plugin marketplace --help
-  Marketplace management available; install/select remains interactive via /plugins.</pre></details>
-      <details><summary>Validation</summary><pre>npm run check
-  Completed successfully according to shared check execution summary.</pre></details>
-    </section>
-
-    <section>
-      <h2>Recommended Fixes</h2>
-      <ul>
-        <li>Fix Windows launcher resolution for <code>.ps1</code> shims in <code>src/chat/index.ts</code>.</li>
-        <li>Add an automation-friendly chat mode that uses <code>copilot -p</code>, <code>claude -p</code>, and <code>codex exec</code> for E2E inspection.</li>
-        <li>Re-verify and update Claude plugin-from-source README guidance for Claude Code 2.1.143.</li>
-        <li>Document noninteractive plugin install limitations for Copilot and Codex, or provide isolated profile/config instructions.</li>
-        <li>Include <code>azd</code> in generated Codex setup hook checks to match setup guidance.</li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Artifacts</h2>
-      <ul>
-        <li><code>reports/e2e/20260517T184312Z/evidence.json</code></li>
-        <li><code>reports/e2e/20260517T184312Z/skill-improvement.md</code></li>
-        <li><code>reports/e2e/20260517T184312Z/transcripts/setup-ghcp-help-prompt.txt</code></li>
-        <li><code>reports/e2e/20260517T184312Z/transcripts/setup-codex-last-message.txt</code></li>
-        <li><code>reports/e2e/20260517T184312Z/workspaces/</code> retained for debugging</li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Cross-check</h2>
-      <p>Self-review result: pass with known gaps. All default-scope scenario records are present and no plugin scenario is marked pass without a completed fresh lifecycle. Chat launch failures are marked fail where the CLI exists but launcher behavior failed. Interactive Claude chat and plugin installation paths are marked blocked or unsupported rather than warning.</p>
-    </section>
-  </main>
+  <h2>Cross-Check</h2>
+  <div class="card">
+    <p>The checklist contains all 12 default local scenarios. No scenario was omitted due to expected failure. All setup/chat/plugin commands that could write files were run in scenario workspaces. The only known incidental write from help probing occurred inside the disposable docs-command-consistency workspace and is recorded as a warning.</p>
+    <p>The E2E skill instructions were updated with the successful manual execution practices and current CLI caveats discovered during this run.</p>
+  </div>
+</main>
 </body>
 </html>

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -35,8 +35,9 @@ export const LAUNCHERS: Record<LauncherId, Launcher> = {
   'github-copilot': {
     command: 'copilot',
     buildArgs: (ctx) => {
-      const args = ['--agent', 'functions-copilot'];
-      if (ctx.startupPrompt) args.push('-i', ctx.startupPrompt);
+      const passthroughArgs = ctx.passthroughArgs || [];
+      const args = ['--agent', 'functions-copilot', ...passthroughArgs];
+      if (ctx.startupPrompt && !hasCopilotPromptArg(passthroughArgs)) args.push('-i', ctx.startupPrompt);
       return args;
     },
     description: 'GitHub Copilot CLI',
@@ -44,8 +45,8 @@ export const LAUNCHERS: Record<LauncherId, Launcher> = {
   'claude-code': {
     command: 'claude',
     buildArgs: (ctx) => {
-      const args = [];
-      if (ctx.startupPrompt) args.push(ctx.startupPrompt);
+      const args = [...(ctx.passthroughArgs || [])];
+      if (ctx.startupPrompt) insertClaudePrompt(args, ctx.startupPrompt);
       return args;
     },
     description: 'Claude Code',
@@ -53,13 +54,26 @@ export const LAUNCHERS: Record<LauncherId, Launcher> = {
   'codex': {
     command: 'codex',
     buildArgs: (ctx) => {
-      const args = [];
+      const args = [...(ctx.passthroughArgs || [])];
       if (ctx.startupPrompt) args.push(ctx.startupPrompt);
       return args;
     },
     description: 'Codex CLI',
   },
 };
+
+function hasCopilotPromptArg(args: string[]): boolean {
+  return args.some(arg => arg === '-p' || arg === '--prompt' || arg === '-i' || arg === '--interactive');
+}
+
+function insertClaudePrompt(args: string[], startupPrompt: string): void {
+  const printIndex = args.findIndex(arg => arg === '-p' || arg === '--print');
+  if (printIndex >= 0) {
+    args.splice(printIndex + 1, 0, startupPrompt);
+    return;
+  }
+  args.push(startupPrompt);
+}
 
 // ─── Agent detection ───
 
@@ -188,7 +202,7 @@ export async function chat(options: ChatOptions = {}): Promise<ChatResult> {
   }
 
   const startupPrompt = options.prompt || await buildStartupPrompt(dir);
-  const args = launcher.buildArgs({ startupPrompt });
+  const args = launcher.buildArgs({ startupPrompt, passthroughArgs: options.passthroughArgs });
   const resolvedLauncher = resolveLauncherCommand(launcher.command);
 
   const child = spawn(resolvedLauncher.command, [...resolvedLauncher.argsPrefix, ...args], {
@@ -273,7 +287,7 @@ function findWindowsLauncherCandidates(command: string, env: NodeJS.ProcessEnv):
     .map(extension => extension.trim())
     .filter(Boolean);
   const commandHasExtension = /\.[^\\/]+$/.test(command);
-  const commandNames = commandHasExtension ? [command] : [command, ...extensions.map(extension => `${command}${extension.toLowerCase()}`)];
+  const commandNames = commandHasExtension ? [command] : [...extensions.map(extension => `${command}${extension.toLowerCase()}`), command];
   const candidates: string[] = [];
 
   for (const directory of pathValue.split(';').map(entry => entry.trim()).filter(Boolean)) {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -15,6 +15,17 @@ import { ensurePrerequisites } from '../setup/prerequisites/index.js';
 import { loadSkills } from '../build/loader.js';
 import type { BuildTargetName, ChatOptions, ChatResult, DetectedCliAgent, Launcher, LauncherId } from '../types.js';
 
+type ResolvedLauncherCommand = {
+  command: string;
+  argsPrefix: string[];
+  shell: boolean;
+};
+
+type ResolveLauncherOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+};
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROMPTS_DIR = join(__dirname, '..', '..', 'templates', 'prompts');
 
@@ -180,7 +191,7 @@ export async function chat(options: ChatOptions = {}): Promise<ChatResult> {
   const args = launcher.buildArgs({ startupPrompt });
   const resolvedLauncher = resolveLauncherCommand(launcher.command);
 
-  const child = spawn(resolvedLauncher.command, args, {
+  const child = spawn(resolvedLauncher.command, [...resolvedLauncher.argsPrefix, ...args], {
     cwd: dir,
     stdio: 'inherit',
     shell: resolvedLauncher.shell,
@@ -224,21 +235,59 @@ async function pickAgent(): Promise<LauncherId> {
   return agents[0].id;
 }
 
-function resolveLauncherCommand(command: string): { command: string; shell: boolean } {
-  if (process.platform !== 'win32') {
-    return { command, shell: false };
+export function resolveLauncherCommand(command: string, options: ResolveLauncherOptions = {}): ResolvedLauncherCommand {
+  const platform = options.platform || process.platform;
+  if (platform !== 'win32') {
+    return { command, argsPrefix: [], shell: false };
   }
 
   try {
-    const resolved = execSync(`where ${command}`, { encoding: 'utf-8' })
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .find(Boolean);
-    if (!resolved) return { command, shell: false };
-    return { command: resolved, shell: /\.(cmd|bat)$/i.test(resolved) };
+    const candidates = findWindowsLauncherCandidates(command, options.env || process.env);
+    const resolved = pickWindowsLauncherCandidate(candidates);
+    if (!resolved) return { command, argsPrefix: [], shell: false };
+    if (/\.(cmd|bat)$/i.test(resolved)) {
+      return {
+        command: 'cmd.exe',
+        argsPrefix: ['/d', '/s', '/c', resolved],
+        shell: false,
+      };
+    }
+    if (/\.ps1$/i.test(resolved)) {
+      return {
+        command: 'powershell.exe',
+        argsPrefix: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', resolved],
+        shell: false,
+      };
+    }
+    return { command: resolved, argsPrefix: [], shell: false };
   } catch {
-    return { command, shell: false };
+    return { command, argsPrefix: [], shell: false };
   }
+}
+
+function findWindowsLauncherCandidates(command: string, env: NodeJS.ProcessEnv): string[] {
+  const pathValue = env.Path || env.PATH || '';
+  const pathExtValue = env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD;.PS1';
+  const extensions = pathExtValue
+    .split(';')
+    .map(extension => extension.trim())
+    .filter(Boolean);
+  const commandHasExtension = /\.[^\\/]+$/.test(command);
+  const commandNames = commandHasExtension ? [command] : [command, ...extensions.map(extension => `${command}${extension.toLowerCase()}`)];
+  const candidates: string[] = [];
+
+  for (const directory of pathValue.split(';').map(entry => entry.trim()).filter(Boolean)) {
+    for (const commandName of commandNames) {
+      const candidate = join(directory, commandName);
+      if (existsSync(candidate)) candidates.push(candidate);
+    }
+  }
+
+  return candidates;
+}
+
+function pickWindowsLauncherCandidate(candidates: string[]): string | undefined {
+  return candidates[0];
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface SetupResult {
 
 export interface LauncherContext {
   startupPrompt?: string;
+  passthroughArgs?: string[];
 }
 
 export interface Launcher {
@@ -74,6 +75,7 @@ export interface ChatOptions {
   agent?: LauncherId;
   prompt?: string;
   dir?: string;
+  passthroughArgs?: string[];
   prerequisites?: PrerequisiteMode;
   prerequisiteRunner?: CommandRunner;
 }

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterAll } from 'vitest';
 import { existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildStartupPrompt, LAUNCHERS, detectCliAgents, chat } from '../src/chat/index.js';
+import { buildStartupPrompt, LAUNCHERS, detectCliAgents, chat, resolveLauncherCommand } from '../src/chat/index.js';
 import { createTempDir, removeDir, resetDir } from './helpers/fs.js';
 
 const TEMP_DIRS: string[] = [];
@@ -86,6 +86,67 @@ describe('LAUNCHERS', () => {
       const args = launcher.buildArgs({});
       expect(args).toBeInstanceOf(Array);
     }
+  });
+});
+
+// ─── Launcher resolution tests ───
+
+describe('resolveLauncherCommand', () => {
+  it('leaves non-Windows launchers unchanged', () => {
+    const resolved = resolveLauncherCommand('codex', {
+      platform: 'linux',
+    });
+
+    expect(resolved).toEqual({ command: 'codex', argsPrefix: [], shell: false });
+  });
+
+  it('wraps cmd shims with cmd.exe on Windows to avoid shell quoting', () => {
+    const binDir = resetDir(join(DIST_DIR, 'launcher-cmd-ps1'));
+    writeFileSync(join(binDir, 'codex.ps1'), 'exit 0');
+    writeFileSync(join(binDir, 'codex.cmd'), '@echo off\r\nexit /b 0\r\n');
+    const resolved = resolveLauncherCommand('codex', {
+      platform: 'win32',
+      env: { Path: binDir, PATHEXT: '.CMD;.PS1' },
+    });
+
+    expect(resolved).toEqual({
+      command: 'cmd.exe',
+      argsPrefix: ['/d', '/s', '/c', join(binDir, 'codex.cmd')],
+      shell: false,
+    });
+  });
+
+  it('runs PowerShell shims through powershell.exe when no better shim is available', () => {
+    const binDir = resetDir(join(DIST_DIR, 'launcher-ps1'));
+    writeFileSync(join(binDir, 'copilot.ps1'), 'exit 0');
+    const resolved = resolveLauncherCommand('copilot', {
+      platform: 'win32',
+      env: { Path: binDir, PATHEXT: '.PS1' },
+    });
+
+    expect(resolved).toEqual({
+      command: 'powershell.exe',
+      argsPrefix: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', join(binDir, 'copilot.ps1')],
+      shell: false,
+    });
+  });
+
+  it('runs exe and extensionless Windows shims directly', () => {
+    const exeDir = resetDir(join(DIST_DIR, 'launcher-exe'));
+    const extensionlessDir = resetDir(join(DIST_DIR, 'launcher-extensionless'));
+    writeFileSync(join(exeDir, 'tool.exe'), 'fake');
+    writeFileSync(join(extensionlessDir, 'tool'), 'fake');
+    const exe = resolveLauncherCommand('tool', {
+      platform: 'win32',
+      env: { Path: exeDir, PATHEXT: '.EXE' },
+    });
+    const extensionless = resolveLauncherCommand('tool', {
+      platform: 'win32',
+      env: { Path: extensionlessDir, PATHEXT: '' },
+    });
+
+    expect(exe).toEqual({ command: join(exeDir, 'tool.exe'), argsPrefix: [], shell: false });
+    expect(extensionless).toEqual({ command: join(extensionlessDir, 'tool'), argsPrefix: [], shell: false });
   });
 });
 

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -71,14 +71,41 @@ describe('LAUNCHERS', () => {
     expect(args).toContain('hello');
   });
 
+  it('ghcp launcher forwards CLI args and lets explicit prompt flags replace interactive startup prompt', () => {
+    const args = LAUNCHERS['github-copilot'].buildArgs({
+      startupPrompt: 'startup',
+      passthroughArgs: ['-p', 'headless', '--yolo', '--output-format', 'json'],
+    });
+
+    expect(args).toEqual(['--agent', 'functions-copilot', '-p', 'headless', '--yolo', '--output-format', 'json']);
+  });
+
   it('claude launcher passes prompt as first arg', () => {
     const args = LAUNCHERS['claude-code'].buildArgs({ startupPrompt: 'hello' });
     expect(args).toContain('hello');
   });
 
+  it('claude launcher forwards CLI args before the startup prompt', () => {
+    const args = LAUNCHERS['claude-code'].buildArgs({
+      startupPrompt: 'hello',
+      passthroughArgs: ['-p', '--permission-mode', 'bypassPermissions'],
+    });
+
+    expect(args).toEqual(['-p', 'hello', '--permission-mode', 'bypassPermissions']);
+  });
+
   it('codex launcher passes prompt as first arg', () => {
     const args = LAUNCHERS['codex'].buildArgs({ startupPrompt: 'hello' });
     expect(args).toContain('hello');
+  });
+
+  it('codex launcher forwards subcommands and CLI args before the startup prompt', () => {
+    const args = LAUNCHERS['codex'].buildArgs({
+      startupPrompt: 'hello',
+      passthroughArgs: ['exec', '--sandbox', 'read-only', '--json'],
+    });
+
+    expect(args).toEqual(['exec', '--sandbox', 'read-only', '--json', 'hello']);
   });
 
   it('launchers return empty args when no prompt', () => {
@@ -112,6 +139,35 @@ describe('resolveLauncherCommand', () => {
     expect(resolved).toEqual({
       command: 'cmd.exe',
       argsPrefix: ['/d', '/s', '/c', join(binDir, 'codex.cmd')],
+      shell: false,
+    });
+  });
+
+  it('prefers Windows batch shims over extensionless scripts in the same directory', () => {
+    const batDir = resetDir(join(DIST_DIR, 'launcher-extensionless-bat'));
+    const cmdDir = resetDir(join(DIST_DIR, 'launcher-extensionless-cmd'));
+    writeFileSync(join(batDir, 'copilot'), '#!/bin/sh\nexit 0\n');
+    writeFileSync(join(batDir, 'copilot.bat'), '@echo off\r\nexit /b 0\r\n');
+    writeFileSync(join(cmdDir, 'codex'), '#!/bin/sh\nexit 0\n');
+    writeFileSync(join(cmdDir, 'codex.cmd'), '@echo off\r\nexit /b 0\r\n');
+
+    const bat = resolveLauncherCommand('copilot', {
+      platform: 'win32',
+      env: { Path: batDir, PATHEXT: '.BAT' },
+    });
+    const cmd = resolveLauncherCommand('codex', {
+      platform: 'win32',
+      env: { Path: cmdDir, PATHEXT: '.CMD' },
+    });
+
+    expect(bat).toEqual({
+      command: 'cmd.exe',
+      argsPrefix: ['/d', '/s', '/c', join(batDir, 'copilot.bat')],
+      shell: false,
+    });
+    expect(cmd).toEqual({
+      command: 'cmd.exe',
+      argsPrefix: ['/d', '/s', '/c', join(cmdDir, 'codex.cmd')],
       shell: false,
     });
   });

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -127,8 +127,8 @@ function createFakeAgentCliDirectory(): string {
     writeFileSync(
       commandPath,
       process.platform === 'win32'
-        ? '@echo off\r\nexit /b 0\r\n'
-        : '#!/usr/bin/env sh\nexit 0\n',
+        ? '@echo off\r\nif not "%AF_SKILLS_FAKE_ARGS_FILE%"=="" echo %*>>"%AF_SKILLS_FAKE_ARGS_FILE%"\r\nexit /b 0\r\n'
+        : '#!/usr/bin/env sh\nif [ -n "$AF_SKILLS_FAKE_ARGS_FILE" ]; then printf "%s\\n" "$*" >> "$AF_SKILLS_FAKE_ARGS_FILE"; fi\nexit 0\n',
       { mode: 0o755 },
     );
 
@@ -190,5 +190,35 @@ describe('CLI command integration', () => {
 
       assertWorkspaceLayout(projectDir, setupTarget, expectedSkillIds, expectedAgentFiles);
     }
+  });
+
+  it('chat forwards unknown arguments to the selected agent CLI', () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-chat-forward-codex-');
+    const argsFile = join(projectDir, 'agent-args.txt');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+
+    runCli([
+      'chat',
+      '--agent', 'codex',
+      '--dir', projectDir,
+      '--prompt', 'hello',
+      '--skip-prerequisites',
+      'exec',
+      '--sandbox', 'read-only',
+      '--json',
+    ], {
+      env: {
+        PATH: pathValue,
+        Path: pathValue,
+        AF_SKILLS_FAKE_ARGS_FILE: argsFile,
+        ...(pathext ? { PATHEXT: pathext } : {}),
+      },
+    });
+
+    expect(readFileSync(argsFile, 'utf-8').trim()).toBe('exec --sandbox read-only --json hello');
   });
 });

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -120,7 +120,7 @@ function runCli(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv
   });
 }
 
-function createFakeCliDirectory(): string {
+function createFakeAgentCliDirectory(): string {
   const fakeBinDir = makeTempDir('af-skills-e2e-bin-');
   for (const launcher of Object.values(LAUNCHERS)) {
     const commandPath = join(fakeBinDir, process.platform === 'win32' ? `${launcher.command}.cmd` : launcher.command);
@@ -131,11 +131,15 @@ function createFakeCliDirectory(): string {
         : '#!/usr/bin/env sh\nexit 0\n',
       { mode: 0o755 },
     );
+
+    if (process.platform === 'win32') {
+      writeFileSync(join(fakeBinDir, `${launcher.command}.ps1`), 'exit 0\r\n', { mode: 0o755 });
+    }
   }
   return fakeBinDir;
 }
 
-describe('CLI command E2E', () => {
+describe('CLI command integration', () => {
   it('build writes GHCP, Claude, and Codex layouts from current templates into a temp dist directory', () => {
     const distDir = makeTempDir('af-skills-e2e-build-');
     const expectedSkillIds = templateSkillIds();
@@ -165,7 +169,7 @@ describe('CLI command E2E', () => {
   });
 
   it('chat auto-installs each target workspace layout before launching the selected agent', () => {
-    const fakeBinDir = createFakeCliDirectory();
+    const fakeBinDir = createFakeAgentCliDirectory();
     const expectedSkillIds = templateSkillIds();
     const expectedAgentFiles = templateAgentFiles();
     const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;


### PR DESCRIPTION
## Summary
- add chat pass-through support so GitHub Copilot, Claude Code, and Codex can receive their own noninteractive/headless flags
- cover pass-through behavior in chat and CLI integration tests
- update E2E skill guidance and the current published report to use chat pass-through artifacts as the primary chat validation path
- ignore generated E2E run directories in ESLint so local analysis artifacts do not break `npm run check`

## Validation
- npm run check