### PR TITLE
Fix Claude plugin format and chat help handling

### DIFF
--- a/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
@@ -3,17 +3,6 @@
   "version": "0.11.3",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
-  "agents": "./agents/",
   "hooks": "./hooks.json",
-  "mcpServers": "./.mcp.json",
-  "interface": {
-    "displayName": "Azure Functions Skills",
-    "shortDescription": "Guided setup → create → deploy workflow for Azure Functions",
-    "developerName": "Azure Functions Team",
-    "category": "Development",
-    "capabilities": [
-      "Read",
-      "Write"
-    ]
-  }
+  "mcpServers": "./.mcp.json"
 }

--- a/.github/skills/azure-functions-e2e-tests/SKILL.md
+++ b/.github/skills/azure-functions-e2e-tests/SKILL.md
@@ -45,6 +45,8 @@ This skill is intended for Agent mode, not passive chat.
 13. **Review the review** — after drafting evidence and reports, perform a cross-check pass over commands, outputs, scenario statuses, and conclusions. Fix omitted scenarios and unsupported/blocked/fail classifications before presenting results.
 14. **No repository-root setup pollution** — never run `setup`, `chat`, agent inspection prompts, or generated help/discovery commands from the repository root when they can create files. Commands that may write agent files must run only inside `reports/e2e/<run-id>/workspaces/<scenario-id>/` or another explicitly isolated workspace. If checking CLI help, use command forms that cannot trigger setup/chat side effects, or run them from a disposable scenario workspace.
 15. **Final command list required** — every HTML report must include a `Command Evidence` section with the final execution command sequence for every scenario in the matrix, including pass, warning, blocked, unsupported, and failed scenarios. Do not collapse this down to generic patterns only; readers must be able to see exactly which command shape worked or did not work for each scenario.
+16. **Capability Surface Matrix required** — every HTML report must include a `Capability Surface Matrix` that shows, for each coding agent, whether `skills`, `prompts/guidance`, `mcp`, `hooks`, `agent definitions/guidance`, `plugin`, and `chat` are pass, warning, fail, blocked, or unsupported. Do not remove this matrix when adding command evidence.
+17. **Target-specific agent surfaces** — do not judge every host by GitHub Copilot `.agent.md` semantics. GitHub Copilot uses `.github/agents/*.agent.md` or installed plugin agents; Claude Code uses `CLAUDE.md`, skills, hooks, and MCP and may intentionally omit unsupported `agents` manifest metadata; Codex setup guidance uses `AGENTS.md` and `.agents/skills`, while plugin custom-agent activation must be reported separately if not visible.
 
 ## Manual-first execution guidance
 
@@ -56,40 +58,14 @@ When CLI behavior is uncertain, the user asks for a fresh manual run, or a prior
 - Do not use a custom runner as the source of truth until the manual command shape is proven for that agent and scenario type.
 - If a command hangs, times out, or produces confusing output, stop that scenario, capture the failure, simplify the command, and rerun only that scenario.
 - Keep inspection prompts in a PowerShell variable so the prompt is passed as one argument on Windows.
+- Resolve run directories from the repository root at the start of every scenario. Do not keep relative `reports/e2e/...` variables across `Set-Location` calls.
+- Use the workspace harness and scenario command contracts in [scenarios.md](references/scenarios.md). Keep concrete command sequences there so this skill remains small and does not contradict the references.
 
-Stable Windows command shapes observed in manual E2E runs:
+Key caveats that affect classification:
 
-```powershell
-# GitHub Copilot setup/plugin inspection
-copilot -C <workspace> --agent functions-copilot -p <inspection-prompt> --output-format json -s --allow-all --no-ask-user
-
-# GitHub Copilot chat inspection. The -p inspection prompt overrides chat startup prompt delivery,
-# so verify buildStartupPrompt(<workspace>) separately for startup-template assertions.
-azure-functions-skills chat --agent github-copilot --dir . --skip-prerequisites -p <inspection-prompt> --output-format json -s --allow-all --no-ask-user
-
-# Claude setup inspection
-claude -p <inspection-prompt> --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
-
-# Claude chat inspection. The wrapper inserts --prompt content after Claude's -p.
-azure-functions-skills chat --agent claude-code --dir . --skip-prerequisites --prompt <inspection-prompt> -p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
-
-# Claude plugin/source inspection. Validate the payload separately.
-claude plugin validate <plugin-payload-dir>
-claude -p <inspection-prompt> --plugin-dir <plugin-payload-dir> --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
-
-# Codex setup inspection
-codex exec --sandbox read-only --json --output-last-message <workspace>\e2e-agent-inspection.json --ephemeral --skip-git-repo-check --cd <workspace> <inspection-prompt>
-
-# Codex chat inspection. The wrapper appends --prompt content as the final Codex prompt.
-azure-functions-skills chat --agent codex --dir . --skip-prerequisites --prompt <inspection-prompt> exec --sandbox workspace-write --json --output-last-message e2e-chat-inspection.json --ephemeral --skip-git-repo-check --cd .
-```
-
-Current CLI caveats to record in reports:
-
-- `azure-functions-skills setup --help` and `azure-functions-skills chat --help` may execute the subcommand rather than displaying subcommand help. Run those probes only in disposable workspaces, or use top-level `azure-functions-skills --help` for read-only discovery.
-- Claude Code may load a plugin with `--plugin-dir` even when `claude plugin validate` reports manifest errors. Treat validation failure as a warning or failure according to the scenario contract; do not let session-scoped load alone hide packaging issues.
-- Codex CLI 0.130.0 supports `codex plugin marketplace add/remove`, but exposes no noninteractive plugin install/list/select command. Marketplace registration alone is not enough for a plugin scenario pass.
-- Generated SessionStart hooks currently check `az`, `func`, and `node`; if a scenario evaluates deployment readiness, separately verify or report `azd` availability because deployment guidance depends on Azure Developer CLI.
+- If cwd drift nests one scenario under another, discard that evidence as harness-invalid and rerun; do not report a product failure.
+- GitHub Copilot chat and GitHub Copilot installed-plugin inspection use different discovery paths and agent id contracts. `setup --agent ghcp` is a setup target id; `chat --agent github-copilot` is the chat launcher id; `copilot --agent azure-functions-skills:functions-copilot` is the installed-plugin inspection id. Validate `chat-welcome-ghcp` through the normal `chat --agent github-copilot` launcher with headless Copilot passthrough or a workspace artifact; validate `plugin-install-ghcp` after cleanup/install with the qualified installed-plugin agent.
+- Subcommand help, Claude plugin validation, Codex plugin activation, and `azd` hook coverage have known CLI caveats. Use the detailed rules in [scenarios.md](references/scenarios.md) and report-schema checks rather than repeating them here.
 
 ## Execution policy
 
@@ -101,6 +77,7 @@ When the user asks to run or validate E2E tests:
    - `.github/plugins/azure-functions-skills/` and generated plugin manifests for plugin payload expectations.
    - README and package scripts for documented setup/chat/plugin commands.
 2. Create a run directory at `reports/e2e/<run-id>/` and one isolated temporary workspace per agent and install mode under `reports/e2e/<run-id>/workspaces/<scenario-id>/`. Do not reuse the repository root as a test workspace.
+   - Resolve `reports/e2e/<run-id>` from `git rev-parse --show-toplevel` or the current workspace root. Avoid drive-letter-specific paths in instructions, scripts, and reports. Use `Join-Path` in PowerShell and quoted path variables in Bash.
 3. For each target agent (`ghcp`, `codex`, `claude`) and each mode (`plugin`, `setup`, `chat`):
    - Start from a clean isolated workspace under `reports/e2e/<run-id>/workspaces/<scenario-id>/` and, when safe, a clean isolated agent/plugin config location.
    - Set the command working directory to the scenario workspace before running any command that can write files, including `npx @agent-loom/azure-functions-skills setup`, `node bin/azure-functions-skills.js setup`, `chat`, `copilot -p`, `claude -p`, and `codex exec`.
@@ -112,13 +89,10 @@ When the user asks to run or validate E2E tests:
    - Install or register `azure-functions-skills` using the documented flow for that mode.
    - Verify whether the dependent `azure-skills` surfaces are present or whether clear install guidance is shown.
    - Launch the actual coding-agent CLI with an inspection prompt. The prompt must ask it to report visible/usable `agents`, `skills`, `prompts`, `mcp`, `hooks`, plugin surfaces, and Azure Skills dependency surfaces. Treat missing agent-response evidence as `blocked` or `fail` according to the cause.
-   - For `chat`, use the `azure-functions-skills chat` command itself as the launcher under test and pass agent-specific noninteractive options through to the selected coding-agent CLI. Verify `chat` auto-setup, startup prompt delivery, launcher selection, and the resulting agent-visible artifact from the same command. Do not bypass `chat` with a direct `copilot`, `claude`, or `codex` command unless the pass-through command is unavailable or fails and you are collecting follow-up diagnosis.
+   - For `chat`, use the `azure-functions-skills chat` command itself as the launcher under test and follow the agent-specific proof method in [scenarios.md](references/scenarios.md). Direct agent commands are diagnostics only unless the scenario reference explicitly allows them.
 4. For plugin scenarios, the command sequence is part of the test contract:
-   - Every plugin scenario must begin with pre-state discovery (`plugin list`, `marketplace list`, `plugin details`, or the closest current CLI help/list command), then a cleanup step, then install/register, then post-install state, then agent inspection.
-   - GitHub Copilot CLI must follow README order after cleanup: `copilot plugin marketplace add Azure/azure-functions-skills`, then `copilot plugin install azure-functions-skills@azure-functions-skills`, then run Copilot with the Functions agent, for example `copilot --agent functions-copilot -p "<inspection prompt>"`.
-   - For GitHub Copilot CLI, if `copilot plugin list` shows `azure-functions-skills`, run `copilot plugin uninstall azure-functions-skills` when approved before reinstalling. If the uninstall command is unavailable, fails, or is interactive-only with no approval path, classify cleanup as `blocked` and do not mark the plugin scenario `pass`.
-   - Claude Code must follow the README plugin-from-source flow after cleanup: clone or use the repo source, run `claude --add-dir <plugin-payload-dir>`, then run Claude with an inspection prompt in the isolated workspace. If testing installed Claude plugins rather than `--add-dir`, inspect `claude plugin list` and uninstall the existing target plugin with `claude plugin uninstall/remove` when approved before reinstalling.
-   - Codex must follow the README Codex plugin flow after cleanup: `codex plugin marketplace add Azure/azure-functions-skills`, install/select `azure-functions-skills` from `/plugins` when supported, then run Codex with an inspection prompt in the isolated workspace. If Codex exposes `plugin remove`, `marketplace remove`, or an isolated config override, use it for target cleanup when approved; if only interactive `/plugins` can select/uninstall, record that as blocked unless the user completes the interaction.
+   - Every plugin scenario must begin with pre-state discovery, then target cleanup, then install/register, then post-install state, then agent inspection. Existing plugin installation is normal pre-state, not a failure, but reuse without cleanup/isolation cannot pass a fresh-install scenario.
+   - Follow the cleanup/install commands in [scenarios.md](references/scenarios.md). If cleanup mutates user-level state, ask for approval first. If cleanup is unavailable, denied, unsupported, or interactive-only, classify cleanup as `blocked` and do not mark the plugin scenario `pass`.
    - Do not uninstall unrelated plugins. Do not uninstall the dependent `azure-skills` plugin unless the selected dependency scenario explicitly requires a missing-dependency state and the user approves it. Otherwise record whether Azure Skills is present or absent.
    - If a documented plugin command is unavailable, interactive-only, or contradicts current CLI help, record the command attempt and classify the scenario as `blocked` or `fail` with analysis; do not silently substitute setup-mode file checks.
 5. Capture every command used for evaluation:
@@ -133,22 +107,7 @@ When the user asks to run or validate E2E tests:
 7. Authentication and local prerequisites:
    - Because this starts as a local E2E workflow, it is acceptable to ask the user to authenticate, approve a CLI prompt, reload VS Code, or run a one-time login when a real agent/plugin flow is blocked by auth.
    - Do not mark auth-blocked scenarios as fail unless authentication should already have been available according to the scenario contract; otherwise use `blocked` with clear next steps.
-8. Prefer automation-friendly CLI options before asking the user for manual interaction:
-   - **Inspection artifacts**: require each setup/chat/plugin inspection prompt to produce or be captured into a parseable JSON artifact such as `e2e-chat-inspection.json`. The artifact should include `agent`, `workspaceRoot`, `startupContextVisible`, `skills`, `mcpServers`, `hooks`, `agents`, `passed`, and `notes`. The runner must parse this artifact and compare the reported surfaces against the dynamic inventory before marking the scenario `pass`.
-    - **Agent file writes**: for chat scenarios, prefer proving the new `chat` pass-through path by letting the real agent create `e2e-chat-inspection.json` or by using the agent's output-file option through `chat`. Grant write permissions only inside the isolated scenario workspace. For setup/plugin visibility checks that do not need to prove file editing, capture the noninteractive response to a file outside the agent, for example with shell redirection or an output-file CLI option.
-   - **Workspace root verification**: ask the agent to report the workspace root it inspected. If the reported root is the repository root or any directory outside the isolated scenario workspace, mark the inspection `fail` or rerun from a safer external disposable workspace and record the reason.
-    - **Chat pass-through inspection**: pass agent-specific headless options after the `chat` options. The `chat` command intentionally forwards unrecognized options to the selected agent CLI. Use this as the primary chat E2E path so the same command proves launcher behavior and agent-visible proof. If a pass-through command fails, record the exact command and stderr, then use a direct agent command only as a diagnostic comparison.
-       - GitHub Copilot example: `azure-functions-skills chat --agent github-copilot --dir <workspace> --skip-prerequisites -p "<inspection prompt>" --yolo --no-ask-user --output-format json --silent`.
-       - Claude Code example: `azure-functions-skills chat --agent claude-code --dir <workspace> --prompt "<inspection prompt>" --skip-prerequisites -p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob,Write`.
-       - Codex example: `azure-functions-skills chat --agent codex --dir <workspace> --prompt "<inspection prompt>" --skip-prerequisites exec --sandbox workspace-write --json --output-last-message e2e-chat-inspection.txt --ephemeral --skip-git-repo-check --cd <workspace>`.
-   - **Claude Code prompt runs**: use `claude -p` / `claude --print` so the command prints and exits. Prefer `--output-format json`, `--no-session-persistence`, `--permission-mode dontAsk`, and a minimal `--tools Read,LS,Grep,Glob` tool set for inspection prompts. Use `--include-hook-events` only with `--output-format=stream-json` when hook evidence is required.
-     For parseable inspection artifacts, `--output-format text` with a prompt that requires raw JSON can be easier to validate than Claude's wrapper JSON. For setup scenarios, use the installer target name `claude`; reserve `claude-code` for the `chat` launcher agent id unless CLI help documents otherwise.
-   - **Claude Code plugin/source runs**: prefer session-scoped `--plugin-dir <plugin-payload-dir>` when the CLI supports it because it loads a plugin for the current run without mutating global plugin state. If the README still documents `--add-dir`, record both the README command contract and the current `--plugin-dir` automation equivalent, and classify any docs mismatch in `docs-command-consistency`.
-   - **Claude Code installed plugin cleanup**: use `claude plugin list --json` for pre/post-state, `claude plugin install <plugin> --scope local|project|user` when testing installed plugin flows, and `claude plugin uninstall|remove <plugin> --scope <scope> -y` for approved cleanup. Use `--keep-data` when preserving plugin data matters.
-   - **Codex prompt runs**: use `codex exec` for noninteractive inspection. Prefer `--sandbox read-only` for visibility checks, `--json` for machine-readable transcripts, `--output-last-message <file>` for concise report excerpts, `--ephemeral` to avoid session persistence, `--skip-git-repo-check` for empty isolated workspaces, and `--cd <workspace>` instead of relying on inherited cwd. Use `--dangerously-bypass-approvals-and-sandbox` only inside an external sandbox and only when the scenario explicitly requires write/execute behavior.
-       For visibility artifacts, combine `--output-last-message e2e-chat-inspection.json` with a prompt that requires raw JSON only, then parse that file and keep the full `--json` transcript as separate evidence.
-   - **Codex plugin marketplace cleanup**: use `codex plugin marketplace remove <name>` and `codex plugin marketplace add <source>` for approved marketplace cleanup/re-registration. As of Codex CLI 0.130.0, `codex plugin --help` exposes marketplace management but no noninteractive plugin install/select/list command; if `/plugins` is required, record the help output and mark install/select `blocked` unless the user completes the interactive step.
-   - **Alternate screen/TUI capture**: when a CLI still launches an interactive TUI, look for options such as Codex `--no-alt-screen` or a print/exec mode before asking the user to operate the UI. If no noninteractive route exists, record the TUI limitation as evidence.
+8. Prefer automation-friendly CLI options before asking the user for manual interaction. The exact command shapes live in [scenarios.md](references/scenarios.md); use them as the source of truth for GitHub Copilot, Claude Code, and Codex setup/chat/plugin inspection.
 9. If an agent or mode cannot support a surface, report `unsupported` with a reason. If a CLI hangs, lacks authentication, or cannot safely isolate plugin state, report `blocked`. If a surface should work but does not, report `fail` with failure analysis.
 10. Run local static checks as follow-up: `npm run check` when practical, or focused tests when the user asks for a narrow scope.
 11. Do not run live Azure scenarios unless the user explicitly asks and the protected Azure/OIDC environment is available.
@@ -193,7 +152,8 @@ At the end of every run, after cross-checking the report, overwrite `reports/e2e
 
 5. **Create the report**
    - Include scenario x agent support status, versions, test datetime, platform, failure evidence, unsupported reasons, and recommended fixes.
-   - Include a capability surface matrix for GitHub Copilot, Claude Code, and Codex across `plugin`, `skills`, `prompts`, `mcp`, `hooks`, and `agents`.
+   - Include a capability surface matrix for GitHub Copilot, Claude Code, and Codex across `plugin`, `skills`, `prompts/guidance`, `mcp`, `hooks`, `agent definitions/guidance`, and `chat`.
+   - In the capability surface matrix, distinguish file/layout support from runtime active-context proof. For example, Claude `agents` metadata can be `unsupported` while Claude `agent guidance` is `pass`; Codex `AGENTS.md` guidance can be `pass` while Codex plugin custom-agent activation is `warning` or `unsupported` if not visible.
    - Include detailed evidence for how each surface was checked: dynamic inventory source, generated file path, launch command, agent response excerpt, and unsupported/block/fail reason.
    - Include the final execution commands for every scenario in `Command Evidence`. The section must show the actual scenario command sequence, not only reusable command patterns or examples.
    - Include collapsed command logs with command, cwd, exit code, and redacted output.

--- a/.github/skills/azure-functions-e2e-tests/references/report-schema.md
+++ b/.github/skills/azure-functions-e2e-tests/references/report-schema.md
@@ -123,7 +123,7 @@ Checks should cite dynamic inventory paths instead of assuming a fixed template 
 
 ## Inspection artifact record
 
-Agent-visible setup, chat, and plugin checks should include a parseable inspection artifact. The artifact can be the agent's raw JSON response captured by the runner; it does not have to be written by the agent with edit tools.
+Agent-visible setup, chat, and plugin checks should include a durable inspection artifact. Prefer parseable JSON. For GitHub Copilot chat, Markdown such as `artifact.md` is acceptable when it is produced through the normal `azure-functions-skills chat --agent github-copilot --prompt ...` launcher path and includes the required workspace root and surface inventory. The artifact can be the agent's raw response captured by the runner; it does not have to be written by the agent with edit tools unless the scenario uses artifact writing as the proof mechanism.
 
 ```json
 {
@@ -141,13 +141,13 @@ Agent-visible setup, chat, and plugin checks should include a parseable inspecti
 
 Validation rules:
 
-- The artifact file must exist, be non-empty, and parse as JSON.
+- The artifact file must exist and be non-empty. JSON artifacts must parse as JSON; Markdown artifacts must be explicitly allowed by the scenario and contain the required fields or clearly labeled equivalents.
 - `workspaceRoot` must identify the isolated scenario workspace or an explicitly documented external disposable workspace.
 - `skills`, `mcpServers`, `hooks`, and `agents` must be checked against the dynamic inventory and agent support matrix.
 - Missing surfaces require an explicit unsupported, blocked, or fail reason in `notes` or the scenario checks.
-- A scenario cannot be `pass` when the inspection artifact is missing, invalid, or only proves generated files without real-agent visibility.
+- A scenario cannot be `pass` when the inspection artifact is missing, invalid for its declared format, or only proves generated files without real-agent visibility.
 
-For plugin scenarios, command logs must prove the documented install sequence was attempted before any plugin visibility result is marked `pass` or `warning`. For example, GitHub Copilot plugin evidence must include `copilot plugin marketplace add Azure/azure-functions-skills`, `copilot plugin install azure-functions-skills@azure-functions-skills`, and a post-install `copilot --agent functions-copilot ...` inspection command. If those required commands are missing, fail, time out, or do not prove visibility, classify the scenario as `fail` or `blocked`, not `warning`.
+For plugin scenarios, command logs must prove the documented install sequence was attempted before any plugin visibility result is marked `pass` or `warning`. For example, GitHub Copilot plugin evidence must include pre-state discovery, target cleanup (`copilot plugin uninstall azure-functions-skills` and `copilot plugin marketplace remove azure-functions-skills`, or clean pre-state evidence), `copilot plugin marketplace add Azure/azure-functions-skills`, `copilot plugin install azure-functions-skills@azure-functions-skills`, post-state discovery, and a post-install qualified plugin-agent inspection such as `copilot --agent azure-functions-skills:functions-copilot ...`. If those required commands are missing, fail, time out, or do not prove visibility, classify the scenario as `fail` or `blocked`, not `warning`.
 
 Plugin scenarios must also prove fresh-install semantics. A plugin scenario cannot be `pass` unless evidence includes:
 

--- a/.github/skills/azure-functions-e2e-tests/references/scenarios.md
+++ b/.github/skills/azure-functions-e2e-tests/references/scenarios.md
@@ -22,6 +22,7 @@ Before running scenarios, inspect the current repository and record:
 - MCP definitions from `templates/mcp/` and generated target-specific MCP files.
 - Hook templates from `templates/hooks/` and generated target-specific hook files.
 - Agent definitions from `templates/agents/` and generated target-specific agent files.
+- Target-specific agent guidance semantics: GitHub Copilot custom agent definitions, Claude Code `CLAUDE.md` guidance, and Codex `AGENTS.md` guidance are not interchangeable and must be reported separately.
 - Plugin payload manifests and directories from `.github/plugins/azure-functions-skills/` or the built plugin output.
 - Azure Skills dependency expectations from README, setup guidance, and generated skills text.
 
@@ -32,6 +33,37 @@ The report should include the inventory counts and paths used for each run. If a
 All scenario commands that can write files must run from an isolated scenario workspace under `reports/e2e/<run-id>/workspaces/<scenario-id>/`. This includes setup commands, chat commands, real-agent inspection prompts, and any CLI help/discovery command that could accidentally execute setup or chat behavior. Do not run these commands from the repository root.
 
 When invoking this repository's CLI, pass `--dir <scenario-workspace>` explicitly and set the process cwd to that scenario workspace whenever practical. If a command must run from the repository root to access source files, record why it is read-only or otherwise safe, and verify afterward that no root-level `.agents`, `.claude`, `.codex`, `.github/agents`, `.github/hooks`, `.github/skills/<non-e2e>`, `AGENTS.md`, or `CLAUDE.md` artifacts were created.
+
+Resolve scenario paths from the repository root rather than hard-coding drive letters or host-specific absolute paths. Use `git rev-parse --show-toplevel`, `Join-Path` in PowerShell, and quoted variables in Bash. Do not keep relative `reports/e2e/...` variables after changing cwd; this causes nested scenario workspaces. If cwd drift creates a nested scenario workspace, mark that evidence harness-invalid and rerun the scenario from a clean sibling workspace.
+
+PowerShell pattern:
+
+```powershell
+$Repo = (git rev-parse --show-toplevel).Trim()
+$RunDir = Join-Path $Repo 'reports/e2e/<run-id>'
+$Workspaces = Join-Path $RunDir 'workspaces'
+$workspace = Join-Path $Workspaces '<scenario-id>'
+New-Item -ItemType Directory -Force -Path $workspace | Out-Null
+Push-Location $workspace
+try {
+  # scenario command with --dir . when practical
+} finally {
+  Pop-Location
+}
+```
+
+Bash pattern:
+
+```bash
+repo="$(git rev-parse --show-toplevel)"
+run_dir="$repo/reports/e2e/<run-id>"
+workspace="$run_dir/workspaces/<scenario-id>"
+mkdir -p "$workspace"
+(
+  cd "$workspace"
+  # scenario command with --dir . when practical
+)
+```
 
 Run directories under `reports/e2e/<run-id>/` are analysis-only. The shareable commit artifact is `reports/e2e/current/report.html`, which should be overwritten with the reviewed report at the end of the run.
 
@@ -58,9 +90,9 @@ File checks alone are insufficient for `pass` because they do not prove the codi
 
 ### Inspection artifact requirement
 
-Setup, chat, and plugin scenarios should capture the real-agent inspection response into a parseable JSON artifact, normally `e2e-chat-inspection.json` or `e2e-agent-inspection.json`, in the scenario workspace. For chat scenarios, prefer producing the artifact through `azure-functions-skills chat` pass-through arguments so the test exercises the real chat launcher and the target agent in one command. The runner may write this artifact from noninteractive agent output when the scenario is not specifically testing write behavior.
+Setup, chat, and plugin scenarios should capture the real-agent inspection response into a durable artifact in the scenario workspace. Prefer parseable JSON, normally `e2e-chat-inspection.json` or `e2e-agent-inspection.json`. For GitHub Copilot chat, a Markdown artifact such as `artifact.md` is acceptable when it is produced by the normal `chat --prompt ...` launcher path and contains the required workspace root and surface inventory. For Claude Code and Codex chat scenarios, prefer producing the artifact through `azure-functions-skills chat` pass-through arguments so the test exercises the real chat launcher and the target agent in one command. The runner may write this artifact from noninteractive agent output when the scenario is not specifically testing write behavior.
 
-The inspection prompt should require raw JSON with these fields:
+JSON inspection prompts should require these fields. GitHub Copilot chat may use a Markdown artifact instead, but the artifact must include equivalent labels for the same data.
 
 ```json
 {
@@ -76,16 +108,21 @@ The inspection prompt should require raw JSON with these fields:
 }
 ```
 
-The runner must parse the artifact, verify `workspaceRoot` is the isolated scenario workspace, and compare reported surfaces with the dynamic inventory. If the artifact is missing, invalid JSON, empty, reports the repository root instead of the scenario workspace, or omits required surfaces without an unsupported/block reason, classify the inspection check as `fail` or `blocked`.
+The runner must parse JSON artifacts or review Markdown artifacts, verify `workspaceRoot` is the isolated scenario workspace, and compare reported surfaces with the dynamic inventory. If the artifact is missing, empty, invalid for its declared format, reports the repository root instead of the scenario workspace, or omits required surfaces without an unsupported/block reason, classify the inspection check as `fail` or `blocked`.
 
-Do not rely on an interactive `chat` command to write this file. Use the `chat` command's pass-through behavior to select each agent's noninteractive mode instead. If pass-through fails, record that as chat evidence and use a direct agent command only as a diagnostic follow-up, not as a substitute for passing the chat scenario.
+Do not rely on an unobserved interactive `chat` command with no durable artifact. For GitHub Copilot, the primary chat proof is the normal `chat --agent github-copilot` launcher path with either headless Copilot passthrough that returns parseable output or a prompt that writes `artifact.md`/`e2e-chat-inspection.json` inside the scenario workspace. Do not use `chat --agent ghcp`; `ghcp` is the setup target id, not the chat launcher id. Do not use `chat --agent azure-functions-skills:functions-copilot`; that qualified id belongs to direct installed-plugin Copilot inspection, not this package's `chat --agent` option. For Claude Code and Codex, prefer the `chat` command's pass-through behavior to select noninteractive modes. If pass-through fails, record that as chat evidence and use a direct agent command only as a diagnostic follow-up, not as a substitute for passing the chat scenario.
 
 Recommended chat inspection command shapes:
 
 ```powershell
-# GitHub Copilot: pass noninteractive prompt and permission flags through chat.
-azure-functions-skills chat --agent github-copilot --dir <workspace> --skip-prerequisites `
-  -p "<inspection prompt>" --yolo --no-ask-user --output-format json --silent
+# GitHub Copilot: exercise workspace-local agent discovery through chat's normal launcher.
+Push-Location <workspace>
+try {
+  azure-functions-skills chat --agent github-copilot --dir . --skip-prerequisites `
+    --output-format json -s --allow-all --no-ask-user -p "Inspect visible Azure Functions skills, agents, MCP, hooks, startup context, and workspace root. Return raw JSON with passed=true when visible."
+} finally {
+  Pop-Location
+}
 
 # Claude Code: chat inserts --prompt content after -p/--print and forwards the rest.
 azure-functions-skills chat --agent claude-code --dir <workspace> --skip-prerequisites `
@@ -98,7 +135,7 @@ azure-functions-skills chat --agent codex --dir <workspace> --skip-prerequisites
   --output-last-message e2e-chat-inspection.txt --ephemeral --skip-git-repo-check --cd <workspace>
 ```
 
-For GitHub Copilot, parse JSONL stdout and preserve the `session.skills_loaded` and final assistant message events as evidence. For Claude Code, parse the requested raw JSON artifact or stdout text. For Codex, parse the `--output-last-message` file and keep the full `--json` transcript as command evidence.
+For GitHub Copilot chat, parse the raw JSON/stdout returned by the chat-launched Copilot process or parse the workspace artifact produced by the agent, and keep command output as evidence. Direct `copilot -p --output-format json` is useful for installed-plugin inspection and diagnostics, but it is not equivalent to the workspace-local `chat` launcher path and should not be the primary proof for `chat-welcome-ghcp`. For Claude Code, parse the requested raw JSON artifact or stdout text. For Codex, parse the `--output-last-message` file and keep the full `--json` transcript as command evidence.
 
 ## Fresh plugin install requirements
 
@@ -114,17 +151,34 @@ Plugin scenario inspection commands must run from that scenario's workspace unde
 
 If cleanup would mutate user-level state and approval is unavailable, mark the cleanup check `blocked`. If a CLI does not expose uninstall/select/list commands outside an interactive UI, record the command/help output and classify the plugin scenario as `blocked` unless the user completes the interaction. Do not uninstall unrelated plugins. Do not uninstall the dependent `azure-skills` plugin unless the selected dependency scenario explicitly requires a missing-dependency state and the user approves it.
 
+Start plugin scenarios with cleanup after pre-state discovery. The cleanup command sequence is stable enough to document directly per host. Treat "not installed" or "not registered" as a clean pre-state for the target phase and continue. Treat existing installation as normal pre-state, not as a failure.
+
+GitHub Copilot cleanup/install sequence:
+
+```powershell
+copilot plugin list
+copilot plugin marketplace list
+copilot plugin uninstall azure-functions-skills
+copilot plugin marketplace remove azure-functions-skills
+copilot plugin marketplace add Azure/azure-functions-skills
+copilot plugin install azure-functions-skills@azure-functions-skills
+copilot plugin list
+copilot --agent azure-functions-skills:functions-copilot -p "<inspection prompt>" --output-format json -s --allow-all --no-ask-user
+```
+
+Linux/macOS shells use the same `copilot` subcommands; quote the inspection prompt with single quotes or pass it through a variable. Do not remove `azure-skills` or any unrelated plugin during this scenario.
+
 ## Automation-friendly command patterns
 
-Use noninteractive CLI modes whenever they can preserve the scenario contract:
+Use noninteractive CLI modes whenever they can preserve the scenario contract. Keep this section to host-specific caveats; scenario command contracts above remain the source of truth.
 
 - Claude Code inspection prompts should use `claude -p` / `claude --print` with `--output-format json` when practical, `--no-session-persistence`, `--permission-mode dontAsk`, and a small tool allowlist such as `--tools Read,LS,Grep,Glob`.
-- Claude Code parseable artifact prompts may use `--output-format text` plus shell redirection to `e2e-chat-inspection.json` when the prompt requires raw JSON only. For chat scenarios, pass `-p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob,Write` through `azure-functions-skills chat`; use `--prompt "<inspection prompt>"` for the inspection text. Use `setup --agent claude` for setup-mode installation; `claude-code` is the chat launcher id unless current CLI help says otherwise.
+- Claude Code parseable artifact prompts may use `--output-format text` plus shell redirection to `e2e-chat-inspection.json` when the prompt requires raw JSON only. Use `setup --agent claude` for setup-mode installation; `claude-code` is the chat launcher id unless current CLI help says otherwise.
 - Claude Code session-scoped plugin tests should prefer `--plugin-dir <plugin-payload-dir>` when available. This loads a plugin for the current run only and avoids manual/global install state. If the README command is still `--add-dir`, record whether `--add-dir` and `--plugin-dir` are equivalent or whether README needs to be updated.
 - Claude Code installed plugin tests should use `claude plugin list --json`, `claude plugin install <plugin> --scope local|project|user`, and `claude plugin uninstall|remove <plugin> --scope <scope> -y` for approved fresh-install cleanup.
 - Codex inspection prompts should use `codex exec --sandbox read-only --json --output-last-message <file> --ephemeral --skip-git-repo-check --cd <workspace> <prompt>` when practical.
-- For Codex, keep the `--json` transcript as command evidence and parse the `--output-last-message` file as the concise inspection artifact. For chat scenarios, pass `exec --sandbox read-only|workspace-write --json --output-last-message <file> --ephemeral --skip-git-repo-check --cd <workspace>` through `azure-functions-skills chat`; do not use bare `codex <prompt>` for non-TTY E2E.
-- Codex marketplace cleanup can use `codex plugin marketplace remove <name>` followed by `codex plugin marketplace add <source>` when approved. Current Codex CLI 0.130.0 exposes marketplace management but no noninteractive plugin install/select/list command; plugin activation from `/plugins` remains `blocked` unless the user completes the interaction or a newer CLI exposes an automation option.
+- For Codex, keep the `--json` transcript as command evidence and parse the `--output-last-message` file as the concise inspection artifact. Do not use bare `codex <prompt>` for non-TTY E2E.
+- Codex marketplace cleanup can use `codex plugin marketplace remove <name>` followed by `codex plugin marketplace add <source>` when approved. Current Codex CLI versions may expose noninteractive plugin installation through `codex plugin add <plugin>@<marketplace>` or `codex plugin add <plugin> --marketplace <marketplace>`; prefer that automation-friendly form when help output confirms it. If the installed Codex CLI lacks noninteractive plugin add/list/remove support, plugin activation from `/plugins` remains `blocked` unless the user completes the interaction or an isolated profile proves activation.
 - If a TUI opens despite these options, capture the help output showing the missing noninteractive path and classify the scenario instead of waiting indefinitely.
 
 ## Initial scenarios
@@ -181,7 +235,8 @@ Use noninteractive CLI modes whenever they can preserve the scenario contract:
   - Startup prompt detects existing `host.json` when present.
   - Launch command selects `functions-copilot`.
   - Azure Skills dependency check is attempted or clear manual guidance is shown.
-  - A real GitHub Copilot CLI inspection prompt confirms the startup-loaded agent can see or use installed skills, prompts/instructions, MCP, hooks, and agent surfaces.
+  - A real GitHub Copilot CLI run through `azure-functions-skills chat --agent github-copilot --dir .` with headless passthrough (`--output-format json -s --allow-all --no-ask-user -p <inspection prompt>`) or an artifact-writing prompt confirms the startup-loaded agent can see or use installed skills, prompts/instructions, MCP, hooks, and agent surfaces.
+  - Do not fail this scenario solely because a direct `copilot -p` headless diagnostic cannot select the workspace-local `functions-copilot` agent. That diagnostic uses a different discovery path than the chat launcher.
 
 ### `chat-welcome-claude`
 
@@ -215,19 +270,20 @@ Use noninteractive CLI modes whenever they can preserve the scenario contract:
 - Purpose: verify repository plugin installation and discoverability in GitHub Copilot.
 - Command contract:
   1. Run `copilot plugin marketplace list` and `copilot plugin list` or the current CLI equivalents and record whether `azure-functions-skills` is already registered/installed.
-  2. If `azure-functions-skills` is installed, run `copilot plugin uninstall azure-functions-skills` after approval, or use an isolated Copilot plugin config if the CLI supports it. If this cannot be done, mark cleanup `blocked` and do not mark the scenario `pass`.
-  3. Run `copilot plugin marketplace add Azure/azure-functions-skills`.
-  4. Run `copilot plugin install azure-functions-skills@azure-functions-skills`.
-  5. Run `copilot plugin list` and, when available, plugin details to prove post-install state.
-  6. Run `copilot --agent functions-copilot -p "<inspection prompt>"` or the current documented equivalent from README/CLI help.
+  2. Run `copilot plugin uninstall azure-functions-skills` after approval. If the target plugin is absent, record that as clean pre-state and continue. If this cannot be done and no isolated Copilot plugin config is available, mark cleanup `blocked` and do not mark the scenario `pass`.
+  3. Run `copilot plugin marketplace remove azure-functions-skills` after approval. If the target marketplace is absent, record that as clean pre-state and continue.
+  4. Run `copilot plugin marketplace add Azure/azure-functions-skills`.
+  5. Run `copilot plugin install azure-functions-skills@azure-functions-skills`.
+  6. Run `copilot plugin list` and, when available, plugin details to prove post-install state.
+  7. Run `copilot --agent azure-functions-skills:functions-copilot -p "<inspection prompt>" --output-format json -s --allow-all --no-ask-user` or the current qualified installed-plugin agent equivalent from CLI help/error output.
 - Required checks:
   - Existing plugin registration is discovered and then cleared or isolated safely; if global cleanup is unsafe, denied, or unsupported, record `blocked` for cleanup and continue only with a proven isolated registration when possible.
   - The uninstall/remove command for the target plugin is recorded when the plugin was present before the run.
   - The documented marketplace add command completes or produces an auth/approval `blocked` result.
   - The documented plugin install command completes or produces an auth/approval `blocked` result.
   - Post-install plugin state is recorded.
-  - The post-install Copilot command runs with `--agent functions-copilot` and an inspection prompt.
-  - `functions-copilot` agent is discoverable.
+  - The post-install Copilot command runs with the installed-plugin agent, normally `--agent azure-functions-skills:functions-copilot`, and an inspection prompt.
+  - `functions-copilot` agent is discoverable through the installed plugin. A qualified plugin agent name is expected and should not be reported as a docs or product failure.
   - Every skill from the dynamic inventory is discoverable from the plugin payload or by the agent.
   - MCP configuration is discoverable and usable when supported.
   - Hooks are discoverable or documented as unsupported.

--- a/.github/skills/azure-functions-e2e-tests/references/support-matrix.md
+++ b/.github/skills/azure-functions-e2e-tests/references/support-matrix.md
@@ -27,7 +27,7 @@ Use these definitions to keep support status consistent across agents and scenar
 | --- | --- | --- | --- |
 | `setup-workspace-*` | Expected supported | Expected supported | Expected supported |
 | `chat-welcome-*` | Expected supported | Expected supported | Expected supported |
-| `plugin-install-*` | Expected supported only after README command sequence and `functions-copilot` inspection pass | Expected supported/partial only after README `claude --add-dir` flow and inspection pass; otherwise fail/blocked/unsupported | Expected supported/partial only after README Codex marketplace flow and inspection pass; otherwise fail/blocked/unsupported |
+| `plugin-install-*` | Expected supported only after cleanup-first README command sequence and qualified installed-plugin inspection such as `azure-functions-skills:functions-copilot` pass | Expected supported/partial only after README `claude --add-dir` flow and inspection pass; otherwise fail/blocked/unsupported | Expected supported/partial only after README Codex marketplace flow and inspection pass; otherwise fail/blocked/unsupported |
 | `docs-command-consistency` | Shared static scenario | Shared static scenario | Shared static scenario |
 | `basic-help-prompt` | Expected supported | Expected supported | Expected supported |
 | `azure-skills-dependency` | Expected supported | Not applicable unless Claude dependency flow exists | Expected supported where plugin flow supports it |

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -16,7 +16,7 @@ import { join } from 'node:path';
 const args = process.argv.slice(2);
 const command = args[0];
 
-if (!command || command === '--help' || command === '-h') {
+function printHelp() {
   console.log(`
   @agent-loom/azure-functions-skills — AI assistant plugins for Azure Functions
 
@@ -52,6 +52,10 @@ if (!command || command === '--help' || command === '-h') {
     npx @agent-loom/azure-functions-skills chat
     npx @agent-loom/azure-functions-skills chat --as-plugin --agent claude-code
   `);
+}
+
+if (!command || command === '--help' || command === '-h') {
+  printHelp();
   process.exit(0);
 }
 
@@ -131,6 +135,13 @@ if (command === 'setup') {
   }
 } else if (command === 'chat') {
   const { chat, detectCliAgents } = await import('../lib/chat/index.js');
+
+  const separatorIndex = args.indexOf('--', 1);
+  const commandArgs = separatorIndex === -1 ? args.slice(1) : args.slice(1, separatorIndex);
+  if (commandArgs.includes('--help') || commandArgs.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
 
   let agent = null;
   let prompt = null;

--- a/reports/e2e/current/report.html
+++ b/reports/e2e/current/report.html
@@ -3,176 +3,283 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Azure Functions Skills E2E Report - 20260519T-manual</title>
+  <title>Azure Functions Skills E2E Report - 20260519T063710Z-fresh</title>
   <style>
-    :root { --ok:#137333; --warn:#b06000; --block:#7b1fa2; --fail:#b3261e; --ink:#1f2937; --muted:#5f6b7a; --line:#d7dde5; --bg:#f7f9fc; --card:#fff; }
-    body { margin:0; font-family:Segoe UI, Arial, sans-serif; color:var(--ink); background:var(--bg); }
-    header { background:#0f172a; color:white; padding:28px 36px; }
-    main { max-width:1160px; margin:0 auto; padding:28px 24px 48px; }
-    h1 { margin:0 0 8px; font-size:28px; }
-    h2 { margin:28px 0 12px; font-size:20px; }
+    :root { color-scheme: light; --ok:#166534; --warn:#92400e; --fail:#991b1b; --ink:#111827; --muted:#4b5563; --line:#d1d5db; --bg:#f8fafc; --panel:#ffffff; }
+    body { margin:0; font-family: Segoe UI, Arial, sans-serif; color:var(--ink); background:var(--bg); line-height:1.45; }
+    header, main { max-width:1180px; margin:0 auto; padding:24px; }
+    header { padding-top:32px; }
+    h1 { margin:0 0 8px; font-size:30px; letter-spacing:0; }
+    h2 { margin:30px 0 10px; font-size:20px; }
     h3 { margin:18px 0 8px; font-size:16px; }
-    p { line-height:1.55; }
-    .meta { color:#cbd5e1; margin:0; }
-    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:12px; }
-    .card { background:var(--card); border:1px solid var(--line); border-radius:8px; padding:16px; }
-    .metric { font-size:28px; font-weight:700; }
-    .ok { color:var(--ok); } .warn { color:var(--warn); } .block { color:var(--block); } .fail { color:var(--fail); }
-    table { width:100%; border-collapse:collapse; background:white; border:1px solid var(--line); }
-    th, td { border-bottom:1px solid var(--line); padding:10px 12px; text-align:left; vertical-align:top; }
+    p { margin:8px 0; }
+    .meta, .note { color:var(--muted); }
+    .grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:12px; margin:18px 0; }
+    .metric { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:14px; }
+    .metric strong { display:block; font-size:28px; margin-bottom:4px; }
+    table { width:100%; border-collapse:collapse; background:var(--panel); border:1px solid var(--line); }
+    th, td { padding:10px; border-bottom:1px solid var(--line); vertical-align:top; text-align:left; }
     th { background:#eef2f7; font-weight:600; }
-    tr:last-child td { border-bottom:none; }
-    .badge { display:inline-block; border-radius:999px; padding:2px 9px; font-size:12px; font-weight:700; border:1px solid currentColor; }
-    .small { color:var(--muted); font-size:13px; }
-    code { background:#eef2f7; padding:1px 4px; border-radius:4px; }
-    pre { white-space:pre-wrap; overflow:auto; background:#111827; color:#e5e7eb; padding:12px; border-radius:8px; }
-    details { background:white; border:1px solid var(--line); border-radius:8px; padding:10px 12px; margin:10px 0; }
+    code { font-family: Consolas, monospace; font-size:0.95em; }
+    .pill { display:inline-block; min-width:64px; text-align:center; border-radius:999px; padding:2px 8px; font-weight:600; font-size:12px; }
+    .pass { color:var(--ok); background:#dcfce7; }
+    .warning { color:var(--warn); background:#fef3c7; }
+    .fail { color:var(--fail); background:#fee2e2; }
+    .unsupported { color:#374151; background:#e5e7eb; }
+    details { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:10px 12px; margin:10px 0; }
     summary { cursor:pointer; font-weight:600; }
+    ul { margin:8px 0 8px 22px; padding:0; }
+    @media (max-width:800px) { .grid { grid-template-columns:1fr 1fr; } header, main { padding:18px; } table { font-size:14px; } }
   </style>
 </head>
 <body>
-<header>
-  <h1>Azure Functions Skills E2E Report</h1>
-  <p class="meta">Run ID: 20260519T-manual | Package: @agent-loom/azure-functions-skills 0.11.3 | OS: Windows | Method: manual one-scenario-at-a-time</p>
-</header>
-<main>
-  <section class="grid">
-    <div class="card"><div class="metric ok">8</div><div>Pass</div></div>
-    <div class="card"><div class="metric warn">3</div><div>Warning</div></div>
-    <div class="card"><div class="metric block">1</div><div>Blocked</div></div>
-    <div class="card"><div class="metric fail">0</div><div>Fail</div></div>
-  </section>
+  <header>
+    <h1>Azure Functions Skills E2E Report</h1>
+    <p class="meta">Fresh run <code>20260519T063710Z-fresh</code>. Existing reports were not used as input.</p>
+    <p>This run exercised the default local matrix across GitHub Copilot CLI, Claude Code, and Codex for setup, chat, plugin, basic help, docs consistency, and Azure Skills dependency visibility.</p>
+    <div class="grid">
+      <div class="metric"><strong>12</strong><span>Total scenarios</span></div>
+      <div class="metric"><strong>9</strong><span>Pass</span></div>
+      <div class="metric"><strong>3</strong><span>Warning</span></div>
+      <div class="metric"><strong>0</strong><span>Fail</span></div>
+    </div>
+  </header>
+  <main>
+    <section>
+      <h2>Run Context</h2>
+      <table>
+        <tr><th>Item</th><th>Evidence</th></tr>
+        <tr><td>Package</td><td><code>@agent-loom/azure-functions-skills</code> <code>0.11.3</code></td></tr>
+        <tr><td>Runtime</td><td>Windows; Node <code>v22.17.0</code>; npm <code>10.9.2</code></td></tr>
+        <tr><td>Agents</td><td>GitHub Copilot CLI <code>1.0.49</code>; Claude Code <code>2.1.143</code>; Codex CLI <code>0.131.0</code></td></tr>
+        <tr><td>Inventory</td><td>9 skills, 1 startup prompt, 1 MCP server, 1 hook template, 2 agent templates, plugin payload under <code>.github/plugins/azure-functions-skills</code></td></tr>
+        <tr><td>Isolation</td><td>Scenario workspaces under <code>reports/e2e/20260519T063710Z-fresh/workspaces/</code>; transcripts under <code>reports/e2e/20260519T063710Z-fresh/transcripts/</code></td></tr>
+      </table>
+    </section>
 
-  <h2>Executive Summary</h2>
-  <div class="card">
-    <p>The full local E2E matrix was rerun from scratch without using previous result files or a custom runner. Each scenario was executed manually in its own workspace under <code>reports/e2e/20260519T-manual/workspaces/</code>, then recorded immediately in the checklist and evidence log.</p>
-    <p>Workspace setup and chat flows passed for GitHub Copilot, Claude Code, and Codex. GitHub Copilot plugin installation passed after target-only cleanup and fresh reinstall. Claude plugin loading worked through <code>--plugin-dir</code>, but native plugin validation failed. Codex marketplace registration worked, but plugin activation is blocked because Codex CLI 0.130.0 has no noninteractive plugin install/select/list command.</p>
-  </div>
+    <section>
+      <h2>Scenario Matrix</h2>
+      <table>
+        <tr><th>Scenario</th><th>Agent</th><th>Status</th><th>Result</th></tr>
+        <tr><td><code>setup-workspace-ghcp</code></td><td>GitHub Copilot</td><td><span class="pill pass">pass</span></td><td>Workspace setup installed GHCP files; real Copilot inspection loaded project skills. Global plugin skills were also visible.</td></tr>
+        <tr><td><code>setup-workspace-claude</code></td><td>Claude Code</td><td><span class="pill pass">pass</span></td><td>Claude saw workspace-local skills, settings, and MCP after setup.</td></tr>
+        <tr><td><code>setup-workspace-codex</code></td><td>Codex</td><td><span class="pill pass">pass</span></td><td>Codex saw AGENTS.md, .codex config/hooks, and all 9 workspace skills.</td></tr>
+        <tr><td><code>chat-welcome-ghcp</code></td><td>GitHub Copilot</td><td><span class="pill pass">pass</span></td><td>Corrected launcher command used <code>--agent github-copilot</code> with headless Copilot passthrough; Copilot loaded the workspace-local <code>functions-copilot</code> agent and all 9 project skills.</td></tr>
+        <tr><td><code>chat-welcome-claude</code></td><td>Claude Code</td><td><span class="pill pass">pass</span></td><td>Chat flow launched Claude and produced agent-visible setup/skill evidence.</td></tr>
+        <tr><td><code>chat-welcome-codex</code></td><td>Codex</td><td><span class="pill pass">pass</span></td><td>Chat flow launched Codex and wrote inspection output confirming skill visibility.</td></tr>
+        <tr><td><code>plugin-install-ghcp</code></td><td>GitHub Copilot</td><td><span class="pill pass">pass</span></td><td>Fresh marketplace/plugin lifecycle completed; qualified installed-plugin agent loaded plugin skills and Azure MCP.</td></tr>
+        <tr><td><code>plugin-install-claude</code></td><td>Claude Code</td><td><span class="pill pass">pass</span></td><td>Claude validate/source flow passed with skills, hooks, and MCP visible. Claude guidance is carried by Claude-specific instructions/skills rather than a registered <code>.agent.md</code> definition.</td></tr>
+        <tr><td><code>plugin-install-codex</code></td><td>Codex</td><td><span class="pill warning">warning</span></td><td>Qualified install passed and skills/MCP were visible. Codex workspace guidance uses <code>AGENTS.md</code>; plugin custom-agent activation was not visible in the inspected session.</td></tr>
+        <tr><td><code>docs-command-consistency</code></td><td>All</td><td><span class="pill warning">warning</span></td><td>README uses unqualified Copilot agent id and does not show Codex's working noninteractive add syntax.</td></tr>
+        <tr><td><code>basic-help-prompt</code></td><td>All</td><td><span class="pill pass">pass</span></td><td>Copilot, Claude, and Codex each returned Azure Functions skill listings for the basic help prompt.</td></tr>
+        <tr><td><code>azure-skills-dependency</code></td><td>All</td><td><span class="pill warning">warning</span></td><td>Dependency guidance is present and Copilot has <code>azure@azure-skills</code>; Codex did not show Azure Skills installed and Claude remains manual/source-guidance only.</td></tr>
+      </table>
+    </section>
 
-  <h2>Scenario Matrix</h2>
-  <table>
-    <thead><tr><th>Scenario</th><th>Status</th><th>Evidence Summary</th></tr></thead>
-    <tbody>
-      <tr><td>setup-workspace-ghcp</td><td><span class="badge ok">pass</span></td><td>56 GitHub Copilot workspace files installed; real Copilot saw all 9 skills, MCP, hook, and functions-copilot agent.</td></tr>
-      <tr><td>setup-workspace-claude</td><td><span class="badge ok">pass</span></td><td>53 Claude files installed; real Claude saw all 9 skills and Azure MCP settings.</td></tr>
-      <tr><td>setup-workspace-codex</td><td><span class="badge ok">pass</span></td><td>54 Codex files installed; real Codex saw all 9 skills, MCP config, hooks, and AGENTS.md guidance.</td></tr>
-      <tr><td>chat-welcome-ghcp</td><td><span class="badge ok">pass</span></td><td>Chat auto-setup installed GHCP files and launched functions-copilot; separate startup prompt check detected host.json and deploy suggestion.</td></tr>
-      <tr><td>chat-welcome-claude</td><td><span class="badge ok">pass</span></td><td>Chat auto-setup installed Claude files; real Claude saw all 9 skills and Azure MCP context.</td></tr>
-      <tr><td>chat-welcome-codex</td><td><span class="badge ok">pass</span></td><td>Chat auto-setup installed Codex files; real Codex wrote parseable inspection JSON with all surfaces visible.</td></tr>
-      <tr><td>plugin-install-ghcp</td><td><span class="badge ok">pass</span></td><td>Target plugin and marketplace were removed, re-added, and reinstalled; Copilot reported pluginInstalled true and all 9 skills.</td></tr>
-      <tr><td>plugin-install-claude</td><td><span class="badge warn">warning</span></td><td><code>claude plugin validate</code> failed with manifest errors, but session-scoped <code>--plugin-dir</code> loading exposed all 9 skills.</td></tr>
-      <tr><td>plugin-install-codex</td><td><span class="badge block">blocked</span></td><td>Marketplace remove/add succeeded, but Codex CLI exposes no noninteractive install/list/select command.</td></tr>
-      <tr><td>docs-command-consistency</td><td><span class="badge warn">warning</span></td><td>README mostly matches real CLI behavior; subcommand <code>setup --help</code>/<code>chat --help</code> execute behavior, and Claude docs should consider <code>--plugin-dir</code>.</td></tr>
-      <tr><td>basic-help-prompt</td><td><span class="badge ok">pass</span></td><td>GHCP, Claude, and Codex all explained setup, create, deploy, diagnostics, best practices, and feedback without unsupported claims.</td></tr>
-      <tr><td>azure-skills-dependency</td><td><span class="badge warn">warning</span></td><td>GHCP confirmed Azure Skills present; Codex correctly reported dependency availability as blocked/warning rather than pass.</td></tr>
-    </tbody>
-  </table>
+    <section>
+      <h2>Key Findings</h2>
+      <h3>1. GitHub Copilot chat and plugin inspection use different agent ids</h3>
+      <p>The original command evidence mixed the setup target id and plugin agent id into the chat scenario. The corrected chat command uses <code>azure-functions-skills chat --agent github-copilot</code> plus headless Copilot passthrough, which lets Copilot load the workspace-local <code>functions-copilot</code> agent. Installed-plugin inspection is separate and correctly uses <code>copilot --agent azure-functions-skills:functions-copilot</code>.</p>
+      <h3>2. Claude/Codex agent guidance is target-specific</h3>
+      <p>Claude should not be marked false for missing <code>agents</code> metadata: the build code emits <code>CLAUDE.md</code> for workspace setup, and the Claude plugin manifest intentionally omits unsupported <code>agents</code> and <code>interface</code> fields. Codex workspace setup similarly carries guidance through <code>AGENTS.md</code>, while the Codex plugin manifest declares <code>agents</code> but did not expose <code>functions-copilot</code> as an active custom-agent surface in this session.</p>
+      <h3>3. Codex install is stricter than the README shows</h3>
+      <p><code>codex plugin add azure-functions-skills</code> failed because Codex requires a marketplace qualifier. <code>codex plugin add azure-functions-skills@azure-functions-skills</code> succeeded, installed version <code>0.11.3</code>, and exposed all 9 skills plus Azure MCP.</p>
+      <h3>4. Help probes can mutate the repository root</h3>
+      <p>Early discovery commands for <code>setup --help</code> and <code>chat --help</code> created root setup/chat artifacts. The run removed only untracked generated artifacts and kept tracked user changes intact.</p>
+    </section>
 
-  <h2>Capability Surface</h2>
-  <table>
-    <thead><tr><th>Agent</th><th>Plugin</th><th>Setup</th><th>Chat</th><th>Skills</th><th>MCP</th><th>Hooks</th><th>Agents/Guidance</th></tr></thead>
-    <tbody>
-      <tr><td>GitHub Copilot</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">9/9</td><td class="ok">azure</td><td class="ok">SessionStart</td><td class="ok">functions-copilot</td></tr>
-      <tr><td>Claude Code</td><td class="warn">warning</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">9/9</td><td class="ok">azure</td><td class="warn">plugin hook visible; native setup hook partial</td><td class="ok">CLAUDE.md/functions-copilot payload</td></tr>
-      <tr><td>Codex</td><td class="block">blocked</td><td class="ok">pass</td><td class="ok">pass</td><td class="ok">9/9 via setup/chat</td><td class="ok">azure via setup/chat</td><td class="ok">.codex/hooks.json</td><td class="ok">AGENTS.md</td></tr>
-    </tbody>
-  </table>
+    <section>
+      <h2>Capability Surface Matrix</h2>
+      <p>This matrix separates target-specific guidance from custom agent definitions. GitHub Copilot is the only tested host where <code>.agent.md</code> registration is the primary agent surface; Claude and Codex primarily use <code>CLAUDE.md</code> and <code>AGENTS.md</code> guidance respectively.</p>
+      <table>
+        <tr><th>Agent</th><th>Plugin</th><th>Skills</th><th>Prompts / Guidance</th><th>MCP</th><th>Hooks</th><th>Agent Definition / Guidance</th><th>Chat</th><th>Notes</th></tr>
+        <tr>
+          <td>GitHub Copilot</td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td>Workspace-local chat worked with <code>azure-functions-skills chat --agent github-copilot</code> and headless Copilot passthrough. Installed-plugin inspection separately worked with <code>azure-functions-skills:functions-copilot</code>.</td>
+        </tr>
+        <tr>
+          <td>Claude Code</td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td>Claude does not require Copilot-style <code>agents</code> manifest metadata. Guidance is carried through <code>CLAUDE.md</code>, skills, hooks, and MCP; build tests intentionally omit unsupported Claude <code>agents</code>/<code>interface</code> manifest fields.</td>
+        </tr>
+        <tr>
+          <td>Codex</td>
+          <td><span class="pill warning">warning</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td><span class="pill warning">warning</span></td>
+          <td><span class="pill warning">warning</span></td>
+          <td><span class="pill pass">pass</span></td>
+          <td>Qualified plugin install worked and skills/MCP were visible. Workspace guidance uses <code>AGENTS.md</code>. Plugin hook output and custom <code>functions-copilot</code> agent activation were not visible as active session surfaces.</td>
+        </tr>
+      </table>
+    </section>
 
-  <h2>Key Findings</h2>
-  <div class="card">
-    <h3>Warnings</h3>
-    <p><strong>Claude plugin validation:</strong> <code>claude plugin validate</code> failed with <code>agents: Invalid input</code> and <code>root: Unrecognized key: "interface"</code>. Session-scoped loading still worked, so packaging validation should be fixed.</p>
-    <p><strong>Docs/help behavior:</strong> <code>azure-functions-skills setup --help</code> and <code>chat --help</code> executed setup/chat behavior in the isolated workspace. Use top-level help for read-only discovery until subcommand help is fixed.</p>
-    <p><strong>Azure Skills dependency:</strong> GitHub Copilot had <code>azure@azure-skills</code> installed. Codex correctly reported dependency availability as blocked/warning because noninteractive plugin activation is unavailable.</p>
-    <h3>Blocked</h3>
-    <p><strong>Codex plugin activation:</strong> Codex CLI 0.130.0 supports marketplace add/remove but not noninteractive plugin install/list/select. Marketplace registration alone cannot prove plugin activation.</p>
-  </div>
+    <section>
+      <h2>Command Evidence</h2>
+      <p>Each row below records the final command sequence used for the scenario. Full stdout/stderr is retained in the transcript files; excerpts here are the command results needed to audit the matrix without relying on earlier reports.</p>
+      <details>
+        <summary><code>setup-workspace-ghcp</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/setup-workspace-ghcp</code></p>
+        <ul>
+          <li><code>node &lt;repo&gt;/bin/azure-functions-skills.js setup --agent ghcp --dir . --skip-prerequisites</code> - exit 0; wrote 56 files and listed all 9 Azure Functions skills.</li>
+          <li><code>copilot -C . -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user</code> - exit 0; inspection showed workspace/project skills visible.</li>
+          <li><code>node &lt;file-check script&gt;</code> - exit 0; verified GHCP files, agent definition, MCP, hook, and skill files.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>setup-workspace-claude</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/setup-workspace-claude</code></p>
+        <ul>
+          <li><code>node &lt;repo&gt;/bin/azure-functions-skills.js setup --agent claude --dir . --skip-prerequisites</code> - exit 0; wrote Claude workspace files and 9 skills.</li>
+          <li><code>claude -p &lt;inspection prompt&gt; --output-format json --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</code> - exit 0; reported <code>CLAUDE.md</code>, skills, and Azure MCP visibility.</li>
+          <li><code>node &lt;file-check script&gt;</code> - exit 0; verified <code>CLAUDE.md</code>, <code>.claude/settings.json</code>, and <code>.claude/skills/*/SKILL.md</code>.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>setup-workspace-codex</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/setup-workspace-codex</code></p>
+        <ul>
+          <li><code>node &lt;repo&gt;/bin/azure-functions-skills.js setup --agent codex --dir . --skip-prerequisites</code> - exit 0; wrote Codex workspace files and 9 skills.</li>
+          <li><code>codex exec --sandbox read-only --json --output-last-message &lt;file&gt; --ephemeral --skip-git-repo-check --dangerously-bypass-hook-trust --cd . &lt;inspection prompt&gt;</code> - exit 0; reported <code>AGENTS.md</code>, skills, hooks, and Azure MCP visibility.</li>
+          <li><code>node &lt;file-check script&gt;</code> - exit 0; verified <code>AGENTS.md</code>, <code>.codex/config.toml</code>, <code>.codex/hooks.json</code>, and <code>.agents/skills/*/SKILL.md</code>.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>chat-welcome-ghcp</code> - pass</summary>
+        <p><strong>Cwd:</strong> isolated GHCP chat workspace; supplemental verification captured in <code>execution.log</code>.</p>
+        <ul>
+          <li><code>node &lt;repo&gt;/bin/azure-functions-skills.js chat --agent github-copilot --dir . --skip-prerequisites --output-format json -s --allow-all --no-ask-user -p &lt;inspection prompt&gt;</code> - exit 0; output included <code>Launching github-copilot</code>, installed 56 GHCP skill files, loaded workspace project skills, connected Azure MCP, and returned <code>passed: true</code>.</li>
+          <li>The previous GHCP chat evidence was harness-invalid because it passed the setup target id to the chat option; <code>ghcp</code> is for setup, while <code>github-copilot</code> is the chat launcher id.</li>
+          <li>Direct <code>copilot --agent azure-functions-skills:functions-copilot</code> remains valid for installed-plugin inspection, but it is not the <code>azure-functions-skills chat --agent</code> value.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>chat-welcome-claude</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/chat-welcome-claude</code></p>
+        <ul>
+          <li><code>node &lt;repo&gt;/bin/azure-functions-skills.js chat --agent claude --dir . --skip-prerequisites</code> - exit 0; launched Claude with Azure Functions context.</li>
+          <li><code>claude -p &lt;inspection prompt&gt; --output-format json --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</code> - exit 0; produced agent-visible setup/skill evidence.</li>
+          <li><code>node &lt;file-check script&gt;</code> - exit 0; verified Claude workspace artifacts.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>chat-welcome-codex</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/chat-welcome-codex</code></p>
+        <ul>
+          <li><code>node &lt;repo&gt;/bin/azure-functions-skills.js chat --agent codex --dir . --skip-prerequisites</code> - exit 0; launched Codex with Azure Functions context.</li>
+          <li><code>codex exec --sandbox read-only --json --output-last-message &lt;file&gt; --ephemeral --skip-git-repo-check --dangerously-bypass-hook-trust --cd . &lt;inspection prompt&gt;</code> - exit 0; output-last-message confirmed skill visibility.</li>
+          <li><code>node &lt;file-check script&gt;</code> - exit 0; verified Codex workspace artifacts.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>plugin-install-ghcp</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/plugin-install-ghcp</code></p>
+        <ul>
+          <li><code>copilot plugin marketplace list</code> - exit 0; pre-state showed registered marketplaces.</li>
+          <li><code>copilot plugin list</code> - exit 0; pre-state showed installed plugins.</li>
+          <li><code>copilot plugin uninstall azure-functions-skills</code> - exit 1; cleanup confirmed plugin was not installed.</li>
+          <li><code>copilot plugin marketplace remove azure-functions-skills</code> - exit 0; removed stale marketplace.</li>
+          <li><code>copilot plugin marketplace add Azure/azure-functions-skills</code> - exit 0; marketplace added.</li>
+          <li><code>copilot plugin install azure-functions-skills@azure-functions-skills</code> - exit 0; installed 9 skills.</li>
+          <li><code>copilot plugin list</code> - exit 0; post-state showed <code>azure-functions-skills@azure-functions-skills (v0.11.3)</code>.</li>
+          <li><code>copilot -C . --agent azure-functions-skills:functions-copilot -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user</code> - exit 0; loaded installed-plugin skills and Azure MCP.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>plugin-install-claude</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/plugin-install-claude</code></p>
+        <ul>
+          <li><code>claude plugin list</code> - exit 0; pre-state showed no installed plugins.</li>
+          <li><code>claude plugin marketplace list</code> - exit 0; listed configured marketplaces.</li>
+          <li><code>claude plugin uninstall azure-functions-skills -y</code> - exit 1; cleanup confirmed plugin was absent.</li>
+          <li><code>claude plugin validate &lt;payload&gt;</code> - exit 0; validation passed with author warning.</li>
+          <li><code>claude --add-dir &lt;payload&gt; -p &lt;inspection prompt&gt; --output-format json --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</code> - exit 0; source guidance exposed skills, hooks, MCP, and payload files.</li>
+          <li><code>claude -p &lt;inspection prompt&gt; --plugin-dir &lt;payload&gt; --output-format json --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</code> - exit 0; plugin-dir inspection again reported 9 skills and Azure MCP.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>plugin-install-codex</code> - warning</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/plugin-install-codex</code></p>
+        <ul>
+          <li><code>codex plugin list</code> - exit 0; captured pre-state.</li>
+          <li><code>codex plugin add azure-functions-skills</code> - exit 2; failed with requirement for <code>--marketplace</code> or <code>PLUGIN@MARKETPLACE</code>.</li>
+          <li><code>codex plugin add --help</code> - exit 0; documented <code>codex plugin add sample@debug</code> and <code>--marketplace</code>.</li>
+          <li><code>codex plugin remove azure-functions-skills@azure-functions-skills</code> - exit 0; cleanup removed prior qualified install.</li>
+          <li><code>codex plugin add azure-functions-skills@azure-functions-skills</code> - exit 0; installed version <code>0.11.3</code>.</li>
+          <li><code>codex plugin list</code> - exit 0; post-state showed <code>azure-functions-skills@azure-functions-skills (installed, enabled)</code>.</li>
+          <li><code>codex exec --sandbox read-only --json --output-last-message &lt;file&gt; --ephemeral --skip-git-repo-check --dangerously-bypass-hook-trust --cd . &lt;inspection prompt&gt;</code> - exit 0; saw 9 skills and Azure MCP, but not active custom-agent/hook output.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>docs-command-consistency</code> - warning</summary>
+        <p><strong>Cwd:</strong> <code>q:\repos\functions-skills\azure-functions-skills</code></p>
+        <ul>
+          <li><code>node &lt;docs consistency script&gt;</code> - exit 0; compared README commands with observed CLI behavior.</li>
+          <li>Result: README uses unqualified Copilot <code>--agent functions-copilot</code> while installed plugin inspection required <code>azure-functions-skills:functions-copilot</code>; README does not show the working noninteractive Codex <code>plugin@marketplace</code> form.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>basic-help-prompt</code> - pass</summary>
+        <p><strong>Cwd:</strong> <code>reports/e2e/20260519T063710Z-fresh/workspaces/basic-help-prompt</code></p>
+        <ul>
+          <li><code>copilot -C . --agent azure-functions-skills:functions-copilot -p &lt;basic help prompt&gt; --output-format json -s --allow-all --no-ask-user</code> - exit 0; returned Azure Functions skill routing/help.</li>
+          <li><code>claude --plugin-dir &lt;payload&gt; -p &lt;basic help prompt&gt; --output-format json --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</code> - exit 0; returned Azure Functions skill listing.</li>
+          <li><code>codex exec --sandbox read-only --json --output-last-message &lt;file&gt; --ephemeral --skip-git-repo-check --dangerously-bypass-hook-trust --cd . &lt;basic help prompt&gt;</code> - exit 0; returned Azure Functions skill listing.</li>
+        </ul>
+      </details>
+      <details>
+        <summary><code>azure-skills-dependency</code> - warning</summary>
+        <p><strong>Cwd:</strong> <code>q:\repos\functions-skills\azure-functions-skills</code></p>
+        <ul>
+          <li><code>node &lt;dependency scan script&gt;</code> - exit 0; found Azure Skills dependency guidance in the deployment-related skill content.</li>
+          <li><code>copilot plugin list</code> - exit 0; showed <code>azure@azure-skills</code> installed alongside Azure Functions Skills.</li>
+          <li><code>codex plugin list</code> - exit 0; did not show Azure Skills installed for Codex.</li>
+          <li>Claude was classified as source/manual guidance only for this dependency check.</li>
+        </ul>
+      </details>
+    </section>
 
-  <h2>Command Evidence</h2>
-  <p class="small">These are the final commands used for each scenario after manual iteration. They include both passing and warning/blocked flows so the working and non-working shapes are visible.</p>
-  <details open><summary>setup-workspace-ghcp - pass</summary>
-<pre>node bin/azure-functions-skills.js setup --agent ghcp --dir reports/e2e/20260519T-manual/workspaces/setup-workspace-ghcp --skip-prerequisites
-copilot -C reports/e2e/20260519T-manual/workspaces/setup-workspace-ghcp --agent functions-copilot -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user</pre>
-  </details>
-  <details><summary>setup-workspace-claude - pass</summary>
-<pre>node bin/azure-functions-skills.js setup --agent claude --dir reports/e2e/20260519T-manual/workspaces/setup-workspace-claude --skip-prerequisites
-claude -p &lt;inspection prompt&gt; --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</pre>
-  </details>
-  <details><summary>setup-workspace-codex - pass</summary>
-<pre>node bin/azure-functions-skills.js setup --agent codex --dir reports/e2e/20260519T-manual/workspaces/setup-workspace-codex --skip-prerequisites
-codex exec --sandbox read-only --json --output-last-message reports/e2e/20260519T-manual/workspaces/setup-workspace-codex/e2e-agent-inspection.json --ephemeral --skip-git-repo-check --cd reports/e2e/20260519T-manual/workspaces/setup-workspace-codex &lt;inspection prompt&gt;</pre>
-  </details>
-  <details><summary>chat-welcome-ghcp - pass</summary>
-<pre>node bin/azure-functions-skills.js chat --agent github-copilot --dir . --skip-prerequisites -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user
-node --input-type=module -e "import('./lib/chat/index.js').then(async m =&gt; console.log(await m.buildStartupPrompt(process.argv[1])))" &lt;workspace&gt;</pre>
-  </details>
-  <details><summary>chat-welcome-claude - pass</summary>
-<pre>node bin/azure-functions-skills.js chat --agent claude-code --dir . --skip-prerequisites --prompt &lt;inspection prompt&gt; -p --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
-node --input-type=module -e "import('./lib/chat/index.js').then(async m =&gt; console.log(await m.buildStartupPrompt(process.argv[1])))" &lt;workspace&gt;</pre>
-  </details>
-  <details><summary>chat-welcome-codex - pass</summary>
-<pre>node bin/azure-functions-skills.js chat --agent codex --dir . --skip-prerequisites --prompt &lt;inspection prompt&gt; exec --sandbox workspace-write --json --output-last-message e2e-chat-inspection.json --ephemeral --skip-git-repo-check --cd .
-node --input-type=module -e "import('./lib/chat/index.js').then(async m =&gt; console.log(await m.buildStartupPrompt(process.argv[1])))" &lt;workspace&gt;</pre>
-  </details>
-  <details><summary>plugin-install-ghcp - pass</summary>
-<pre>copilot plugin --help
-copilot plugin marketplace --help
-copilot plugin list
-copilot plugin marketplace list
-copilot plugin uninstall azure-functions-skills
-copilot plugin marketplace remove azure-functions-skills
-copilot plugin marketplace add Azure/azure-functions-skills
-copilot plugin install azure-functions-skills@azure-functions-skills
-copilot plugin list
-copilot plugin marketplace list
-copilot --agent functions-copilot -p &lt;inspection prompt&gt; --output-format json -s --allow-all --no-ask-user</pre>
-  </details>
-  <details><summary>plugin-install-claude - warning</summary>
-<pre>claude plugin --help
-claude plugin list
-claude --help | Select-String -Pattern "plugin|add-dir" -Context 0,2
-claude plugin marketplace --help
-claude plugin validate &lt;plugin-payload-dir&gt;
-claude -p &lt;inspection prompt&gt; --plugin-dir &lt;plugin-payload-dir&gt; --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob</pre>
-  </details>
-  <details><summary>plugin-install-codex - blocked</summary>
-<pre>codex plugin --help
-codex plugin marketplace --help
-codex exec --help
-codex plugin marketplace list
-codex plugin marketplace remove azure-functions-skills
-codex plugin marketplace add Azure/azure-functions-skills
-codex exec --sandbox read-only --json --output-last-message e2e-plugin-inspection.json --ephemeral --skip-git-repo-check --cd . &lt;inspection prompt&gt;</pre>
-  </details>
-  <details><summary>docs-command-consistency - warning</summary>
-<pre>README.md command sections
-package.json scripts
-templates/skills/*/SKILL.md inventory
-copilot --help | Select-String -Pattern "yolo|allow-all|silent|output-format|agent|no-ask-user"
-node bin/azure-functions-skills.js --help
-node bin/azure-functions-skills.js setup --help
-node bin/azure-functions-skills.js chat --help</pre>
-  </details>
-  <details><summary>basic-help-prompt - pass</summary>
-<pre>copilot --agent functions-copilot -p &lt;basic-help prompt&gt; --output-format json -s --allow-all --no-ask-user
-claude -p &lt;basic-help prompt&gt; --plugin-dir &lt;plugin-payload-dir&gt; --output-format text --no-session-persistence --permission-mode bypassPermissions --tools Read,LS,Grep,Glob
-node bin/azure-functions-skills.js setup --agent codex --dir &lt;workspace&gt; --skip-prerequisites
-codex exec --sandbox read-only --json --output-last-message e2e-basic-help.json --ephemeral --skip-git-repo-check --cd &lt;workspace&gt; &lt;basic-help prompt&gt;</pre>
-  </details>
-  <details><summary>azure-skills-dependency - warning</summary>
-<pre>copilot --agent functions-copilot -p &lt;dependency prompt&gt; --output-format json -s --allow-all --no-ask-user
-node bin/azure-functions-skills.js setup --agent codex --dir &lt;workspace&gt; --skip-prerequisites
-codex exec --sandbox read-only --json --output-last-message e2e-azure-skills-dependency.json --ephemeral --skip-git-repo-check --cd &lt;workspace&gt; &lt;dependency prompt&gt;</pre>
-  </details>
-  <details><summary>Retained workspaces</summary>
-    <p>All scenario workspaces were retained under <code>reports/e2e/20260519T-manual/workspaces/</code> for review. Date-stamped run directories are analysis artifacts; only this reviewed HTML is copied to <code>reports/e2e/current/report.html</code>.</p>
-  </details>
+    <section>
+      <h2>Evidence Files</h2>
+      <ul>
+        <li><code>evidence.json</code> - structured scenario evidence and cross-checks.</li>
+        <li><code>skill-improvement.md</code> - improvements for the E2E skill and product findings.</li>
+        <li><code>transcripts/plugin-install-ghcp-plugin.txt</code> - Copilot plugin lifecycle and inspection.</li>
+        <li><code>transcripts/plugin-install-claude-plugin.txt</code> - Claude plugin validation/source evidence.</li>
+        <li><code>transcripts/plugin-install-codex-plugin.txt</code> - Codex plugin lifecycle, qualified install, and inspection.</li>
+        <li><code>transcripts/basic-help-prompt.txt</code> - real-agent basic help outputs.</li>
+        <li><code>transcripts/docs-command-consistency.txt</code> and <code>transcripts/azure-skills-dependency.txt</code> - shared scenario evidence.</li>
+        <li><code>execution.log</code> - supplemental corrected GHCP chat verification using <code>--agent github-copilot</code> and headless Copilot passthrough.</li>
+      </ul>
+    </section>
 
-  <h2>Cross-Check</h2>
-  <div class="card">
-    <p>The checklist contains all 12 default local scenarios. No scenario was omitted due to expected failure. All setup/chat/plugin commands that could write files were run in scenario workspaces. The only known incidental write from help probing occurred inside the disposable docs-command-consistency workspace and is recorded as a warning.</p>
-    <p>The E2E skill instructions were updated with the successful manual execution practices and current CLI caveats discovered during this run.</p>
-  </div>
-</main>
+    <section>
+      <h2>Cross-Check</h2>
+      <table>
+        <tr><th>Check</th><th>Outcome</th></tr>
+        <tr><td>Default matrix represented</td><td>Yes: setup, chat, plugin for three agents plus shared scenarios.</td></tr>
+        <tr><td>Existing E2E reports used as input</td><td>No.</td></tr>
+        <tr><td>Plugin lifecycle evidence</td><td>Captured pre-state, cleanup/install or source load, post-state, and real-agent inspection where available.</td></tr>
+        <tr><td>Agent-visible proof</td><td>Present for passing setup/chat/plugin/basic-help flows; the corrected GHCP chat evidence supersedes the earlier setup-target-id harness attempt.</td></tr>
+        <tr><td>Root pollution</td><td>Detected and cleaned for generated untracked artifacts.</td></tr>
+        <tr><td>Workspace retention</td><td>All scenario workspaces retained for auditability.</td></tr>
+      </table>
+    </section>
+  </main>
 </body>
 </html>

--- a/src/build/build-target.ts
+++ b/src/build/build-target.ts
@@ -28,12 +28,13 @@ export function buildPluginPayload(data: BuildData, pluginDir: string): void {
   mkdirSync(pluginDir, { recursive: true });
 
   const manifest = generatePluginManifest(data);
+  const claudeManifest = generateClaudePluginManifest(data);
   mkdirSync(join(pluginDir, '.plugin'), { recursive: true });
   writeFileSync(join(pluginDir, '.plugin', 'plugin.json'), JSON.stringify(manifest, null, 2));
   writeFileSync(join(pluginDir, 'plugin.json'), JSON.stringify(manifest, null, 2));
 
   mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
-  writeFileSync(join(pluginDir, '.claude-plugin', 'plugin.json'), JSON.stringify(manifest, null, 2));
+  writeFileSync(join(pluginDir, '.claude-plugin', 'plugin.json'), JSON.stringify(claudeManifest, null, 2));
 
   mkdirSync(join(pluginDir, '.codex-plugin'), { recursive: true });
   writeFileSync(join(pluginDir, '.codex-plugin', 'plugin.json'), JSON.stringify(manifest, null, 2));
@@ -270,6 +271,17 @@ function generatePluginManifest(data: BuildData) {
       category: 'Development',
       capabilities: ['Read', 'Write'],
     },
+  };
+}
+
+function generateClaudePluginManifest(data: BuildData) {
+  return {
+    name: 'azure-functions-skills',
+    version: data.packageVersion || '0.0.0-dev',
+    description: 'Azure Functions skills for setup, create, and deploy workflows',
+    skills: './skills/',
+    hooks: './hooks.json',
+    mcpServers: './.mcp.json',
   };
 }
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -451,6 +451,32 @@ describe('buildPluginPayload', () => {
       expect(existsSync(join(payloadDir, 'skills', s.id, 'SKILL.md'))).toBe(true);
     }
   });
+
+  it('emits a Claude plugin manifest without unsupported Copilot/Codex metadata', () => {
+    const skills = loadSkills(join(TEMPLATES_DIR, 'skills'));
+    const mcpServers = loadMcpServers(join(TEMPLATES_DIR, 'mcp', 'servers.yaml'));
+    const agents = loadAgents(join(TEMPLATES_DIR, 'agents'));
+    const hooks = loadHooks(join(TEMPLATES_DIR, 'hooks'));
+    const payloadDir = join(DIST_DIR, 'plugin', 'azure-functions-skills');
+
+    buildPluginPayload({ skills, mcpServers, agents, hooks, packageVersion: '9.8.7' }, payloadDir);
+
+    const defaultManifest = JSON.parse(readFileSync(join(payloadDir, 'plugin.json'), 'utf-8'));
+    const claudeManifest = JSON.parse(readFileSync(join(payloadDir, '.claude-plugin', 'plugin.json'), 'utf-8'));
+
+    expect(defaultManifest.agents).toBe('./agents/');
+    expect(defaultManifest.interface).toBeTruthy();
+    expect(claudeManifest).toMatchObject({
+      name: 'azure-functions-skills',
+      version: '9.8.7',
+      description: 'Azure Functions skills for setup, create, and deploy workflows',
+      skills: './skills/',
+      hooks: './hooks.json',
+      mcpServers: './.mcp.json',
+    });
+    expect(claudeManifest).not.toHaveProperty('agents');
+    expect(claudeManifest).not.toHaveProperty('interface');
+  });
 });
 
 describe('buildPluginMarketplaces', () => {
@@ -543,6 +569,18 @@ describe('setup module', () => {
 
     expect(existsSync(join(DIST_DIR, 'CLAUDE.md'))).toBe(true);
     expect(existsSync(join(DIST_DIR, '.claude', 'settings.json'))).toBe(true);
+  });
+
+  it('applySetup omits Claude plugin payload files from workspace setup', async () => {
+    await applySetup(DIST_DIR, { agents: ['claude'], prerequisites: 'skip' });
+
+    expect(existsSync(join(DIST_DIR, 'CLAUDE.md'))).toBe(true);
+    expect(existsSync(join(DIST_DIR, '.claude', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(DIST_DIR, '.claude-plugin'))).toBe(false);
+    expect(existsSync(join(DIST_DIR, 'plugin.json'))).toBe(false);
+    expect(existsSync(join(DIST_DIR, 'agents'))).toBe(false);
+    expect(existsSync(join(DIST_DIR, 'hooks.json'))).toBe(false);
+    expect(existsSync(join(DIST_DIR, '.mcp.json'))).toBe(false);
   });
 
   it('applySetup handles multiple agents at once', async () => {

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -112,11 +112,16 @@ function assertPluginLayout(root: string, target: BuildTargetName, expectedSkill
 }
 
 function runCli(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): void {
+  runCliOutput(args, options);
+}
+
+function runCliOutput(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): string {
   const env = { ...process.env, ...options.env };
-  execFileSync(process.execPath, [CLI_PATH, ...args], {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], {
     cwd: options.cwd || ROOT_DIR,
     env,
     stdio: 'pipe',
+    encoding: 'utf-8',
   });
 }
 
@@ -220,5 +225,57 @@ describe('CLI command integration', () => {
     });
 
     expect(readFileSync(argsFile, 'utf-8').trim()).toBe('exec --sandbox read-only --json hello');
+  });
+
+  it('chat --help prints command help without launching an agent', () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-chat-help-');
+    const argsFile = join(projectDir, 'agent-args.txt');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+
+    const output = runCliOutput(['chat', '--help'], {
+      env: {
+        PATH: pathValue,
+        Path: pathValue,
+        AF_SKILLS_FAKE_ARGS_FILE: argsFile,
+        ...(pathext ? { PATHEXT: pathext } : {}),
+      },
+    });
+
+    expect(output).toContain('Options (chat):');
+    expect(output).toContain('-- <args...>');
+    expect(existsSync(argsFile)).toBe(false);
+  });
+
+  it('chat forwards --help after the pass-through separator', () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-chat-forward-help-');
+    const argsFile = join(projectDir, 'agent-args.txt');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+
+    runCli([
+      'chat',
+      '--agent', 'codex',
+      '--dir', projectDir,
+      '--prompt', 'hello',
+      '--skip-prerequisites',
+      '--',
+      '--help',
+    ], {
+      env: {
+        PATH: pathValue,
+        Path: pathValue,
+        AF_SKILLS_FAKE_ARGS_FILE: argsFile,
+        ...(pathext ? { PATHEXT: pathext } : {}),
+      },
+    });
+
+    expect(readFileSync(argsFile, 'utf-8').trim()).toBe('--help hello');
   });
 });


### PR DESCRIPTION
- Claude plugin manifest: Updated format according to latest specs.
- chat --help/pass-through: Fixed handling of help flags.
- E2E guidance/report: Updated instructions and reporting.
- Tests: \
pm run check\ passed with 100 tests.
- Claude validation: \claude plugin validate .github/plugins/azure-functions-skills\ passed with missing author warning.
- Local files: Untracked files were not included.