### PR TITLE
docs: add bug bash summary pages

### DIFF
--- a/.github/workflows/publish-e2e-report.yml
+++ b/.github/workflows/publish-e2e-report.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/publish-e2e-report.yml'
+      - 'docs/bug-bash-feedback-summary-20260519.html'
+      - 'docs/bug-bash-feedback-summary-20260519-en.html'
       - 'reports/e2e/current/report.html'
   workflow_dispatch:
 
@@ -31,9 +33,15 @@ jobs:
         run: |
           set -euo pipefail
           test -f reports/e2e/current/report.html
+          test -f docs/bug-bash-feedback-summary-20260519.html
+          test -f docs/bug-bash-feedback-summary-20260519-en.html
           mkdir -p _site
+          mkdir -p _site/bug-bash
           cp reports/e2e/current/report.html _site/index.html
           cp reports/e2e/current/report.html _site/report.html
+          cp docs/bug-bash-feedback-summary-20260519-en.html _site/bug-bash/index.html
+          cp docs/bug-bash-feedback-summary-20260519-en.html _site/bug-bash/en.html
+          cp docs/bug-bash-feedback-summary-20260519.html _site/bug-bash/ja.html
           touch _site/.nojekyll
 
       - uses: actions/configure-pages@v5

--- a/docs/bug-bash-feedback-summary-20260519-en.html
+++ b/docs/bug-bash-feedback-summary-20260519-en.html
@@ -1,0 +1,570 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Azure Functions Skills Bug Bash Feedback Summary</title>
+  <style>
+    :root {
+      --bg: #f6f8fb;
+      --surface: #ffffff;
+      --soft: #eef5ff;
+      --text: #1d2635;
+      --muted: #5f6f86;
+      --line: #d9e2ef;
+      --azure: #0078d4;
+      --azure-dark: #005a9e;
+      --teal: #008575;
+      --orange: #c85f00;
+      --red: #c4314b;
+      --shadow: 0 18px 45px rgba(24, 39, 75, 0.10);
+      --radius: 8px;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      font-family: "Segoe UI", system-ui, sans-serif;
+      line-height: 1.72;
+      letter-spacing: 0;
+    }
+
+    a { color: var(--azure-dark); text-underline-offset: 0.18em; }
+
+    code {
+      padding: 0.12rem 0.34rem;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #f4f7fb;
+      font-family: Consolas, "Cascadia Code", monospace;
+      font-size: 0.92em;
+    }
+
+    .hero {
+      color: #ffffff;
+      background: linear-gradient(135deg, #005a9e 0%, #0078d4 52%, #008575 100%);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    .hero-inner, .layout, .footer {
+      width: min(1180px, calc(100% - 40px));
+      margin: 0 auto;
+    }
+
+    .hero-inner { padding: 54px 0 36px; }
+
+    .kicker {
+      margin: 0 0 10px;
+      color: rgba(255, 255, 255, 0.84);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 960px;
+      margin: 0;
+      font-size: clamp(2.25rem, 5vw, 4.4rem);
+      line-height: 1.06;
+      letter-spacing: 0;
+    }
+
+    .hero-summary {
+      max-width: 930px;
+      margin: 20px 0 0;
+      color: rgba(255, 255, 255, 0.92);
+      font-size: 1.06rem;
+    }
+
+    .meta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 24px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 34px;
+      padding: 6px 12px;
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.14);
+      color: #ffffff;
+      font-size: 0.9rem;
+    }
+
+    a.pill {
+      color: #ffffff;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    a.pill:hover {
+      background: rgba(255, 255, 255, 0.22);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: 270px minmax(0, 1fr);
+      gap: 28px;
+      margin-top: 28px;
+      margin-bottom: 56px;
+      align-items: start;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 10px 30px rgba(24, 39, 75, 0.06);
+    }
+
+    .toc h2 {
+      margin: 0 0 12px;
+      color: var(--muted);
+      font-size: 0.84rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .toc a {
+      display: block;
+      padding: 8px 0;
+      border-top: 1px solid #edf1f7;
+      color: var(--text);
+      font-size: 0.92rem;
+      text-decoration: none;
+    }
+
+    .toc a:hover { color: var(--azure-dark); }
+
+    main { min-width: 0; }
+
+    section {
+      margin-bottom: 28px;
+      padding: 28px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 12px 36px rgba(24, 39, 75, 0.06);
+    }
+
+    .section-plain {
+      padding: 0;
+      border: 0;
+      background: transparent;
+      box-shadow: none;
+    }
+
+    h2, h3, h4 { line-height: 1.25; letter-spacing: 0; }
+    h2 { margin: 0 0 16px; color: #10243f; font-size: 1.6rem; }
+    h3 { margin: 24px 0 10px; color: #183a63; font-size: 1.18rem; }
+    h4 { margin: 0 0 8px; font-size: 1rem; }
+    p { margin: 0 0 14px; }
+    ul, ol { margin: 10px 0 0; padding-left: 1.35rem; }
+    li { margin: 7px 0; }
+    .lead { color: #33465e; font-size: 1.04rem; }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .metric {
+      min-height: 120px;
+      padding: 16px;
+      border: 1px solid #cfe0f4;
+      border-radius: var(--radius);
+      background: linear-gradient(180deg, #ffffff, #f3f8ff);
+    }
+
+    .metric strong {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--azure-dark);
+      font-size: 1.55rem;
+      line-height: 1;
+    }
+
+    .metric span { display: block; color: #38506c; font-size: 0.9rem; line-height: 1.45; }
+
+    .split, .theme-grid, .issue-grid, .todo-grid, .link-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .note-box, .theme, .issue, .todo, .link-card {
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+    }
+
+    .note-box { border-left: 4px solid var(--azure); background: var(--soft); }
+    .note-box.warning { border-left-color: var(--orange); background: #fff7ed; }
+    .note-box.success { border-left-color: var(--teal); background: #eefaf7; }
+    .theme { border-top: 4px solid var(--azure); }
+    .issue { border-top: 4px solid #6f89a8; }
+    .issue.critical { border-top-color: var(--red); }
+    .issue.product { border-top-color: var(--azure); }
+    .issue.new-skill { border-top-color: var(--teal); }
+    .link-card { border-top: 4px solid var(--azure); }
+    .link-card h3 { margin-top: 0; }
+    .link-card .link-action { display: inline-flex; margin-top: 4px; font-weight: 700; }
+
+    .issue-meta, .todo-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 8px 0 12px;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 26px;
+      padding: 3px 9px;
+      border-radius: 999px;
+      color: #284057;
+      background: #eef2f7;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .tag.p0 { color: #8a1f32; background: #ffe8ed; }
+    .tag.p1 { color: #005a9e; background: #e4f1ff; }
+    .tag.p2 { color: #006b5e; background: #dcf8f2; }
+    .tag.p3 { color: #665100; background: #fff5c2; }
+    .todo-number { color: var(--azure-dark); font-weight: 800; }
+
+    .triage-list {
+      counter-reset: triage;
+      list-style: none;
+      padding-left: 0;
+    }
+
+    .triage-list li {
+      counter-increment: triage;
+      display: grid;
+      grid-template-columns: 38px minmax(0, 1fr);
+      gap: 12px;
+      align-items: start;
+      margin: 12px 0;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+    }
+
+    .triage-list li::before {
+      content: counter(triage);
+      display: grid;
+      width: 32px;
+      height: 32px;
+      place-items: center;
+      border-radius: 50%;
+      color: #ffffff;
+      background: var(--azure);
+      font-weight: 800;
+    }
+
+    .footer {
+      margin-bottom: 40px;
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-align: center;
+    }
+
+    @media (max-width: 980px) {
+      .layout { display: block; }
+      .toc { position: static; margin-bottom: 20px; }
+      .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .theme-grid, .issue-grid, .todo-grid, .link-grid, .split { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 620px) {
+      .hero-inner, .layout, .footer { width: min(100% - 24px, 1180px); }
+      .hero-inner { padding: 38px 0 26px; }
+      section { padding: 20px; }
+      .summary-grid { grid-template-columns: 1fr; }
+    }
+
+    @media print {
+      body { background: #ffffff; }
+      .hero { color: #000000; background: #ffffff; }
+      .toc { display: none; }
+      .layout, .footer { width: 100%; margin: 0; }
+      section, .theme, .issue, .todo, .metric, .triage-list li { box-shadow: none; break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <p class="kicker">Bug Bash Feedback Summary</p>
+      <h1>Azure Functions Skills</h1>
+      <p class="hero-summary">This English version consolidates the bug bash conversation notes and GitHub issues #68 and later into structured meeting notes, feedback themes, proposals, and prioritized follow-up work.</p>
+      <div class="meta-row" aria-label="Document metadata">
+        <span class="pill">Date: 2026-05-19</span>
+        <span class="pill">Issues: #68-#79</span>
+        <span class="pill">Focus: Scope, UX, Routing, Quality</span>
+        <a class="pill" href="/bug-bash/ja.html">日本語版</a>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <a href="#summary">Executive Summary</a>
+      <a href="#sources">Input Sources</a>
+      <a href="#links">Useful Links</a>
+      <a href="#sentiment">Overall Sentiment</a>
+      <a href="#discussion">Discussion Notes</a>
+      <a href="#issues">GitHub Issues</a>
+      <a href="#themes">Themes and Directions</a>
+      <a href="#todo">Prioritized TODO</a>
+      <a href="#triage">Suggested Triage Order</a>
+    </nav>
+
+    <main>
+      <section id="summary">
+        <h2>1. Executive Summary</h2>
+        <p class="lead">The bug bash feedback was not only about individual bug fixes. The central discussion was about what kind of skill suite Azure Functions Skills should become, what responsibilities it should own, and how it should fit into the broader Azure Skills ecosystem.</p>
+        <p>Overall, the direction of having Copilot and agent skills dedicated to Azure Functions was received positively. Participants saw strong value in making the Azure Functions team's domain knowledge available to agents through setup, creation, diagnostics, best-practices review, upgrade guidance, and operational review workflows. At the same time, the discussion surfaced major concerns around overlap with Azure Skills, plugin installation UX, opaque routing when many skills are visible, and the difficulty of evaluating LLM-based skills.</p>
+
+        <div class="summary-grid" aria-label="Top themes">
+          <div class="metric"><strong>1</strong><span>Clarify the scope boundary between Azure Skills and Azure Functions Skills.</span></div>
+          <div class="metric"><strong>2</strong><span>Design routing so the right skill is selected even when 100+ skills are visible.</span></div>
+          <div class="metric"><strong>3</strong><span>Reduce onboarding friction around install, reload, accounts, and plugin versus CLI flows.</span></div>
+          <div class="metric"><strong>4</strong><span>Turn Azure Functions team recommendations into practical skills.</span></div>
+          <div class="metric"><strong>5</strong><span>Combine E2E tests and agent-based evals to continuously assess quality.</span></div>
+        </div>
+      </section>
+
+      <section id="sources">
+        <h2>2. Input Sources</h2>
+        <ul>
+          <li>Local bug bash notes: <code>azure-functions-skills-bug-bash.md</code></li>
+          <li>GitHub issues reviewed: #68 through #79</li>
+          <li>GitHub issue comments: none were returned for #68 through #79 at the time of collection.</li>
+          <li>Japanese source page: <code>docs/bug-bash-feedback-summary-20260519.html</code></li>
+        </ul>
+      </section>
+
+      <section id="links">
+        <h2>3. Useful Links</h2>
+        <p class="lead">Important links for bug bash feedback, formal issue/PR follow-up, Azure Skills references, and VS Code extension integration research.</p>
+        <div class="link-grid">
+          <article class="link-card">
+            <h3>1. Feedback Forum Thread in Teams</h3>
+            <p><strong>Summary:</strong> The main thread for posting Azure Functions Skills Bug Bash feedback.</p>
+            <p><strong>Use:</strong> Use this for lightweight feedback and discussion that does not yet need a formal GitHub issue.</p>
+            <a class="link-action" href="https://teams.microsoft.com/l/message/19:7e8b0770f3504455a6901a79742ac1e5@thread.tacv2/1779211330336?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&amp;groupId=201c2bb2-812d-4986-ac92-9bfad0d6cc59&amp;parentMessageId=1779211330336&amp;teamName=Azure%20Functions%20Team&amp;channelName=Functions.ai%20%F0%9F%A4%96&amp;createdTime=1779211330336">Open the Azure Functions Skills Bug Bash Feedback Forum</a>
+          </article>
+
+          <article class="link-card">
+            <h3>2. Azure Functions Skills GitHub Repository</h3>
+            <p><strong>Summary:</strong> The repository for the skills tested during this bug bash.</p>
+            <p><strong>Use:</strong> Use the README for usage guidance, and GitHub issues or PRs for formal feedback.</p>
+            <a class="link-action" href="https://github.com/Azure/azure-functions-skills/">Open the Azure Functions Skills GitHub repository</a>
+          </article>
+
+          <article class="link-card">
+            <h3>3. Azure Skills Base Repository</h3>
+            <p><strong>Summary:</strong> The repository for broader Azure skills beyond Azure Functions.</p>
+            <p><strong>Use:</strong> Reference this for Azure Functions Skills dependencies, especially deploy workflows, shared logic, and generic Azure best practices.</p>
+            <a class="link-action" href="https://github.com/microsoft/azure-skills/tree/main">Open the Azure Skills repository</a>
+          </article>
+
+          <article class="link-card">
+            <h3>4. VS Code Copilot Extension Configuration Example</h3>
+            <p><strong>Summary:</strong> A reference example for including skills in an extension package.</p>
+            <p><strong>Use:</strong> Use this when exploring whether skills should be bundled with an extension and how enable/disable control might work.</p>
+            <a class="link-action" href="https://github.com/microsoft/vscode/blob/cf238f65873ac96d4d9f9e25a2f01c0d4b733636/extensions/copilot/package.json#L6648">View the skills configuration in VS Code Copilot package.json</a>
+          </article>
+        </div>
+
+        <div class="note-box" style="margin-top: 16px;">
+          <h3>Intent From the Conversation</h3>
+          <ul>
+            <li>Feedback is being collected through two channels: the Teams thread and GitHub issues.</li>
+            <li>Azure Functions Skills are intended to carry Azure Functions-specific knowledge, while Azure Skills should cover generic Azure patterns such as multi-region architecture.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="sentiment">
+        <h2>4. Overall Sentiment</h2>
+        <div class="split">
+          <div class="note-box success">
+            <h3>Positive Signals</h3>
+            <ul>
+              <li>Participants generally supported having a dedicated Azure Functions skill suite.</li>
+              <li>There is clear value in Functions-specific guidance that generic Azure Skills may not cover deeply enough.</li>
+              <li>The workspace-local CLI/setup experience was viewed positively because it reduces global plugin collision risk.</li>
+              <li>The core asset is not the skill file itself, but the Azure Functions team's domain knowledge made available to agents.</li>
+            </ul>
+          </div>
+          <div class="note-box warning">
+            <h3>Main Concerns</h3>
+            <ul>
+              <li>The boundary between Azure Skills and Azure Functions Skills is unclear, especially around create, deploy, best-practices, and upgrade workflows.</li>
+              <li>Global plugin installation can make skills visible in contexts where users did not intend to use them.</li>
+              <li>Install steps, reload requirements, account differences, and plugin/CLI differences can confuse users.</li>
+              <li>As the skill count grows, selection and routing become more important than simple discoverability.</li>
+              <li>LLM skill quality is non-deterministic, so unit tests alone are not enough.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="discussion">
+        <h2>5. Detailed Discussion Notes</h2>
+        <h3>5.1 Scope: Azure Skills vs Azure Functions Skills</h3>
+        <p>The most important topic was the responsibility split between Azure Skills and Azure Functions Skills. Participants agreed that a dedicated Azure Functions skill suite is valuable, but duplicating generic Azure workflows can confuse both users and agents.</p>
+        <p>Areas such as <code>create</code>, <code>deploy</code>, <code>best practices</code>, and <code>upgrade</code> already have related concepts in Azure Skills. Azure Functions Skills should focus on Functions-specific runtime behavior, triggers and bindings, language workers, hosting plans, scaling behavior, diagnostics, and migration paths.</p>
+        <p>Madhura's framing is especially important: Day 0 creation and generic deployment preparation should lean toward Azure Skills, while Day 1+ troubleshooting, upgrades, comparisons, and operational review should be strong Azure Functions Skills responsibilities.</p>
+        <p>The recommended direction is to document a clear boundary and routing contract. Functions-specific questions should be handled directly by Functions Skills, while generic Azure patterns should redirect or delegate to Azure Skills.</p>
+
+        <h3>5.2 Routing and Skill Collision</h3>
+        <p>As the number of skills grows, the problem becomes less about whether users can find a skill and more about whether the correct skill is selected. The bug bash highlighted situations where 100+ skills may be visible, with both Functions-specific and generic Azure skills competing for routing.</p>
+        <p>When a plugin is installed globally, its skills can become candidates in unrelated workspaces or tasks, increasing the risk of collisions and incorrect routing. The agent should act as a router, and the visible skill set should be scoped by agent and workspace context where possible.</p>
+        <p>The <code>functions-copilot</code> agent should have an explicit intent-to-skill routing table, including when to delegate to Azure Skills.</p>
+
+        <h3>5.3 Installation and Onboarding UX</h3>
+        <p>Installation UX was a major friction point. In particular, issue #69 notes that the natural-language-looking <code>copilot plugin marketplace add ...</code> form can be interpreted as an agent prompt, causing unnecessary skill routing and slow installation.</p>
+        <p>The expected experience is that installation runs as a direct command without unrelated skill resolution. Documentation should therefore use the slash command form <code>/plugin marketplace add Azure/azure-functions-skills</code>.</p>
+        <p>The docs should also clearly explain reload/restart requirements, skill list refresh behavior, EMU versus personal account differences, and CLI versus plugin behavior.</p>
+        <ul>
+          <li>Which install path to use for each agent or host.</li>
+          <li>Whether reload or restart is required after installation.</li>
+          <li>The difference between plugin install and workspace-local setup.</li>
+          <li>The possibility that global plugins affect other workspaces.</li>
+          <li>Differences across GitHub Copilot CLI, VS Code, Claude Code, and Codex.</li>
+        </ul>
+
+        <h3>5.4 Discoverability: VS Code, Portal, Marketplace</h3>
+        <p>Participants also discussed where skills should be discovered and launched: VS Code extension integration, Azure Portal Copilot, marketplace/plugin installation, and CLI setup were all mentioned.</p>
+        <p>The core issue is not simply increasing visibility. More visibility can also increase overlap and routing confusion, so discoverability must be designed together with routing, scope control, and installation guidance.</p>
+        <p>Azure Portal Copilot may work well for resource-context workflows such as inventory, health, best-practices review, and diagnostics. VS Code extension integration may be better suited for local project context, code anti-pattern detection, test generation, and migration assistance.</p>
+
+        <h3>5.5 Value Proposition: Best Practices, Diagnostics, Optimization</h3>
+        <p>The strongest value proposition is proactive access to current Azure Functions team recommendations. Participants noted that this is more valuable than relying on outdated community answers or older blog posts.</p>
+        <ul>
+          <li>Detect outdated programming models or runtime versions and recommend migration paths.</li>
+          <li>Highlight migration needs such as Python v1 model, Node.js v3 model, and .NET in-process.</li>
+          <li>Detect customer code anti-patterns such as HTTP client misuse, connection handling issues, Service Bus message lock problems, and retry/concurrency misconfiguration.</li>
+          <li>Provide what-if or preflight checks that catch misconfiguration before deployment.</li>
+          <li>Recommend cost and performance optimizations based on concurrency, scale, hosting plan, and trigger behavior.</li>
+          <li>Support event-driven architecture guidance for Service Bus, Blob, Cosmos DB, and related Functions scenarios.</li>
+        </ul>
+        <p>Finbar emphasized preventing CRIs and production incidents before they occur. Swapnil emphasized that user churn often comes from unknowns: runtime behavior, binding recommendations, testing approaches, and observability setup that users may not know to ask about.</p>
+
+        <h3>5.6 Knowledge as the Asset</h3>
+        <p>A repeated point was that the real value is domain knowledge, not the skill packaging itself. Skills are a way to deliver operational knowledge, known issues, migration paths, best practices, and source-level references to agents.</p>
+        <p>Knowledge fragmentation is a risk. If Dobby, SRE agents, Azure Skills, Azure Functions Skills, docs, and internal troubleshooting knowledge drift apart, the same question can receive different answers. The ideal direction is to move Functions-specific knowledge toward a single source of truth that multiple agents and channels can consume.</p>
+
+        <h3>5.7 Evaluation and Quality</h3>
+        <p>Quality evaluation for LLM-based skills remains a major open problem. Unlike deterministic code, agents can produce different outputs for the same prompt, so CI validation for text-based skills needs more than simple unit tests.</p>
+        <p>Zach proposed an agent-based evaluation model where an outer agent evaluates the output of an inner agent. This can help assess whether the right skill was used, whether key dimensions were covered, and whether unsafe or misleading recommendations were avoided.</p>
+        <ul>
+          <li>Static validation: SKILL.md, frontmatter, references, links, and agent manifest structure.</li>
+          <li>Unit/integration tests: deterministic checks for CLI setup, plugin packaging, and script behavior.</li>
+          <li>E2E smoke tests: whether the agent recognizes the skills and returns expected high-level output.</li>
+          <li>Agent-based eval: rubric-driven assessment of output quality, routing, coverage, and safety.</li>
+        </ul>
+
+        <h3>5.8 Feedback Collection</h3>
+        <p>Feedback is distributed across Teams threads, meeting chat, GitHub issues, and the feedback skill. Madhura pointed out that input needs to be aggregated from multiple places.</p>
+        <p>A better workflow would use the feedback skill to generate issue drafts from chat or thread content, or periodically generate bug bash summaries that link back to GitHub issues. The goal is a single intake and triage flow that does not lose context.</p>
+      </section>
+
+      <section id="issues" class="section-plain">
+        <h2>6. GitHub Issues #68-#79</h2>
+        <div class="issue-grid">
+          <article class="issue product"><h3>#68: best-practices review dimensions expansion</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/68">Issue #68</a></div><p>Expand <code>azure-functions-best-practices</code> full review to automatically include programming model version, runtime version, extension bundle range, and reliability posture. This requires updates to <code>review-checklist.md</code>, workflow routing, and report output shape.</p></article>
+          <article class="issue critical"><h3>#69: GHCP install instructions should use slash command</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/69">Issue #69</a></div><p>Update README and installation docs to use <code>/plugin marketplace add Azure/azure-functions-skills</code> instead of a natural-language-looking command that can trigger unrelated skill routing.</p></article>
+          <article class="issue product"><h3>#70: New azure-functions-upgrade skill</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/70">Issue #70</a></div><p>Create an upgrade skill for language versions, extension bundles, programming models, .NET isolated migration, and Functions runtime v4 migration. Route CV1 to Flex Consumption to Azure Skills <code>azure-upgrade</code>.</p></article>
+          <article class="issue new-skill"><h3>#71: SDK-type bindings recommendation</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/71">Issue #71</a></div><p>Recommend SDK-type bindings as the modern approach for Service Bus, Blob, Cosmos DB, and related bindings. This affects best-practices, create, diagnostics, and common references.</p></article>
+          <article class="issue new-skill"><h3>#72: Functions testing skills</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/72">Issue #72</a></div><p>Propose a Functions testing skill covering unit tests, integration tests, local emulators, trigger-specific tests, and CI validation.</p></article>
+          <article class="issue new-skill"><h3>#73: OpenTelemetry skill for language support</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/73">Issue #73</a></div><p>Propose a language-specific OpenTelemetry skill covering OTEL setup, sampling, trace correlation, dependency tracking, logs, metrics, traces, and validation.</p></article>
+          <article class="issue critical"><h3>#74: Kudu API auth path improvements</h3><div class="issue-meta"><span class="tag">FinVamp1</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/74">Issue #74</a></div><p>Before calling the Kudu VFS API, check whether SCM basic auth publishing credentials are enabled. If disabled, fall back to an Entra token for the App Service audience.</p></article>
+          <article class="issue new-skill"><h3>#75: EOL language migration skill</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/75">Issue #75</a></div><p>Propose a skill for migration away from end-of-life language versions. This likely belongs initially as a language EOL dimension in <code>azure-functions-upgrade</code>.</p></article>
+          <article class="issue new-skill"><h3>#76: Performance and scaling configuration skill</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/76">Issue #76</a></div><p>Propose scenario-based performance and scaling guidance, including cost optimization, concurrency tuning, scale behavior, and event-driven design.</p></article>
+          <article class="issue critical"><h3>#77: Setup should warn about outdated tool versions</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/77">Issue #77</a></div><p><code>azure-functions-setup</code> currently reports all-green even when tools are outdated. Add tiered indicators for up-to-date, near-latest, outdated, and missing or unsupported versions.</p></article>
+          <article class="issue critical"><h3>#78: Invalid FUNCTIONS_WORKER_RUNTIME attribution</h3><div class="issue-meta"><span class="tag">FinVamp1</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/78">Issue #78</a></div><p>Diagnose <code>WorkerConfig for runtime: node27 not found</code> as an invalid <code>FUNCTIONS_WORKER_RUNTIME=node27</code> value, not as <code>WEBSITE_NODE_DEFAULT_VERSION</code>.</p></article>
+          <article class="issue critical"><h3>#79: Use Functions Host health check endpoints</h3><div class="issue-meta"><span class="tag">FinVamp1</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/79">Issue #79</a></div><p>Add <code>/runtime/health</code>, <code>/runtime/health/live</code>, and <code>/runtime/health/ready</code> to the health-status workflow so direct host health is checked before telemetry fallback.</p></article>
+        </div>
+      </section>
+
+      <section id="themes" class="section-plain">
+        <h2>7. Consolidated Themes and Proposed Directions</h2>
+        <div class="theme-grid">
+          <article class="theme"><h3>Theme A: Define the Product Boundary</h3><p>Position Azure Functions Skills as a Functions-specific domain layer, not merely a subset of generic Azure skills. Create a scope matrix, skill ownership table, and delegation rules for Azure Skills.</p></article>
+          <article class="theme"><h3>Theme B: Make Installation Boring and Predictable</h3><p>Use slash command installation guidance, provide verification prompts and expected output, clarify plugin versus workspace-local setup, and document reload or restart requirements.</p></article>
+          <article class="theme"><h3>Theme C: Expand Best Practices</h3><p>Evolve best-practices review into a proactive cross-cutting assessment across runtime, model, bundles, reliability, identity, networking, security, observability, and scale.</p></article>
+          <article class="theme"><h3>Theme D: Build Upgrade Workflow</h3><p>Create <code>azure-functions-upgrade</code> to provide migration paths, code and configuration changes, breaking-change awareness, and validation steps.</p></article>
+          <article class="theme"><h3>Theme E: Improve Diagnostics Evidence</h3><p>Make root cause attribution precise and evidence-first, including error strings, setting values, valid values, and next commands.</p></article>
+          <article class="theme"><h3>Theme F: Invest in New Skills</h3><p>Testing, OTEL/observability, and performance/scaling are high-value backlog items because they map directly to real customer pain.</p></article>
+        </div>
+      </section>
+
+      <section id="todo" class="section-plain">
+        <h2>8. Prioritized TODO</h2>
+        <div class="todo-grid">
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#69</span></div><h4><span class="todo-number">1.</span> Update GHCP install documentation to slash command syntax</h4><p>Update README, usage docs, and plugin install examples.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#77</span></div><h4><span class="todo-number">2.</span> Add outdated-version warning behavior to setup</h4><p>Add tiered indicators and upgrade command output.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#78</span></div><h4><span class="todo-number">3.</span> Fix invalid FUNCTIONS_WORKER_RUNTIME diagnosis</h4><p>Add valid value references, diagnostic pattern mapping, and inventory/best-practices validation.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#74</span></div><h4><span class="todo-number">4.</span> Add SCM credential policy check and Entra fallback</h4><p>Update inventory/health scripts, auth path docs, and validation coverage.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#79</span></div><h4><span class="todo-number">5.</span> Add Functions Host health endpoints</h4><p>Add native liveness/readiness evidence to the health-status workflow.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span><span class="tag">#68</span></div><h4><span class="todo-number">6.</span> Expand best-practices full review dimensions</h4><p>Add runtime, model, bundle, and reliability checks to full review.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span></div><h4><span class="todo-number">7.</span> Define Azure Skills vs Azure Functions Skills scope matrix</h4><p>Create a skill ownership table and delegation rules.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span></div><h4><span class="todo-number">8.</span> Create functions-copilot routing matrix</h4><p>Document agent instructions, intent-to-skill mapping, fallback, and delegation guidance.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span><span class="tag">#70</span><span class="tag">#75</span></div><h4><span class="todo-number">9.</span> Implement azure-functions-upgrade skill skeleton</h4><p>Add the core workflow that connects outdated/EOL detection to migration guidance.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span><span class="tag">#71</span></div><h4><span class="todo-number">10.</span> Add SDK-type bindings recommendation references</h4><p>Add common references, binding checklist updates, and language-specific notes.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span><span class="tag">#72</span></div><h4><span class="todo-number">11.</span> Design Functions Testing skill</h4><p>Create scope docs, sample prompts, and a trigger-specific testing matrix.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span><span class="tag">#73</span></div><h4><span class="todo-number">12.</span> Design OTEL/observability skill</h4><p>Design language support matrix, setup validation, and App Insights/OTEL guidance.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span><span class="tag">#76</span></div><h4><span class="todo-number">13.</span> Design performance/scaling optimization skill</h4><p>Create scenario intake questions, hosting plan/trigger tuning matrix, and cost/performance checklist.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span></div><h4><span class="todo-number">14.</span> Build feedback aggregation workflow</h4><p>Aggregate feedback from Teams, chat, issues, and the feedback skill.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span></div><h4><span class="todo-number">15.</span> Create layered eval strategy</h4><p>Define rubric and CI gating levels across static, unit, E2E, and agent-based evals.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p3">P3</span></div><h4><span class="todo-number">16.</span> Investigate VS Code and Azure Portal integration paths</h4><p>Create channel-specific user journeys and integration proposals.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p3">P3</span></div><h4><span class="todo-number">17.</span> Establish a Functions knowledge registry plan</h4><p>Define knowledge ownership, reference update process, and shared docs/reference strategy.</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p3">P3</span></div><h4><span class="todo-number">18.</span> Clarify global plugin vs workspace-local setup recommendation</h4><p>Document decision guide, known limitations, and recommended setup per scenario.</p></article>
+        </div>
+      </section>
+
+      <section id="triage">
+        <h2>9. Suggested Triage Order</h2>
+        <ol class="triage-list">
+          <li>Complete the concrete fixes first: #69, #77, #78, #74, and #79.</li>
+          <li>Implement the #68 best-practices expansion and make best-practices the core proactive review workflow.</li>
+          <li>Create the Azure Skills versus Azure Functions Skills scope/routing document to stabilize future skill decisions.</li>
+          <li>Build <code>azure-functions-upgrade</code>, combining #70 and #75.</li>
+          <li>Organize #71, #72, #73, and #76 as a new-skill backlog, with testing, observability, and performance/scaling as the likely sequence.</li>
+          <li>Create a minimal E2E plus agent-based eval rubric and use it as a quality gate for future skill additions.</li>
+        </ol>
+        <p>This order balances short-term UX and bug fixes, improvement of existing skills, investment in new skills, and the quality infrastructure needed to keep the suite healthy.</p>
+      </section>
+    </main>
+  </div>
+
+  <footer class="footer">
+    English version generated from <code>docs/bug-bash-feedback-summary-20260519.html</code>. Standalone HTML for review and sharing.
+  </footer>
+</body>
+</html>

--- a/docs/bug-bash-feedback-summary-20260519.html
+++ b/docs/bug-bash-feedback-summary-20260519.html
@@ -1,0 +1,569 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Azure Functions Skills Bug Bash Feedback Summary</title>
+  <style>
+    :root {
+      --bg: #f6f8fb;
+      --surface: #ffffff;
+      --soft: #eef5ff;
+      --text: #1d2635;
+      --muted: #5f6f86;
+      --line: #d9e2ef;
+      --azure: #0078d4;
+      --azure-dark: #005a9e;
+      --teal: #008575;
+      --orange: #c85f00;
+      --red: #c4314b;
+      --shadow: 0 18px 45px rgba(24, 39, 75, 0.10);
+      --radius: 8px;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      font-family: "Segoe UI", "Yu Gothic UI", "Meiryo", system-ui, sans-serif;
+      line-height: 1.75;
+      letter-spacing: 0;
+    }
+
+    a { color: var(--azure-dark); text-underline-offset: 0.18em; }
+
+    code {
+      padding: 0.12rem 0.34rem;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #f4f7fb;
+      font-family: Consolas, "Cascadia Code", monospace;
+      font-size: 0.92em;
+    }
+
+    .hero {
+      color: #ffffff;
+      background: linear-gradient(135deg, #005a9e 0%, #0078d4 52%, #008575 100%);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    .hero-inner, .layout, .footer {
+      width: min(1180px, calc(100% - 40px));
+      margin: 0 auto;
+    }
+
+    .hero-inner { padding: 54px 0 36px; }
+
+    .kicker {
+      margin: 0 0 10px;
+      color: rgba(255, 255, 255, 0.84);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 960px;
+      margin: 0;
+      font-size: clamp(2.25rem, 5vw, 4.4rem);
+      line-height: 1.06;
+      letter-spacing: 0;
+    }
+
+    .hero-summary {
+      max-width: 930px;
+      margin: 20px 0 0;
+      color: rgba(255, 255, 255, 0.92);
+      font-size: 1.06rem;
+    }
+
+    .meta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 24px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 34px;
+      padding: 6px 12px;
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.14);
+      color: #ffffff;
+      font-size: 0.9rem;
+    }
+
+    a.pill {
+      color: #ffffff;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    a.pill:hover {
+      background: rgba(255, 255, 255, 0.22);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: 270px minmax(0, 1fr);
+      gap: 28px;
+      margin-top: 28px;
+      margin-bottom: 56px;
+      align-items: start;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 10px 30px rgba(24, 39, 75, 0.06);
+    }
+
+    .toc h2 {
+      margin: 0 0 12px;
+      color: var(--muted);
+      font-size: 0.84rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .toc a {
+      display: block;
+      padding: 8px 0;
+      border-top: 1px solid #edf1f7;
+      color: var(--text);
+      font-size: 0.92rem;
+      text-decoration: none;
+    }
+
+    .toc a:hover { color: var(--azure-dark); }
+
+    main { min-width: 0; }
+
+    section {
+      margin-bottom: 28px;
+      padding: 28px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 12px 36px rgba(24, 39, 75, 0.06);
+    }
+
+    .section-plain {
+      padding: 0;
+      border: 0;
+      background: transparent;
+      box-shadow: none;
+    }
+
+    h2, h3, h4 { line-height: 1.25; letter-spacing: 0; }
+    h2 { margin: 0 0 16px; color: #10243f; font-size: 1.6rem; }
+    h3 { margin: 24px 0 10px; color: #183a63; font-size: 1.18rem; }
+    h4 { margin: 0 0 8px; font-size: 1rem; }
+    p { margin: 0 0 14px; }
+    ul, ol { margin: 10px 0 0; padding-left: 1.35rem; }
+    li { margin: 7px 0; }
+    .lead { color: #33465e; font-size: 1.04rem; }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .metric {
+      min-height: 120px;
+      padding: 16px;
+      border: 1px solid #cfe0f4;
+      border-radius: var(--radius);
+      background: linear-gradient(180deg, #ffffff, #f3f8ff);
+    }
+
+    .metric strong {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--azure-dark);
+      font-size: 1.55rem;
+      line-height: 1;
+    }
+
+    .metric span { display: block; color: #38506c; font-size: 0.9rem; line-height: 1.45; }
+
+    .split, .theme-grid, .issue-grid, .todo-grid, .link-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .note-box, .theme, .issue, .todo, .link-card {
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+    }
+
+    .note-box { border-left: 4px solid var(--azure); background: var(--soft); }
+    .note-box.warning { border-left-color: var(--orange); background: #fff7ed; }
+    .note-box.success { border-left-color: var(--teal); background: #eefaf7; }
+    .theme { border-top: 4px solid var(--azure); }
+    .issue { border-top: 4px solid #6f89a8; }
+    .issue.critical { border-top-color: var(--red); }
+    .issue.product { border-top-color: var(--azure); }
+    .issue.new-skill { border-top-color: var(--teal); }
+    .link-card { border-top: 4px solid var(--azure); }
+    .link-card h3 { margin-top: 0; }
+    .link-card .link-action { display: inline-flex; margin-top: 4px; font-weight: 700; }
+
+    .issue-meta, .todo-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 8px 0 12px;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 26px;
+      padding: 3px 9px;
+      border-radius: 999px;
+      color: #284057;
+      background: #eef2f7;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .tag.p0 { color: #8a1f32; background: #ffe8ed; }
+    .tag.p1 { color: #005a9e; background: #e4f1ff; }
+    .tag.p2 { color: #006b5e; background: #dcf8f2; }
+    .tag.p3 { color: #665100; background: #fff5c2; }
+    .todo-number { color: var(--azure-dark); font-weight: 800; }
+
+    .triage-list {
+      counter-reset: triage;
+      list-style: none;
+      padding-left: 0;
+    }
+
+    .triage-list li {
+      counter-increment: triage;
+      display: grid;
+      grid-template-columns: 38px minmax(0, 1fr);
+      gap: 12px;
+      align-items: start;
+      margin: 12px 0;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+    }
+
+    .triage-list li::before {
+      content: counter(triage);
+      display: grid;
+      width: 32px;
+      height: 32px;
+      place-items: center;
+      border-radius: 50%;
+      color: #ffffff;
+      background: var(--azure);
+      font-weight: 800;
+    }
+
+    .footer {
+      margin-bottom: 40px;
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-align: center;
+    }
+
+    @media (max-width: 980px) {
+      .layout { display: block; }
+      .toc { position: static; margin-bottom: 20px; }
+      .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .theme-grid, .issue-grid, .todo-grid, .link-grid, .split { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 620px) {
+      .hero-inner, .layout, .footer { width: min(100% - 24px, 1180px); }
+      .hero-inner { padding: 38px 0 26px; }
+      section { padding: 20px; }
+      .summary-grid { grid-template-columns: 1fr; }
+    }
+
+    @media print {
+      body { background: #ffffff; }
+      .hero { color: #000000; background: #ffffff; }
+      .toc { display: none; }
+      .layout, .footer { width: 100%; margin: 0; }
+      section, .theme, .issue, .todo, .metric, .triage-list li { box-shadow: none; break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <p class="kicker">Bug Bash Feedback Summary</p>
+      <h1>Azure Functions Skills</h1>
+      <p class="hero-summary">会話記録と GitHub issue #68 以降を統合し、収集されたコメント、意見、アイデア、提案を議事内容として整理した HTML 版です。</p>
+      <div class="meta-row" aria-label="Document metadata">
+        <span class="pill">Date: 2026-05-19</span>
+        <span class="pill">Issues: #68-#79</span>
+        <span class="pill">Focus: Scope, UX, Routing, Quality</span>
+        <a class="pill" href="/bug-bash/">English default</a>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <a href="#summary">Executive Summary</a>
+      <a href="#sources">Input Sources</a>
+      <a href="#links">Useful Links</a>
+      <a href="#sentiment">Overall Sentiment</a>
+      <a href="#discussion">Discussion Notes</a>
+      <a href="#issues">GitHub Issues</a>
+      <a href="#themes">Themes and Directions</a>
+      <a href="#todo">Prioritized TODO</a>
+      <a href="#triage">Suggested Triage Order</a>
+    </nav>
+
+    <main>
+      <section id="summary">
+        <h2>1. Executive Summary</h2>
+        <p class="lead">今回の bug bash で集まったフィードバックは、単なる個別バグ修正ではなく、Azure Functions Skills をどのような責務を持つ skill suite として育てるか、という設計上の論点が中心だった。</p>
+        <p>全体として、Azure Functions に特化した Copilot/agent skills の方向性は好意的に受け止められている。特に、Azure Functions team が持つドメイン知識を、作成、診断、ベストプラクティス、アップグレード、運用レビューの形で agent に渡せることには価値がある、という認識が共有された。一方で、Azure Skills との重複、plugin install の UX、skill の多さによる routing の不透明さ、品質評価の難しさが大きな課題として挙がっている。</p>
+
+        <div class="summary-grid" aria-label="Top themes">
+          <div class="metric"><strong>1</strong><span>Azure Skills と Azure Functions Skills のスコープ境界を明確化する。</span></div>
+          <div class="metric"><strong>2</strong><span>100 個以上の skill が見える環境でも正しい skill が選ばれる routing/agent 体験を作る。</span></div>
+          <div class="metric"><strong>3</strong><span>install、reload、account、plugin/CLI 差分など導入 UX の摩擦を減らす。</span></div>
+          <div class="metric"><strong>4</strong><span>Functions team の推奨知識を実用 skill に落とし込む。</span></div>
+          <div class="metric"><strong>5</strong><span>E2E と agent-based eval を組み合わせ、品質を継続的に評価する。</span></div>
+        </div>
+      </section>
+
+      <section id="sources">
+        <h2>2. Input Sources</h2>
+        <ul>
+          <li>Local bug bash notes: <code>azure-functions-skills-bug-bash.md</code></li>
+          <li>GitHub issues reviewed: #68 through #79</li>
+          <li>GitHub issue comments: none were returned for #68 through #79 at the time of collection.</li>
+        </ul>
+      </section>
+
+      <section id="links">
+        <h2>3. Useful Links</h2>
+        <p class="lead">Bug Bash のフィードバック投稿、正式な issue/PR、関連する Azure Skills、VS Code extension 統合検討に使う重要リンクです。</p>
+        <div class="link-grid">
+          <article class="link-card">
+            <h3>1. フィードバック投稿スレッド（Teams）</h3>
+            <p><strong>概要:</strong> Bug Bash のフィードバックを投稿するためのメインスレッド。</p>
+            <p><strong>用途:</strong> Issue 以外の軽いフィードバックや議論はこちらに集約する。</p>
+            <a class="link-action" href="https://teams.microsoft.com/l/message/19:7e8b0770f3504455a6901a79742ac1e5@thread.tacv2/1779211330336?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&amp;groupId=201c2bb2-812d-4986-ac92-9bfad0d6cc59&amp;parentMessageId=1779211330336&amp;teamName=Azure%20Functions%20Team&amp;channelName=Functions.ai%20%F0%9F%A4%96&amp;createdTime=1779211330336">Azure Functions Skills Bug Bash - Feedback Forum を開く</a>
+          </article>
+
+          <article class="link-card">
+            <h3>2. Azure Functions Skills GitHub Repository</h3>
+            <p><strong>概要:</strong> 今回テスト対象となるスキルのリポジトリ。</p>
+            <p><strong>用途:</strong> README で使い方を確認し、Issue / PR で正式なフィードバックを行う。</p>
+            <a class="link-action" href="https://github.com/Azure/azure-functions-skills/">Azure Functions Skills GitHub リポジトリを見る</a>
+          </article>
+
+          <article class="link-card">
+            <h3>3. Azure Skills ベーススキル リポジトリ</h3>
+            <p><strong>概要:</strong> Azure 全体のスキルを扱う、Functions 以外も含むベーススキルのリポジトリ。</p>
+            <p><strong>用途:</strong> Functions Skills の依存、特に deploy 系や共通ロジック、ベストプラクティスの参照に使う。</p>
+            <a class="link-action" href="https://github.com/microsoft/azure-skills/tree/main">Azure Skills リポジトリを見る</a>
+          </article>
+
+          <article class="link-card">
+            <h3>4. VS Code Copilot Extension の設定例</h3>
+            <p><strong>概要:</strong> 拡張機能に skills を組み込む方法の参考例。</p>
+            <p><strong>用途:</strong> extension 側に skills を含める設計検討や、enable/disable 制御の実装参考に使う。</p>
+            <a class="link-action" href="https://github.com/microsoft/vscode/blob/cf238f65873ac96d4d9f9e25a2f01c0d4b733636/extensions/copilot/package.json#L6648">VS Code Copilot package.json の skills 設定部分を見る</a>
+          </article>
+        </div>
+
+        <div class="note-box" style="margin-top: 16px;">
+          <h3>会話からの補足意図</h3>
+          <ul>
+            <li>フィードバックは Teams スレッドまたは GitHub issue の 2 系統で収集している。</li>
+            <li>Azure Functions Skills は Functions 特化の知識を担当し、Azure Skills はマルチリージョンなどの汎用 Azure パターンを担当する、という役割分担で設計されている。</li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="sentiment">
+        <h2>4. Overall Sentiment</h2>
+        <div class="split">
+          <div class="note-box success">
+            <h3>Positive Signals</h3>
+            <ul>
+              <li>Azure Functions 専用の skill suite を持つこと自体は、複数参加者から肯定的に見られている。</li>
+              <li>汎用 Azure Skills では拾いきれない Functions-specific な設計、移行、診断、ベストプラクティスに価値がある。</li>
+              <li>workspace-local な CLI/setup 体験は、global plugin よりも競合を避けやすく、方向性として評価されている。</li>
+              <li>「skill そのもの」よりも「Azure Functions team の知識を agent が利用できること」が本質的価値だ、という理解が強い。</li>
+            </ul>
+          </div>
+          <div class="note-box warning">
+            <h3>Main Concerns</h3>
+            <ul>
+              <li>Azure Skills と Azure Functions Skills の境界が不明確で、create/deploy/best-practices/upgrade のような領域で重複や競合が起きる。</li>
+              <li>plugin install が global に効くため、ユーザーが意図しない skill routing や skill 衝突に遭遇する可能性がある。</li>
+              <li>install 手順や reload 要否がわかりにくく、GitHub Copilot CLI、VS Code、EMU/個人アカウント、plugin/CLI の体験差が混乱を生んでいる。</li>
+              <li>skill が増えるほど discoverability よりも selection/routing の問題が大きくなる。</li>
+              <li>LLM skill の品質評価は非決定的であり、通常の unit test だけでは十分ではない。</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="discussion">
+        <h2>5. Detailed Discussion Notes</h2>
+        <h3>4.1 Scope: Azure Skills vs Azure Functions Skills</h3>
+        <p>最も重要な論点は、Azure Skills と Azure Functions Skills の責務分担である。Azure Functions 専用 skill を分離することには価値があるが、汎用 Azure Skills と同じ領域を二重実装すると、ユーザーも agent も混乱するという指摘があった。</p>
+        <p>特に <code>create</code>、<code>deploy</code>、<code>best practices</code>、<code>upgrade</code> は Azure Skills 側にも近い概念が存在する。Azure Functions Skills は、Azure 全般の一般論ではなく、Functions 固有の runtime、trigger/binding、language worker、hosting plan、scale behavior、diagnostics、migration path に寄せるべきだ、という方向性が見えている。</p>
+        <p>Madhura の整理として、Day 0 の作成や汎用 deployment preparation は Azure Skills に寄せ、Day 1+ の troubleshooting、upgrade、comparison、operational review は Azure Functions Skills が強く担当する、という考え方が重要である。</p>
+        <p>推奨される方向性は、明確な境界と routing contract を文書化することである。Functions-specific な問いは Functions Skills が直接処理し、共通 Azure pattern は Azure Skills へ redirect または delegate する。</p>
+
+        <h3>4.2 Routing and Skill Collision</h3>
+        <p>skill が増えるほど、ユーザーにとっての問題は「skill を見つけられるか」だけではなく、「正しい skill が選ばれるか」になる。bug bash では、100 個以上の skill が見える状況や、Functions 系と汎用 Azure 系の skill が混在する状況が指摘された。</p>
+        <p>plugin が global にインストールされる場合、別 workspace や別 task でも意図せず skill が routing 候補に入るため、衝突や誤選択が起きやすい。agent が router として機能し、visible な skill を agent や workspace の context によって絞る設計が必要である。</p>
+        <p>今後は、<code>functions-copilot</code> agent がどの user intent をどの skill に route するかを、routing table として明文化し、必要に応じて Azure Skills への delegation も含めるべきである。</p>
+
+        <h3>4.3 Installation and Onboarding UX</h3>
+        <p>install UX は大きな摩擦点として挙がった。特に GitHub Copilot CLI の plugin install において、自然言語に見える <code>copilot plugin marketplace add ...</code> が agent prompt として解釈され、不要な skill routing が発生して install が遅くなる、という issue #69 が作成されている。</p>
+        <p>期待される体験は、install が direct command として実行され、無関係な skill resolution を起こさないことである。そのため README などの手順は <code>/plugin marketplace add Azure/azure-functions-skills</code> のような slash command 形式に更新する必要がある。</p>
+        <p>install 後に reload/restart が必要な場合にそれが明示されない、skills list に反映されない、EMU と個人アカウントで挙動が異なる、CLI と plugin の体験差がある、という混乱も挙げられた。</p>
+        <ul>
+          <li>どの agent/host でどの install path を使うべきか。</li>
+          <li>install 後に reload/restart が必要か。</li>
+          <li>plugin install と workspace-local setup の違い。</li>
+          <li>global plugin が他 workspace に影響する可能性。</li>
+          <li>GitHub Copilot CLI、VS Code、Claude Code、Codex での差分。</li>
+        </ul>
+
+        <h3>4.4 Discoverability: VS Code, Portal, Marketplace</h3>
+        <p>skill をどこで発見し、どこから使うのかも未整理である。候補として、VS Code extension への統合、Azure Portal Copilot への統合、marketplace/plugin からの導入、CLI setup などが挙がっている。</p>
+        <p>ただし、この議論の本質は単なる露出面の増加ではない。露出が増えるほど、skill の重複と routing の問題も増える。そのため、discoverability の改善は routing、scope control、install guidance とセットで考える必要がある。</p>
+        <p>Azure Portal Copilot に入れる場合は、既に対象 resource context があるため inventory/health/best-practices/diagnostics と相性が良い。一方、VS Code extension 統合では local project context、code anti-pattern detection、test generation、migration assistance と相性が良い。</p>
+
+        <h3>4.5 Value Proposition: Best Practices, Diagnostics, Optimization</h3>
+        <p>参加者から強く支持された価値は、Azure Functions team の推奨を agent が proactive に提供することである。特に、StackOverflow や古い blog に残る outdated な知識より、Functions team の現在の推奨を参照できることが価値だという意見があった。</p>
+        <ul>
+          <li>outdated な programming model や runtime version を検出し、推奨移行先を提示する。</li>
+          <li>Python v1 model、Node.js v3 model、.NET in-process など、移行が必要な領域を明確にする。</li>
+          <li>HTTP client misuse、connection management、Service Bus message lock、retry/concurrency 設定など、customer code anti-pattern を検出する。</li>
+          <li>deployment 前に misconfiguration を見つける what-if/preflight 的なチェックを提供する。</li>
+          <li>concurrency、scale、hosting plan、trigger behavior に基づく cost/performance optimization を提案する。</li>
+          <li>event-driven architecture、Service Bus、Blob、Cosmos DB など、Functions の主用途に近い設計支援を行う。</li>
+        </ul>
+        <p>Finbar の観点として、CRI や production incident を未然に防ぐことが非常に重要である。Swapnil の観点として、Functions 利用者の churn の一因は「知らないこと」にある。</p>
+
+        <h3>4.6 Knowledge as the Asset</h3>
+        <p>bug bash では、「重要なのは skill そのものではなく domain knowledge である」という認識が繰り返し出ている。skill は知識を agent に届けるための packaging であり、価値の中心は Azure Functions team が持つ operational knowledge、known issues、migration paths、best practices、source-level references である。</p>
+        <p>Dobby、SRE agent、Azure Skills、Azure Functions Skills、docs repo、internal troubleshooting knowledge が別々に存在すると、同じ問いに対して異なる回答が出る可能性がある。理想は、Functions-specific knowledge をできるだけ single source of truth に寄せ、それを複数 agent/channel から利用できるようにすることである。</p>
+
+        <h3>4.7 Evaluation and Quality</h3>
+        <p>LLM skill の品質担保は未解決の大課題として挙がっている。通常の deterministic test と違い、agent は同じ prompt でも出力が揺れる。text-based skill の品質をどのように CI で検証するかは、今後の重要テーマである。</p>
+        <p>Zach のアイデアとして、outer agent が inner agent の出力を評価する agent-based eval が挙がった。これは、単純な string assertion では評価しにくい「正しい skill を使ったか」「必要な観点を含んだか」「危険な提案を避けたか」を判定するのに有効である。</p>
+        <ul>
+          <li>Static validation: SKILL.md、frontmatter、references、links、agent manifests の構造検証。</li>
+          <li>Unit/integration tests: CLI setup、plugin packaging、script behavior の deterministic test。</li>
+          <li>E2E smoke tests: agent が skill を認識し、期待される high-level output を返すか。</li>
+          <li>Agent-based eval: 出力品質、routing、coverage、safety を rubric で評価する。</li>
+        </ul>
+
+        <h3>4.8 Feedback Collection</h3>
+        <p>フィードバックは Teams thread、meeting chat、GitHub issues、feedback skill に分散している。Madhura からは、複数の場所から集約する必要があるという指摘があった。</p>
+        <p>今後は、feedback skill を使って chat/thread から issue draft を生成する、または bug bash summary を定期的に生成して GitHub issue に link するなど、単一の intake/triage flow を作るべきである。</p>
+      </section>
+
+      <section id="issues" class="section-plain">
+        <h2>6. GitHub Issues #68-#79</h2>
+        <div class="issue-grid">
+          <article class="issue product"><h3>#68: best-practices review dimensions expansion</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/68">Issue #68</a></div><p><code>azure-functions-best-practices</code> の full review に programming model version、runtime version、extension bundle range、reliability posture を自動的に含める提案。<code>review-checklist.md</code>、workflow routing、output shape の更新が必要。</p></article>
+          <article class="issue critical"><h3>#69: GHCP install instructions should use slash command</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/69">Issue #69</a></div><p>自然言語形式ではなく <code>/plugin marketplace add Azure/azure-functions-skills</code> を使うよう README と install docs を更新する。不要な skill routing による遅延を避ける。</p></article>
+          <article class="issue product"><h3>#70: New azure-functions-upgrade skill</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/70">Issue #70</a></div><p>language version、extension bundle、programming model、.NET isolated worker、runtime v4 migration を案内する新 skill。CV1 から Flex は Azure Skills の <code>azure-upgrade</code> へ route する。</p></article>
+          <article class="issue new-skill"><h3>#71: SDK-type bindings recommendation</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/71">Issue #71</a></div><p>Service Bus、Blob、Cosmos DB などで modern recommended approach として SDK-type bindings を推奨する提案。best-practices、create、diagnostics、common references に横断的に関係する。</p></article>
+          <article class="issue new-skill"><h3>#72: Functions testing skills</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/72">Issue #72</a></div><p>unit test、integration test、local emulator、trigger-specific test、CI validation を案内する Azure Functions testing skill の提案。</p></article>
+          <article class="issue new-skill"><h3>#73: OpenTelemetry skill for language support</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/73">Issue #73</a></div><p>言語ごとの OTEL setup、sampling、trace correlation、dependency tracking、logs/metrics/traces の guidance と validation を扱う新 skill 提案。</p></article>
+          <article class="issue critical"><h3>#74: Kudu API auth path improvements</h3><div class="issue-meta"><span class="tag">FinVamp1</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/74">Issue #74</a></div><p>Kudu VFS API を使う前に SCM basic auth publishing credentials が有効か確認し、無効な場合は App Service audience の Entra token に fallback する。</p></article>
+          <article class="issue new-skill"><h3>#75: EOL language migration skill</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/75">Issue #75</a></div><p>End-of-life language version からの migration を扱う新 skill 提案。まずは <code>azure-functions-upgrade</code> の language EOL dimension として統合するのが自然。</p></article>
+          <article class="issue new-skill"><h3>#76: Performance and scaling configuration skill</h3><div class="issue-meta"><span class="tag">swapnil-nagar</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/76">Issue #76</a></div><p>customer scenario に基づき performance と scaling configuration を提案する新 skill。cost optimization、concurrency tuning、scale behavior、event-driven design と重なる。</p></article>
+          <article class="issue critical"><h3>#77: Setup should warn about outdated tool versions</h3><div class="issue-meta"><span class="tag">MadhuraBharadwaj-MSFT</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/77">Issue #77</a></div><p><code>azure-functions-setup</code> が古い tool でも all-green を出す問題。latest/near-latest/outdated/missing-or-unsupported の tiered indicator と upgrade command が必要。</p></article>
+          <article class="issue critical"><h3>#78: Invalid FUNCTIONS_WORKER_RUNTIME attribution</h3><div class="issue-meta"><span class="tag">FinVamp1</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/78">Issue #78</a></div><p><code>WorkerConfig for runtime: node27 not found</code> を <code>WEBSITE_NODE_DEFAULT_VERSION</code> ではなく <code>FUNCTIONS_WORKER_RUNTIME=node27</code> の invalid value と診断すべき。</p></article>
+          <article class="issue critical"><h3>#79: Use Functions Host health check endpoints</h3><div class="issue-meta"><span class="tag">FinVamp1</span><span class="tag">OPEN</span><a class="tag" href="https://github.com/Azure/azure-functions-skills/issues/79">Issue #79</a></div><p><code>/runtime/health</code>、<code>/runtime/health/live</code>、<code>/runtime/health/ready</code> を health-status workflow に追加し、direct host health を確認する。</p></article>
+        </div>
+      </section>
+
+      <section id="themes" class="section-plain">
+        <h2>7. Consolidated Themes and Proposed Directions</h2>
+        <div class="theme-grid">
+          <article class="theme"><h3>Theme A: Define the Product Boundary</h3><p>Azure Functions Skills は、Azure 全般 skill の subset ではなく、Functions 固有の domain layer として位置付ける。Scope matrix、skill ownership table、delegate-to-Azure-Skills rules を作る。</p></article>
+          <article class="theme"><h3>Theme B: Make Installation Boring and Predictable</h3><p>GHCP install 手順を slash command に修正し、install 後の verification prompt、plugin と workspace-local setup の選び方、reload/restart 要否を明確化する。</p></article>
+          <article class="theme"><h3>Theme C: Expand Best Practices</h3><p>runtime/model/bundle/reliability/identity/networking/security/observability/scale を横断して proactive に gap を見つける review に進化させる。</p></article>
+          <article class="theme"><h3>Theme D: Build Upgrade Workflow</h3><p>outdated/EOL を検出するだけでなく、migration path、code/config changes、validation steps を提供する <code>azure-functions-upgrade</code> を作る。</p></article>
+          <article class="theme"><h3>Theme E: Improve Diagnostics Evidence</h3><p>root cause attribution を正確にし、error string、setting value、valid values、next command を明示する evidence-first output を徹底する。</p></article>
+          <article class="theme"><h3>Theme F: Invest in New Skills</h3><p>Testing、OTEL/observability、performance/scaling は Functions 利用者の実務 pain に近く、次の skill backlog として優先度が高い。</p></article>
+        </div>
+      </section>
+
+      <section id="todo" class="section-plain">
+        <h2>8. Prioritized TODO</h2>
+        <div class="todo-grid">
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#69</span></div><h4><span class="todo-number">1.</span> Update GHCP install documentation to slash command syntax</h4><p>README、usage docs、plugin install examples を更新する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#77</span></div><h4><span class="todo-number">2.</span> Add outdated-version warning behavior to setup</h4><p>tiered indicator と upgrade command 表示を追加する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#78</span></div><h4><span class="todo-number">3.</span> Fix invalid FUNCTIONS_WORKER_RUNTIME diagnosis</h4><p>valid values reference、diagnostic pattern mapping、inventory/best-practices validation を追加する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#74</span></div><h4><span class="todo-number">4.</span> Add SCM credential policy check and Entra fallback</h4><p>inventory/health scripts、auth path docs、validation を更新する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p0">P0</span><span class="tag">#79</span></div><h4><span class="todo-number">5.</span> Add Functions Host health endpoints</h4><p>native liveness/readiness を direct host health evidence として health-status workflow に追加する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span><span class="tag">#68</span></div><h4><span class="todo-number">6.</span> Expand best-practices full review dimensions</h4><p>runtime/model/bundle/reliability を full review に追加する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span></div><h4><span class="todo-number">7.</span> Define Azure Skills vs Azure Functions Skills scope matrix</h4><p>skill ownership table と delegate-to-Azure-Skills rules を作る。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span></div><h4><span class="todo-number">8.</span> Create functions-copilot routing matrix</h4><p>agent instructions、intent-to-skill table、fallback/delegation guidance を整備する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span><span class="tag">#70</span><span class="tag">#75</span></div><h4><span class="todo-number">9.</span> Implement azure-functions-upgrade skill skeleton</h4><p>outdated/EOL detection から migration guidance へ進む中核 workflow として追加する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p1">P1</span><span class="tag">#71</span></div><h4><span class="todo-number">10.</span> Add SDK-type bindings recommendation references</h4><p>common references、binding checklist、language-specific notes を追加する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span><span class="tag">#72</span></div><h4><span class="todo-number">11.</span> Design Functions Testing skill</h4><p>trigger-specific testing と CI guidance の scope doc、sample prompts、trigger matrix を作る。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span><span class="tag">#73</span></div><h4><span class="todo-number">12.</span> Design OTEL/observability skill</h4><p>language support matrix、setup validation、App Insights/OTEL guidance を設計する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span><span class="tag">#76</span></div><h4><span class="todo-number">13.</span> Design performance/scaling optimization skill</h4><p>scenario intake questions、hosting plan/trigger tuning matrix、cost/performance checklist を作る。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span></div><h4><span class="todo-number">14.</span> Build feedback aggregation workflow</h4><p>Teams、chat、issues、feedback skill に分散した情報を集約する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p2">P2</span></div><h4><span class="todo-number">15.</span> Create layered eval strategy</h4><p>static/unit/E2E/agent eval を組み合わせる rubric と CI gating level を定義する。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p3">P3</span></div><h4><span class="todo-number">16.</span> Investigate VS Code and Azure Portal integration paths</h4><p>channel-specific user journeys と integration proposal を作る。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p3">P3</span></div><h4><span class="todo-number">17.</span> Establish a Functions knowledge registry plan</h4><p>knowledge ownership map、reference update process、shared docs/references strategy を作る。</p></article>
+          <article class="todo"><div class="todo-meta"><span class="tag p3">P3</span></div><h4><span class="todo-number">18.</span> Clarify global plugin vs workspace-local setup recommendation</h4><p>decision guide、known limitations、recommended setup per scenario を明確化する。</p></article>
+        </div>
+      </section>
+
+      <section id="triage">
+        <h2>9. Suggested Triage Order</h2>
+        <ol class="triage-list">
+          <li>#69, #77, #78, #74, #79 の concrete fixes を先に片付ける。</li>
+          <li>#68 の best-practices expansion を実装し、best-practices を proactive review の中核にする。</li>
+          <li>Azure Skills vs Azure Functions Skills の scope/routing doc を作り、今後の skill 追加判断を安定させる。</li>
+          <li>#70/#75 を統合した <code>azure-functions-upgrade</code> を作る。</li>
+          <li>#71/#72/#73/#76 を新 skill backlog として整理し、testing、observability、performance/scaling の順で設計する。</li>
+          <li>E2E と agent-based eval の最小 rubric を作り、今後の skill 追加に対する quality gate にする。</li>
+        </ol>
+        <p>この順序にすると、短期的な UX/bug fix、既存 skill の価値向上、新 skill 投資、品質基盤の整備をバランスよく進められる。</p>
+      </section>
+    </main>
+  </div>
+
+  <footer class="footer">
+    Generated from <code>docs/bug-bash-feedback-summary-20260519.md</code>. Standalone HTML for review and sharing.
+  </footer>
+</body>
+</html>

--- a/docs/bug-bash-feedback-summary-20260519.md
+++ b/docs/bug-bash-feedback-summary-20260519.md
@@ -1,0 +1,452 @@
+# Azure Functions Skills Bug Bash Feedback Summary
+
+Date: 2026-05-19  
+Scope: bug bash conversation notes in `azure-functions-skills-bug-bash.md` and GitHub issues #68 and later in `Azure/azure-functions-skills`.
+
+## 1. Executive Summary
+
+今回の bug bash で集まったフィードバックは、単なる個別バグ修正ではなく、Azure Functions Skills をどのような責務を持つ skill suite として育てるか、という設計上の論点が中心だった。
+
+全体として、Azure Functions に特化した Copilot/agent skills の方向性は好意的に受け止められている。特に、Azure Functions team が持つドメイン知識を、作成、診断、ベストプラクティス、アップグレード、運用レビューの形で agent に渡せることには価値がある、という認識が共有された。一方で、Azure Skills との重複、plugin install の UX、skill の多さによる routing の不透明さ、品質評価の難しさが大きな課題として挙がっている。
+
+最重要テーマは次の 5 つに集約できる。
+
+1. Azure Skills と Azure Functions Skills のスコープ境界を明確化する。
+2. 100 個以上の skill が見える環境でも、正しい skill が選ばれる routing/agent 体験を作る。
+3. install、reload、account、plugin/CLI 差分など、導入 UX の摩擦を減らす。
+4. Functions team の推奨知識を、best practices、diagnostics、upgrade、testing、observability などの実用 skill に落とし込む。
+5. E2E と agent-based eval を組み合わせ、非決定的な LLM 出力でも品質を継続的に評価できる仕組みを作る。
+
+## 2. Input Sources
+
+- Local bug bash notes: `azure-functions-skills-bug-bash.md`
+- GitHub issues reviewed: #68 through #79
+- GitHub issue comments: none were returned for #68 through #79 at the time of collection.
+
+## 3. Overall Sentiment
+
+### Positive Signals
+
+- Azure Functions 専用の skill suite を持つこと自体は、複数参加者から肯定的に見られている。
+- 汎用 Azure Skills では拾いきれない Functions-specific な設計、移行、診断、ベストプラクティスに価値がある。
+- workspace-local な CLI/setup 体験は、global plugin よりも競合を避けやすく、方向性として評価されている。
+- 「skill そのもの」よりも「Azure Functions team の知識を agent が利用できること」が本質的価値だ、という理解が強い。
+
+### Main Concerns
+
+- Azure Skills と Azure Functions Skills の境界が不明確で、create/deploy/best-practices/upgrade のような領域で重複や競合が起きる。
+- plugin install が global に効くため、ユーザーが意図しない skill routing や skill 衝突に遭遇する可能性がある。
+- install 手順や reload 要否がわかりにくく、特に GitHub Copilot CLI、VS Code、EMU/個人アカウント、plugin/CLI の体験差が混乱を生んでいる。
+- skill が増えるほど discoverability よりも selection/routing の問題が大きくなる。
+- LLM skill の品質評価は非決定的であり、通常の unit test だけでは十分ではない。
+
+## 4. Detailed Discussion Notes
+
+### 4.1 Scope: Azure Skills vs Azure Functions Skills
+
+最も重要な論点は、Azure Skills と Azure Functions Skills の責務分担である。参加者の意見として、Azure Functions 専用 skill を分離することには価値があるが、汎用 Azure Skills と同じ領域を二重実装すると、ユーザーも agent も混乱するという指摘があった。
+
+特に `create`、`deploy`、`best practices`、`upgrade` は Azure Skills 側にも近い概念が存在する。Azure Functions Skills は、Azure 全般の一般論ではなく、Functions 固有の runtime、trigger/binding、language worker、hosting plan、scale behavior、diagnostics、migration path に寄せるべきだ、という方向性が見えている。
+
+Madhura の整理として、Day 0 の作成や汎用 deployment preparation は Azure Skills に寄せ、Day 1+ の troubleshooting、upgrade、comparison、operational review は Azure Functions Skills が強く担当する、という考え方が重要である。この分担により、Azure Functions Skills は「Functions 固有の深い判断」を提供し、汎用 Azure Skills は共通 Azure platform workflow を担う、という補完関係にできる。
+
+推奨される方向性は、明確な境界と routing contract を文書化することである。Functions-specific な問いは Functions Skills が直接処理し、共通 Azure pattern は Azure Skills へ redirect または delegate する。たとえば Consumption から Flex Consumption への hosting plan migration は Azure Skills の `azure-upgrade` が既に扱うなら、Functions 側の upgrade skill はそこへ route する設計が望ましい。
+
+### 4.2 Routing and Skill Collision
+
+skill が増えるほど、ユーザーにとっての問題は「skill を見つけられるか」だけではなく、「正しい skill が選ばれるか」になる。bug bash では、100 個以上の skill が見える状況や、Functions 系と汎用 Azure 系の skill が混在する状況が指摘された。
+
+この状態では、Copilot がどの skill を選ぶかが不透明になり、ユーザーはなぜその回答になったのかを理解しにくい。plugin が global にインストールされる場合、別 workspace や別 task でも意図せず skill が routing 候補に入るため、衝突や誤選択が起きやすい。
+
+Lily らの観点として、agent が router として機能し、visible な skill を agent や workspace の context によって絞る設計が必要である。現在の CLI/setup アプローチは workspace-local に skill を配置できるため、global plugin の副作用を減らせる点で評価されている。
+
+今後は、`functions-copilot` agent がどの user intent をどの skill に route するかを、routing table として明文化し、必要に応じて Azure Skills への delegation も含めるべきである。
+
+### 4.3 Installation and Onboarding UX
+
+install UX は大きな摩擦点として挙がった。特に GitHub Copilot CLI の plugin install において、自然言語に見える `copilot plugin marketplace add ...` が agent prompt として解釈され、不要な skill routing が発生して install が遅くなる、という issue #69 が作成されている。
+
+期待される体験は、install が direct command として実行され、無関係な skill resolution を起こさないことである。そのため README などの手順は `/plugin marketplace add Azure/azure-functions-skills` のような slash command 形式に更新する必要がある。
+
+また、install 後に reload/restart が必要な場合にそれが明示されない、skills list に反映されない、EMU と個人アカウントで挙動が異なる、CLI と plugin の体験差がある、という混乱も挙げられた。これらは feature の良し悪し以前に、初回体験で信頼を損なう可能性がある。
+
+今後の install UX では、次の情報を明示すべきである。
+
+- どの agent/host でどの install path を使うべきか。
+- install 後に reload/restart が必要か。
+- plugin install と workspace-local setup の違い。
+- global plugin が他 workspace に影響する可能性。
+- GitHub Copilot CLI、VS Code、Claude Code、Codex での差分。
+
+### 4.4 Discoverability: VS Code, Portal, Marketplace
+
+skill をどこで発見し、どこから使うのかも未整理である。候補として、VS Code extension への統合、Azure Portal Copilot への統合、marketplace/plugin からの導入、CLI setup などが挙がっている。
+
+ただし、この議論の本質は単なる露出面の増加ではない。露出が増えるほど、skill の重複と routing の問題も増える。そのため、discoverability の改善は routing、scope control、install guidance とセットで考える必要がある。
+
+Azure Portal Copilot に入れる場合は、既に対象 resource context があるため inventory/health/best-practices/diagnostics と相性が良い。一方、VS Code extension 統合では local project context、code anti-pattern detection、test generation、migration assistance と相性が良い。チャネルごとに「何を主導する UI か」を分けると、導線が整理しやすい。
+
+### 4.5 Value Proposition: Best Practices, Diagnostics, Optimization
+
+参加者から強く支持された価値は、Azure Functions team の推奨を agent が proactive に提供することである。特に、StackOverflow や古い blog に残る outdated な知識より、Functions team の現在の推奨を参照できることが価値だという意見があった。
+
+代表的な高価値領域は次の通りである。
+
+- outdated な programming model や runtime version を検出し、推奨移行先を提示する。
+- Python v1 model、Node.js v3 model、.NET in-process など、移行が必要な領域を明確にする。
+- HTTP client misuse、connection management、Service Bus message lock、retry/concurrency 設定など、customer code anti-pattern を検出する。
+- deployment 前に misconfiguration を見つける what-if/preflight 的なチェックを提供する。
+- concurrency、scale、hosting plan、trigger behavior に基づく cost/performance optimization を提案する。
+- event-driven architecture、Service Bus、Blob、Cosmos DB など、Functions の主用途に近い設計支援を行う。
+
+Finbar の観点として、CRI や production incident を未然に防ぐことが非常に重要である。問題が起きた後に診断するだけでなく、bad code patterns や misconfiguration を事前に検出する仕組みが求められている。
+
+Swapnil の観点として、Functions 利用者の churn の一因は「知らないこと」にある。ユーザーが知らない runtime behavior、binding recommendation、testing approach、observability setup を agent が補うことで、学習コストと運用リスクを下げられる。
+
+### 4.6 Knowledge as the Asset
+
+bug bash では、「重要なのは skill そのものではなく domain knowledge である」という認識が繰り返し出ている。skill は知識を agent に届けるための packaging であり、価値の中心は Azure Functions team が持つ operational knowledge、known issues、migration paths、best practices、source-level references である。
+
+この観点では、知識の分散と drift が大きなリスクになる。Dobby、SRE agent、Azure Skills、Azure Functions Skills、docs repo、internal troubleshooting knowledge が別々に存在すると、同じ問いに対して異なる回答が出る可能性がある。
+
+理想は、Functions-specific knowledge をできるだけ single source of truth に寄せ、それを複数 agent/channel から利用できるようにすることである。skill repo は、その知識を agent-consumable な workflow、checklist、reference、script に変換する場所として設計するとよい。
+
+### 4.7 Evaluation and Quality
+
+LLM skill の品質担保は未解決の大課題として挙がっている。通常の deterministic test と違い、agent は同じ prompt でも出力が揺れる。text-based skill の品質をどのように CI で検証するかは、今後の重要テーマである。
+
+現在の方向性として、CLI ベースの E2E test、install から agent execution までの smoke test、出力の部分検証が進められている。一方で、過剰な E2E はコストが高く、maintenance burden も大きい。
+
+Zach のアイデアとして、outer agent が inner agent の出力を評価する agent-based eval が挙がった。これは、単純な string assertion では評価しにくい「正しい skill を使ったか」「必要な観点を含んだか」「危険な提案を避けたか」を判定するのに有効である。
+
+今後は、次のような layered evaluation が現実的である。
+
+- Static validation: SKILL.md、frontmatter、references、links、agent manifests の構造検証。
+- Unit/integration tests: CLI setup、plugin packaging、script behavior の deterministic test。
+- E2E smoke tests: agent が skill を認識し、期待される high-level output を返すか。
+- Agent-based eval: 出力品質、routing、coverage、safety を rubric で評価する。
+
+### 4.8 Feedback Collection
+
+フィードバックは Teams thread、meeting chat、GitHub issues、feedback skill に分散している。Madhura からは、複数の場所から集約する必要があるという指摘があった。
+
+この分散は、bug bash のような短期イベントでは特に問題になる。重要な提案が chat に残り、issue 化されないまま失われる可能性がある。逆に issue だけを見ると、会話上の背景や優先順位が抜け落ちる。
+
+今後は、feedback skill を使って chat/thread から issue draft を生成する、または bug bash summary を定期的に生成して GitHub issue に link するなど、単一の intake/triage flow を作るべきである。
+
+## 5. GitHub Issues #68-#79
+
+### #68: azure-functions-best-practices review dimensions expansion
+
+Author: MadhuraBharadwaj-MSFT  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/68
+
+`azure-functions-best-practices` は現状でも security、networking、identity、observability、scale などを評価できるが、full review で自動的に含めるべき重要観点が不足しているという提案である。
+
+不足していた観点は、Node/Python の programming model version、Functions runtime version、extension bundle range、reliability posture である。Flex Consumption Node.js 22 app の full review では、zonal zone redundancy が有効であることや global DR gap が、ユーザーが明示的に聞くまで報告されなかった。
+
+提案アクションは、`review-checklist.md` に reliability section を追加し、full/reliability scope では reliability assessment に route し、output shape に programming model、runtime、extension bundle range を明示することである。
+
+### #69: GHCP install instructions should use slash command
+
+Author: MadhuraBharadwaj-MSFT  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/69
+
+GitHub Copilot CLI の install 手順で、自然言語形式の `copilot plugin marketplace add Azure/azure-functions-skills` ではなく、slash command の `/plugin marketplace add Azure/azure-functions-skills` を使うべきという提案である。
+
+自然言語形式だと agent が通常の conversation prompt として解釈し、不要な skill routing が走って install が遅くなる。期待される install は、direct command として一発で実行され、無関係な skill resolution を起こさないことである。
+
+README と installation documentation 全体を更新する必要がある。
+
+### #70: New azure-functions-upgrade skill
+
+Author: MadhuraBharadwaj-MSFT  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/70
+
+`azure-functions-upgrade` skill を新設し、Functions 固有の upgrade workflows をまとめて案内する提案である。
+
+対象 dimension は、language version upgrade、Consumption v1 から Flex Consumption、extension bundles、programming model upgrade、.NET in-process から isolated worker、Functions runtime v1/v2/v3 から v4 である。
+
+重要なのは、`azure-functions-best-practices` が outdated version を検出するだけでは不十分で、ユーザーには breaking changes、dependency update、code/config changes、validation steps を含む step-by-step migration assistance が必要だという点である。
+
+設計としては、inventory から current state を検出し、適用可能な upgrade path を提示する。Consumption v1 から Flex Consumption は Azure Skills plugin の `azure-upgrade` に route する。
+
+### #71: SDK-type bindings recommendation
+
+Author: swapnil-nagar  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/71
+
+Service Bus、Blob、Cosmos DB などで、modern recommended approach として SDK-type bindings を推奨する必要があるという提案である。issue body は空だが、bug bash の event-driven optimization や binding best practices の議論と一致している。
+
+この内容は、best-practices、create、diagnostics、common references のいずれにも影響する。古い binding pattern や非推奨 pattern を検出し、言語別の推奨 SDK-type binding guidance を出す設計が考えられる。
+
+### #72: Functions testing skills
+
+Author: swapnil-nagar  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/72
+
+Azure Functions の testing に関する新 skill 提案である。issue body は空だが、Functions 利用者が unit test、integration test、local emulator、trigger-specific test、CI validation をどう構成すべきかを案内する skill として価値がある。
+
+特に、Service Bus、Storage、HTTP trigger、Timer trigger、Durable Functions など、trigger ごとに testing strategy が異なるため、Functions-specific knowledge を提供しやすい領域である。
+
+### #73: OpenTelemetry skill for different language support
+
+Author: swapnil-nagar  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/73
+
+言語ごとの OpenTelemetry support を扱う新 skill 提案である。issue body は空だが、observability と Application Insights instrumentation の進化に関係する。
+
+Functions の言語 worker ごとに OTEL setup、sampling、trace correlation、dependency tracking、logs/metrics/traces の出し方が異なるため、language-specific references と setup validation を持つ skill が有効と考えられる。
+
+### #74: SCM publishing credentials and Entra token auth for Kudu API
+
+Author: FinVamp1  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/74
+
+Kudu VFS API を使って deployed content を検証する際、SCM basic auth publishing credentials が有効かどうかを事前に確認し、無効な場合は Entra ID token-based authentication に fallback すべきという具体的な診断改善である。
+
+現状では、SCM basic auth が disabled の Function App に対して `az webapp deployment list-publishing-credentials` で取得した publishing credentials を使い、Kudu VFS API call が 401 Unauthorized になるケースがある。
+
+期待動作は、`basicPublishingCredentialsPolicies` を確認し、SCM credentials が disabled なら App Service audience の Entra token を使うことである。影響範囲は diagnostics、inventory、health-status scripts、inventory scripts、関連 references である。
+
+### #75: EOL language migration skill
+
+Author: swapnil-nagar  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/75
+
+End-of-life language version からの migration を扱う新 skill 提案である。issue body は空だが、#70 の `azure-functions-upgrade` と強く関連する。
+
+独立 skill として作るより、まずは `azure-functions-upgrade` の language EOL dimension として統合し、必要なら後で分割するのが自然である。best-practices で EOL を検出し、upgrade skill へ route する導線が重要になる。
+
+### #76: Performance and scaling configurations based on customer scenarios
+
+Author: swapnil-nagar  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/76
+
+customer scenario に基づいて performance と scaling configuration を提案する新 skill である。issue body は空だが、bug bash で強く支持された cost optimization、concurrency tuning、scale behavior、event-driven design と重なる。
+
+この skill は、hosting plan、trigger type、message rate、cold start tolerance、concurrency、timeout、retry、batch size、Service Bus lock duration、storage account behavior などを踏まえて guidance を出すものとして設計できる。
+
+### #77: Setup should warn about outdated tool versions
+
+Author: MadhuraBharadwaj-MSFT  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/77
+
+`azure-functions-setup` の environment check が、tool が古い場合でも all-green を出してしまうという UX/quality issue である。たとえば Azure Functions Core Tools 4.6.0 が入っていて latest が 4.10.0 の場合でも、警告なしに check mark が表示される。
+
+期待動作は、latest または one minor version 以内なら OK、newer version available なら warning、missing/unsupported version なら error とする tiered indicator である。warning には upgrade command を含めるべきである。
+
+これは setup skill の信頼性に直結する。すべて green なのに実際には outdated という状態は、ユーザーに誤った安心感を与える。
+
+### #78: Incorrect root cause attribution for invalid FUNCTIONS_WORKER_RUNTIME
+
+Author: FinVamp1  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/78
+
+`WorkerConfig for runtime: node27 not found` の診断で、skill が原因を `WEBSITE_NODE_DEFAULT_VERSION` と誤って解釈したという root cause attribution の修正提案である。実際の原因は `FUNCTIONS_WORKER_RUNTIME=node27` という invalid value であり、error message も worker runtime setting を示している。
+
+期待動作は、`WorkerConfig for runtime: X` pattern を `FUNCTIONS_WORKER_RUNTIME` の検証に結びつけ、valid values を `node`、`python`、`dotnet`、`dotnet-isolated`、`java`、`powershell`、`custom` に限定して check することである。
+
+影響範囲は diagnostics、health-status、best-practices、common references である。inventory/best-practices checks に runtime validation を追加し、diagnostic routing で error pattern を正しく map する必要がある。
+
+### #79: Use Functions Host health check endpoints
+
+Author: FinVamp1  
+State: OPEN  
+URL: https://github.com/Azure/azure-functions-skills/issues/79
+
+`azure-functions-health-status` が、metadata availability や telemetry queries だけでなく、Azure Functions Host に追加された native health check endpoints を利用すべきという提案である。
+
+関連 endpoint は `/runtime/health`、`/runtime/health/live`、`/runtime/health/ready` である。現状は app metadata、Resource Health、Application Insights errors に依存しているが、Consumption では Resource Health が unsupported であるなど制約がある。
+
+期待動作は、direct host health として liveness/readiness を health report に含め、telemetry analysis に fallback する前に health endpoint を確認することである。`get-functionapp-health-status.ps1/.sh` と `references/health-status-commands-and-kql.md`、output template の更新が必要である。
+
+## 6. Consolidated Themes and Proposed Directions
+
+### Theme A: Define the Product Boundary
+
+Azure Functions Skills は、Azure 全般 skill の subset ではなく、Functions 固有の domain layer として位置付けるべきである。作成や deployment の共通部分は Azure Skills と連携し、Functions 固有の判断、検証、移行、診断を担当する。
+
+Proposed direction:
+
+- Scope matrix を作り、Azure Skills、Azure Functions Skills、shared/common の境界を明記する。
+- `functions-copilot` agent の routing guidance に、Functions-specific / generic Azure / delegate to Azure Skills の判断基準を入れる。
+- create/deploy/upgrade/best-practices の重複点を洗い出し、delegation pattern を決める。
+
+### Theme B: Make Installation Boring and Predictable
+
+install が遅い、skill が見えない、reload が必要かわからない、account によって違う、という問題は adoption を阻害する。
+
+Proposed direction:
+
+- README の GHCP install 手順を slash command に修正する。
+- install 後の verification prompt と expected output を明記する。
+- plugin と workspace-local setup の選び方を明確化する。
+- reload/restart が必要な環境では、手順内で明示する。
+
+### Theme C: Expand Best Practices from Checklist to Proactive Review
+
+best-practices skill は、単に既知の checklist を読むだけでなく、runtime/model/bundle/reliability/identity/networking/security/observability/scale を横断して proactive に gap を見つけるべきである。
+
+Proposed direction:
+
+- #68 の dimensions を full review に追加する。
+- #77 の outdated tool version warning を setup と best-practices の両方の観点で扱う。
+- #78 の `FUNCTIONS_WORKER_RUNTIME` validation を best-practices と inventory に追加する。
+- #71 の SDK-type bindings recommendation を language/binding references に追加する。
+
+### Theme D: Build Upgrade as a First-Class Workflow
+
+upgrade は bug bash 全体で重要な流れである。outdated/EOL を検出するだけではなく、実際に migration path を示す必要がある。
+
+Proposed direction:
+
+- #70 の `azure-functions-upgrade` を新設する。
+- #75 の EOL language migration を upgrade skill の dimension として統合する。
+- best-practices と setup から upgrade skill への route を作る。
+- CV1 から Flex Consumption は Azure Skills の `azure-upgrade` へ delegate する。
+
+### Theme E: Improve Diagnostics with Precise Evidence
+
+diagnostics は root cause attribution の正確性が重要である。誤った設定を原因として提示すると、agent への信頼が下がる。
+
+Proposed direction:
+
+- #78 の worker runtime error mapping を diagnostics reference に追加する。
+- #74 の Kudu auth path を scripts と docs に追加する。
+- #79 の native health endpoints を health-status workflow に追加する。
+- evidence-first output を徹底し、error string、setting value、expected valid values、next command を明示する。
+
+### Theme F: Invest in Testing, Observability, Performance Skills
+
+新 skill 案として、testing、OTEL、performance/scaling が挙がっている。これらは Functions 利用者の実務 pain に直結しており、優先度が高い。
+
+Proposed direction:
+
+- Testing skill は trigger-specific strategy と local/CI validation を扱う。
+- OTEL skill は language-specific setup と trace/log/metric correlation を扱う。
+- Performance/scaling skill は scenario-based tuning と cost optimization を扱う。
+
+## 7. Prioritized TODO
+
+### P0: Immediate Fixes
+
+1. Update GHCP install documentation to slash command syntax.
+   - Source: #69
+   - Rationale: install UX の摩擦が大きく、修正範囲が小さい。
+   - Deliverable: README、usage docs、plugin install examples の更新。
+
+2. Add outdated-version warning behavior to `azure-functions-setup`.
+   - Source: #77
+   - Rationale: all-green の誤表示は setup skill の信頼性を落とす。
+   - Deliverable: tiered indicator、latest/near-latest/outdated/unsupported 判定、upgrade command 表示。
+
+3. Fix invalid `FUNCTIONS_WORKER_RUNTIME` diagnosis and validation.
+   - Source: #78
+   - Rationale: root cause attribution の誤りは diagnostics の信頼を直接損なう。
+   - Deliverable: valid values reference、diagnostic pattern mapping、inventory/best-practices validation。
+
+4. Add SCM publishing credentials policy check and Entra token fallback for Kudu API.
+   - Source: #74
+   - Rationale: real diagnostic path で 401 が発生しており、scripts/docs 両方の改善が必要。
+   - Deliverable: inventory/health scripts update、auth path docs、validation for enabled/disabled SCM basic auth。
+
+5. Add Functions Host health endpoints to health-status workflow.
+   - Source: #79
+   - Rationale: native liveness/readiness は direct host health evidence として価値が高い。
+   - Deliverable: PowerShell/shell scripts update、health-status reference update、output template update。
+
+### P1: Near-Term Product Improvements
+
+6. Expand `azure-functions-best-practices` full review dimensions.
+   - Source: #68
+   - Rationale: full review が runtime/model/bundle/reliability を自動評価しないと、重要 gap が漏れる。
+   - Deliverable: checklist update、workflow routing、report output shape update、reliability route。
+
+7. Define Azure Skills vs Azure Functions Skills scope matrix.
+   - Source: bug bash discussion
+   - Rationale: 重複と routing 不透明性を減らすための前提。
+   - Deliverable: docs page or design note、skill ownership table、delegate-to-Azure-Skills rules。
+
+8. Create `functions-copilot` routing matrix and conflict guidance.
+   - Source: bug bash discussion
+   - Rationale: skill 数が増えるほど agent router の明文化が必要。
+   - Deliverable: agent instructions update、intent-to-skill table、fallback/delegation guidance。
+
+9. Implement initial `azure-functions-upgrade` skill skeleton.
+   - Source: #70, #75
+   - Rationale: outdated/EOL detection から migration guidance へ進むための中核 workflow。
+   - Deliverable: SKILL.md、references、inventory integration plan、best-practices route。
+
+10. Add SDK-type bindings recommendation references.
+    - Source: #71
+    - Rationale: modern binding guidance は create/best-practices/diagnostics に横断的に効く。
+    - Deliverable: common references、binding checklist、language-specific notes。
+
+### P2: Medium-Term Skill Expansion
+
+11. Design Functions Testing skill.
+    - Source: #72
+    - Rationale: trigger-specific testing と CI guidance は Functions 利用者の実務課題に近い。
+    - Deliverable: scope doc、sample prompts、trigger matrix、test strategy references。
+
+12. Design OTEL/observability skill or observability expansion.
+    - Source: #73 and bug bash discussion
+    - Rationale: language-specific OTEL setup と trace correlation は user confusion が大きい領域。
+    - Deliverable: language support matrix、setup validation、App Insights/OTEL guidance。
+
+13. Design performance/scaling optimization skill.
+    - Source: #76 and bug bash discussion
+    - Rationale: cost optimization、concurrency、scale tuning は高価値で incident prevention にも効く。
+    - Deliverable: scenario intake questions、hosting plan/trigger tuning matrix、cost/performance checklist。
+
+14. Build feedback aggregation workflow.
+    - Source: bug bash discussion
+    - Rationale: Teams、chat、issues、feedback skill に分散した情報を失わないようにする。
+    - Deliverable: feedback intake template、summary generation flow、issue draft workflow。
+
+15. Create layered eval strategy for skill quality.
+    - Source: bug bash discussion, Zach's agent-based eval idea
+    - Rationale: LLM output の非決定性に対して、static/unit/E2E/agent eval を組み合わせる必要がある。
+    - Deliverable: eval rubric、representative prompts、CI gating level、outer-agent evaluator prototype。
+
+### P3: Strategic Follow-Ups
+
+16. Investigate VS Code extension and Azure Portal Copilot integration paths.
+    - Source: bug bash discussion
+    - Rationale: discoverability は重要だが、routing/scope 設計とセットで扱う必要がある。
+    - Deliverable: channel-specific user journeys and integration proposal。
+
+17. Establish a Functions knowledge registry or source-of-truth plan.
+    - Source: bug bash discussion
+    - Rationale: Dobby、SRE agent、Azure Skills、Functions Skills、docs の knowledge drift を防ぐ。
+    - Deliverable: knowledge ownership map、reference update process、shared docs/references strategy。
+
+18. Clarify global plugin vs workspace-local setup recommendation.
+    - Source: bug bash discussion
+    - Rationale: global plugin は便利だが skill collision の副作用がある。
+    - Deliverable: decision guide、known limitations、recommended setup per scenario。
+
+## 8. Suggested Triage Order
+
+最初の実行順としては、次の流れが最も現実的である。
+
+1. #69, #77, #78, #74, #79 の concrete fixes を先に片付ける。
+2. #68 の best-practices expansion を実装し、best-practices を proactive review の中核にする。
+3. Azure Skills vs Azure Functions Skills の scope/routing doc を作り、今後の skill 追加判断を安定させる。
+4. #70/#75 を統合した `azure-functions-upgrade` を作る。
+5. #71/#72/#73/#76 を新 skill backlog として整理し、testing、observability、performance/scaling の順で設計する。
+6. E2E と agent-based eval の最小 rubric を作り、今後の skill 追加に対する quality gate にする。
+
+この順序にすると、短期的な UX/bug fix、既存 skill の価値向上、新 skill 投資、品質基盤の整備をバランスよく進められる。


### PR DESCRIPTION
Adds Markdown, Japanese HTML, and English HTML bug bash feedback summaries.
Publishes bug bash pages under /bug-bash/, with English as default and Japanese at /bug-bash/ja.html.
Keeps the existing E2E report at / and /report.html.
Validation: git diff --check and HTML structure checks passed.