### PR TITLE
feat: add workspace apply command

### DIFF
--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -22,6 +22,8 @@ function printHelp() {
 
   Commands:
     setup    Detect coding agents and install skill files into your project
+    workspace apply   Apply Azure Functions routing/activation files to a workspace
+    workspace update  Update existing Azure Functions managed workspace routing blocks
     chat     Launch a CLI coding agent with Azure Functions Welcome prompt
     build    Build plugin artifacts for all targets (ghcp, claude, codex)
 
@@ -31,6 +33,14 @@ function printHelp() {
     --as-plugin        Register as a native platform plugin (instead of copying files)
     --check-prerequisites  Check external prerequisites without installing them
     --skip-prerequisites   Skip external prerequisite checks
+
+  Options (workspace apply/update):
+    --agent <name>     Specify agent: ghcp, claude, codex (repeatable)
+    --dir <path>       Target directory (default: current directory)
+    --mode <name>      minimal, copy, plugin-reference (default: copy)
+    --merge-strategy <name> managed-block, include-file, fail-if-exists, append
+    --update           Replace existing Azure Functions managed blocks
+    --dry-run          Print planned changes without writing files
 
   Options (chat):
     --agent <name>     Agent: github-copilot, claude-code, codex (auto-detected if omitted)
@@ -49,6 +59,7 @@ function printHelp() {
   Examples:
     npx @agent-loom/azure-functions-skills setup
     npx @agent-loom/azure-functions-skills setup --as-plugin
+    npx @agent-loom/azure-functions-skills workspace apply --agent codex --mode plugin-reference --dry-run
     npx @agent-loom/azure-functions-skills chat
     npx @agent-loom/azure-functions-skills chat --as-plugin --agent claude-code
   `);
@@ -211,6 +222,48 @@ if (command === 'setup') {
   if (passthroughArgs.length > 0) options.passthroughArgs = passthroughArgs;
   options.prerequisites = prerequisites;
   await chat(options);
+} else if (command === 'workspace') {
+  const action = args[1];
+  if (action !== 'apply' && action !== 'update') {
+    console.error(`Unknown workspace command: ${action || ''}`.trim());
+    console.error('Usage: azure-functions-skills workspace apply|update [options]');
+    process.exit(1);
+  }
+
+  const { applyWorkspace } = await import('../lib/setup/workspace.js');
+  const agents = [];
+  let dir = process.cwd();
+  let mode = 'copy';
+  let mergeStrategy = 'managed-block';
+  let dryRun = false;
+  let update = action === 'update';
+
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--agent' && args[i + 1]) agents.push(args[++i]);
+    else if (args[i] === '--dir' && args[i + 1]) dir = args[++i];
+    else if (args[i] === '--mode' && args[i + 1]) mode = args[++i];
+    else if (args[i] === '--merge-strategy' && args[i + 1]) mergeStrategy = args[++i];
+    else if (args[i] === '--dry-run') dryRun = true;
+    else if (args[i] === '--update') update = true;
+  }
+
+  const result = await applyWorkspace(dir, {
+    agents: agents.length > 0 ? agents : undefined,
+    mode,
+    mergeStrategy,
+    update,
+    dryRun,
+  });
+
+  if (dryRun) {
+    console.log('Planned workspace changes:');
+    for (const file of result.plannedFiles) console.log(`  - ${file}`);
+  } else {
+    console.log(`Workspace ${action} complete.`);
+    console.log(`  Agents configured: ${result.agents.join(', ')}`);
+    console.log(`  Mode: ${result.mode}`);
+    console.log(`  Files written: ${result.filesWritten}`);
+  }
 } else if (command === 'build') {
   // Delegate to build script
   const { execFileSync } = await import('node:child_process');

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -1,8 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { applySetup, detectAgents } from './index.js';
 import type { CliAgentName, MergeStrategy, WorkspaceApplyOptions, WorkspaceApplyResult, WorkspaceMode } from '../types.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = join(__dirname, '..', '..', 'templates');
 const BLOCK_START = '<!-- azure-functions-skills:start';
 const BLOCK_END = '<!-- azure-functions-skills:end -->';
 
@@ -78,17 +81,17 @@ function plannedCopyFiles(agent: CliAgentName): string[] {
 function activationFiles(agent: CliAgentName, mode: WorkspaceMode): PlannedFile[] {
   const files: PlannedFile[] = [];
   if (agent === 'ghcp') {
-    files.push({ path: '.github/copilot-instructions.md', content: ghcpRoutingBlock(), merge: true });
+    files.push({ path: '.github/copilot-instructions.md', content: routingBlock(agent), merge: true });
     if (mode === 'plugin-reference') files.push({ path: '.github/copilot/settings.json', content: JSON.stringify(ghcpPluginSettings(), null, 2) });
   }
 
   if (agent === 'claude') {
-    files.push({ path: 'CLAUDE.md', content: claudeRoutingBlock(), merge: true });
+    files.push({ path: 'CLAUDE.md', content: routingBlock(agent), merge: true });
     if (mode === 'plugin-reference') files.push({ path: '.claude/settings.json', content: JSON.stringify(claudePluginSettings(), null, 2) });
   }
 
   if (agent === 'codex') {
-    files.push({ path: 'AGENTS.md', content: codexRoutingBlock(), merge: true });
+    files.push({ path: 'AGENTS.md', content: routingBlock(agent), merge: true });
     if (mode === 'plugin-reference') files.push({ path: '.agents/plugins/marketplace.json', content: JSON.stringify(codexMarketplace(), null, 2) });
   }
 
@@ -163,32 +166,8 @@ function includeInstructionPath(filePath: string): string {
   return `.azure-functions-skills/${fileName}`;
 }
 
-function ghcpRoutingBlock(): string {
-  return [
-    '# Azure Functions Skills',
-    '',
-    'For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer Azure Functions Skills.',
-    'Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.',
-  ].join('\n');
-}
-
-function claudeRoutingBlock(): string {
-  return [
-    '# Azure Functions Skills',
-    '',
-    'For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer the Azure Functions Skills plugin.',
-    'Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.',
-  ].join('\n');
-}
-
-function codexRoutingBlock(): string {
-  return [
-    '# Azure Functions Skills',
-    '',
-    'For Azure Functions work, use the Azure Functions Skills plugin or repo-local `.agents/skills` entries.',
-    'Prefer setup/create/deploy/diagnostics/best-practices skills by intent.',
-    'Do not treat generic Azure tasks as Azure Functions tasks unless the user mentions Function Apps, triggers, bindings, host.json, or Functions deployment/runtime errors.',
-  ].join('\n');
+function routingBlock(agent: CliAgentName): string {
+  return readFileSync(join(TEMPLATES_DIR, 'routing', `${agent}.md`), 'utf-8').trimEnd();
 }
 
 function ghcpPluginSettings() {

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -1,0 +1,237 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { applySetup, detectAgents } from './index.js';
+import type { CliAgentName, MergeStrategy, WorkspaceApplyOptions, WorkspaceApplyResult, WorkspaceMode } from '../types.js';
+
+const BLOCK_START = '<!-- azure-functions-skills:start';
+const BLOCK_END = '<!-- azure-functions-skills:end -->';
+
+type PlannedFile = {
+  path: string;
+  content: string;
+  merge?: boolean;
+};
+
+export async function applyWorkspace(targetDir: string, options: WorkspaceApplyOptions = {}): Promise<WorkspaceApplyResult> {
+  const agents = options.agents || await detectAgents();
+  const mode = options.mode || 'copy';
+  const mergeStrategy = options.mergeStrategy || 'managed-block';
+  const dryRun = options.dryRun === true;
+
+  if (mode === 'copy') {
+    if (dryRun) {
+      return {
+        agents,
+        mode,
+        filesWritten: 0,
+        plannedFiles: agents.flatMap(agent => plannedCopyFiles(agent)),
+        dryRun,
+      };
+    }
+    const setupResult = await applySetup(targetDir, { agents, prerequisites: 'skip' });
+    return {
+      agents,
+      mode,
+      filesWritten: setupResult.filesWritten,
+      plannedFiles: [],
+      dryRun,
+    };
+  }
+
+  const plannedFiles = agents.flatMap(agent => activationFiles(agent, mode));
+  if (dryRun) {
+    return {
+      agents,
+      mode,
+      filesWritten: 0,
+      plannedFiles: plannedFiles.map(file => file.path),
+      dryRun,
+    };
+  }
+
+  let filesWritten = 0;
+  for (const file of plannedFiles) {
+    const fullPath = join(targetDir, file.path);
+    const content = file.merge
+      ? mergeInstructionFile(fullPath, file.content, mergeStrategy, options.update === true)
+      : mergeJsonLikeFile(fullPath, file.content);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, content);
+    filesWritten++;
+  }
+
+  return {
+    agents,
+    mode,
+    filesWritten,
+    plannedFiles: plannedFiles.map(file => file.path),
+    dryRun,
+  };
+}
+
+function plannedCopyFiles(agent: CliAgentName): string[] {
+  if (agent === 'ghcp') return ['.github/copilot-instructions.md', '.github/skills/<skill-id>/SKILL.md'];
+  if (agent === 'claude') return ['CLAUDE.md', '.claude/skills/<skill-id>/SKILL.md'];
+  return ['AGENTS.md', '.agents/skills/<skill-id>/SKILL.md'];
+}
+
+function activationFiles(agent: CliAgentName, mode: WorkspaceMode): PlannedFile[] {
+  const files: PlannedFile[] = [];
+  if (agent === 'ghcp') {
+    files.push({ path: '.github/copilot-instructions.md', content: ghcpRoutingBlock(), merge: true });
+    if (mode === 'plugin-reference') files.push({ path: '.github/copilot/settings.json', content: JSON.stringify(ghcpPluginSettings(), null, 2) });
+  }
+
+  if (agent === 'claude') {
+    files.push({ path: 'CLAUDE.md', content: claudeRoutingBlock(), merge: true });
+    if (mode === 'plugin-reference') files.push({ path: '.claude/settings.json', content: JSON.stringify(claudePluginSettings(), null, 2) });
+  }
+
+  if (agent === 'codex') {
+    files.push({ path: 'AGENTS.md', content: codexRoutingBlock(), merge: true });
+    if (mode === 'plugin-reference') files.push({ path: '.agents/plugins/marketplace.json', content: JSON.stringify(codexMarketplace(), null, 2) });
+  }
+
+  return files;
+}
+
+function mergeInstructionFile(filePath: string, generatedContent: string, strategy: MergeStrategy, update: boolean): string {
+  const block = managedBlock(generatedContent);
+  if (!existsSync(filePath)) return `${block}\n`;
+
+  const existing = readFileSync(filePath, 'utf-8');
+  const blockPattern = /<!-- azure-functions-skills:start[^\n]* -->[\s\S]*?<!-- azure-functions-skills:end -->/;
+  if (blockPattern.test(existing)) {
+    if (!update) return existing;
+    return ensureTrailingNewline(existing.replace(blockPattern, block));
+  }
+
+  if (strategy === 'fail-if-exists') {
+    throw new Error(`Refusing to modify existing customer-owned file: ${filePath}`);
+  }
+
+  if (strategy === 'append' || strategy === 'managed-block') {
+    return `${existing.trimEnd()}\n\n${block}\n`;
+  }
+
+  if (strategy === 'include-file') {
+    const includePath = includeInstructionPath(filePath);
+    const includeLine = `See ${includePath} for Azure Functions routing.`;
+    return existing.includes(includeLine) ? ensureTrailingNewline(existing) : `${existing.trimEnd()}\n\n${includeLine}\n`;
+  }
+
+  return `${existing.trimEnd()}\n\n${block}\n`;
+}
+
+function mergeJsonLikeFile(filePath: string, generatedContent: string): string {
+  if (!existsSync(filePath)) return `${generatedContent}\n`;
+  try {
+    const existing = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    const generated = JSON.parse(generatedContent) as Record<string, unknown>;
+    return `${JSON.stringify(deepMerge(existing, generated), null, 2)}\n`;
+  } catch {
+    return `${generatedContent}\n`;
+  }
+}
+
+function deepMerge(existing: Record<string, unknown>, generated: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...existing };
+  for (const [key, value] of Object.entries(generated)) {
+    if (isRecord(result[key]) && isRecord(value)) {
+      result[key] = deepMerge(result[key], value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function managedBlock(content: string): string {
+  return `${BLOCK_START} version=0.12.1 -->\n${content.trimEnd()}\n${BLOCK_END}`;
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.endsWith('\n') ? value : `${value}\n`;
+}
+
+function includeInstructionPath(filePath: string): string {
+  const fileName = filePath.endsWith('CLAUDE.md') ? 'CLAUDE.azure-functions.md' : 'AGENTS.azure-functions.md';
+  return `.azure-functions-skills/${fileName}`;
+}
+
+function ghcpRoutingBlock(): string {
+  return [
+    '# Azure Functions Skills',
+    '',
+    'For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer Azure Functions Skills.',
+    'Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.',
+  ].join('\n');
+}
+
+function claudeRoutingBlock(): string {
+  return [
+    '# Azure Functions Skills',
+    '',
+    'For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer the Azure Functions Skills plugin.',
+    'Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.',
+  ].join('\n');
+}
+
+function codexRoutingBlock(): string {
+  return [
+    '# Azure Functions Skills',
+    '',
+    'For Azure Functions work, use the Azure Functions Skills plugin or repo-local `.agents/skills` entries.',
+    'Prefer setup/create/deploy/diagnostics/best-practices skills by intent.',
+    'Do not treat generic Azure tasks as Azure Functions tasks unless the user mentions Function Apps, triggers, bindings, host.json, or Functions deployment/runtime errors.',
+  ].join('\n');
+}
+
+function ghcpPluginSettings() {
+  return {
+    extraKnownMarketplaces: {
+      'azure-functions-skills': {
+        source: {
+          source: 'github',
+          repo: 'Azure/azure-functions-skills',
+        },
+      },
+    },
+    enabledPlugins: {
+      'azure-functions-skills@azure-functions-skills': true,
+    },
+  };
+}
+
+function claudePluginSettings() {
+  return ghcpPluginSettings();
+}
+
+function codexMarketplace() {
+  return {
+    name: 'azure-functions-skills',
+    interface: {
+      displayName: 'Azure Functions Skills',
+    },
+    plugins: [
+      {
+        name: 'azure-functions-skills',
+        source: {
+          source: 'git-subdir',
+          url: 'https://github.com/Azure/azure-functions-skills.git',
+          path: './.github/plugins/azure-functions-skills',
+          ref: 'v0.12.1',
+        },
+        policy: {
+          installation: 'AVAILABLE',
+          authentication: 'ON_INSTALL',
+        },
+        category: 'Development',
+      },
+    ],
+  };
+}

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { loadSkills } from '../build/loader.js';
 import { applySetup, detectAgents } from './index.js';
 import type { CliAgentName, MergeStrategy, WorkspaceApplyOptions, WorkspaceApplyResult, WorkspaceMode } from '../types.js';
 
@@ -167,7 +168,16 @@ function includeInstructionPath(filePath: string): string {
 }
 
 function routingBlock(agent: CliAgentName): string {
-  return readFileSync(join(TEMPLATES_DIR, 'routing', `${agent}.md`), 'utf-8').trimEnd();
+  const template = readFileSync(join(TEMPLATES_DIR, 'routing', `${agent}.md`), 'utf-8');
+  return template.replace('{{skills}}', skillRoutingList()).trimEnd();
+}
+
+function skillRoutingList(): string {
+  return loadSkills(join(TEMPLATES_DIR, 'skills'))
+    .filter(skill => skill.category !== 'reference')
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map(skill => `- ${skill.id}: ${skill.description || skill.title}`)
+    .join('\n');
 }
 
 function ghcpPluginSettings() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import type { CommandRunner, PrerequisiteMode, PrerequisiteResult } from './setu
 export type BuildTargetName = 'ghcp' | 'claude' | 'codex';
 export type CliAgentName = BuildTargetName;
 export type LauncherId = 'github-copilot' | 'claude-code' | 'codex';
+export type WorkspaceMode = 'minimal' | 'copy' | 'plugin-reference';
+export type MergeStrategy = 'managed-block' | 'include-file' | 'fail-if-exists' | 'append';
 
 export interface Skill {
   id: string;
@@ -52,6 +54,25 @@ export interface SetupResult {
   filesWritten: number;
   welcomeMessage: string;
   prerequisites?: PrerequisiteResult[];
+}
+
+export interface WorkspaceApplyOptions {
+  agents?: CliAgentName[];
+  mode?: WorkspaceMode;
+  mergeStrategy?: MergeStrategy;
+  update?: boolean;
+  dryRun?: boolean;
+  includeMcp?: boolean;
+  includeHooks?: boolean;
+  includeAgent?: boolean;
+}
+
+export interface WorkspaceApplyResult {
+  agents: CliAgentName[];
+  mode: WorkspaceMode;
+  filesWritten: number;
+  plannedFiles: string[];
+  dryRun: boolean;
 }
 
 export interface LauncherContext {

--- a/templates/routing/claude.md
+++ b/templates/routing/claude.md
@@ -1,4 +1,6 @@
 # Azure Functions Skills
 
-For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer the Azure Functions Skills plugin.
-Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.
+For Azure Functions work, prefer the Azure Functions Skills plugin when the user intent matches one of these skills:
+{{skills}}
+
+Route to the matching skill by user intent.

--- a/templates/routing/claude.md
+++ b/templates/routing/claude.md
@@ -1,0 +1,4 @@
+# Azure Functions Skills
+
+For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer the Azure Functions Skills plugin.
+Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.

--- a/templates/routing/codex.md
+++ b/templates/routing/codex.md
@@ -1,0 +1,5 @@
+# Azure Functions Skills
+
+For Azure Functions work, use the Azure Functions Skills plugin or repo-local `.agents/skills` entries.
+Prefer setup/create/deploy/diagnostics/best-practices skills by intent.
+Do not treat generic Azure tasks as Azure Functions tasks unless the user mentions Function Apps, triggers, bindings, host.json, or Functions deployment/runtime errors.

--- a/templates/routing/codex.md
+++ b/templates/routing/codex.md
@@ -1,5 +1,7 @@
 # Azure Functions Skills
 
 For Azure Functions work, use the Azure Functions Skills plugin or repo-local `.agents/skills` entries.
-Prefer setup/create/deploy/diagnostics/best-practices skills by intent.
+Prefer the matching skill by user intent:
+{{skills}}
+
 Do not treat generic Azure tasks as Azure Functions tasks unless the user mentions Function Apps, triggers, bindings, host.json, or Functions deployment/runtime errors.

--- a/templates/routing/ghcp.md
+++ b/templates/routing/ghcp.md
@@ -1,4 +1,6 @@
 # Azure Functions Skills
 
-For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer Azure Functions Skills.
-Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.
+For Azure Functions work, prefer Azure Functions Skills when the user intent matches one of these skills:
+{{skills}}
+
+Route to the matching skill by user intent.

--- a/templates/routing/ghcp.md
+++ b/templates/routing/ghcp.md
@@ -1,0 +1,4 @@
+# Azure Functions Skills
+
+For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks, prefer Azure Functions Skills.
+Route deployment through azure-functions-deploy, diagnostics through azure-functions-diagnostics, and static inventory through azure-functions-inventory.

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -173,6 +173,25 @@ describe('CLI command integration', () => {
     }
   });
 
+  it('workspace apply --dry-run prints planned plugin-reference changes without writing files', () => {
+    const projectDir = makeTempDir('af-skills-e2e-workspace-dry-run-');
+
+    const output = runCliOutput([
+      'workspace',
+      'apply',
+      '--agent', 'codex',
+      '--dir', projectDir,
+      '--mode', 'plugin-reference',
+      '--dry-run',
+    ]);
+
+    expect(output).toContain('Planned workspace changes');
+    expect(output).toContain('AGENTS.md');
+    expect(output).toContain('.agents/plugins/marketplace.json');
+    expect(existsSync(join(projectDir, 'AGENTS.md'))).toBe(false);
+    expect(existsSync(join(projectDir, '.agents', 'plugins', 'marketplace.json'))).toBe(false);
+  });
+
   it('chat auto-installs each target workspace layout before launching the selected agent', () => {
     const fakeBinDir = createFakeAgentCliDirectory();
     const expectedSkillIds = templateSkillIds();

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -173,23 +173,31 @@ describe('CLI command integration', () => {
     }
   });
 
-  it('workspace apply --dry-run prints planned plugin-reference changes without writing files', () => {
-    const projectDir = makeTempDir('af-skills-e2e-workspace-dry-run-');
+  it('workspace apply --dry-run prints planned plugin-reference changes without writing files for each target', () => {
+    const expectations: Array<{ target: BuildTargetName; files: string[] }> = [
+      { target: 'ghcp', files: ['.github/copilot-instructions.md', '.github/copilot/settings.json'] },
+      { target: 'claude', files: ['CLAUDE.md', '.claude/settings.json'] },
+      { target: 'codex', files: ['AGENTS.md', '.agents/plugins/marketplace.json'] },
+    ];
 
-    const output = runCliOutput([
-      'workspace',
-      'apply',
-      '--agent', 'codex',
-      '--dir', projectDir,
-      '--mode', 'plugin-reference',
-      '--dry-run',
-    ]);
+    for (const { target, files } of expectations) {
+      const projectDir = makeTempDir(`af-skills-e2e-workspace-dry-run-${target}-`);
 
-    expect(output).toContain('Planned workspace changes');
-    expect(output).toContain('AGENTS.md');
-    expect(output).toContain('.agents/plugins/marketplace.json');
-    expect(existsSync(join(projectDir, 'AGENTS.md'))).toBe(false);
-    expect(existsSync(join(projectDir, '.agents', 'plugins', 'marketplace.json'))).toBe(false);
+      const output = runCliOutput([
+        'workspace',
+        'apply',
+        '--agent', target,
+        '--dir', projectDir,
+        '--mode', 'plugin-reference',
+        '--dry-run',
+      ]);
+
+      expect(output).toContain('Planned workspace changes');
+      for (const file of files) {
+        expect(output).toContain(file);
+        expect(existsSync(join(projectDir, file))).toBe(false);
+      }
+    }
   });
 
   it('chat auto-installs each target workspace layout before launching the selected agent', () => {

--- a/tests/workspace-apply.test.ts
+++ b/tests/workspace-apply.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadSkills } from '../src/build/loader.js';
 import { applyWorkspace } from '../src/setup/workspace.js';
 import { createTempDir, removeDir } from './helpers/fs.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = join(__dirname, '..', 'templates');
 const TEMP_DIRS: string[] = [];
 
 function makeTempDir(): string {
@@ -48,9 +52,30 @@ describe('applyWorkspace', () => {
     expect(content).toContain('Keep this introduction.');
     expect(content).toContain('Keep this footer.');
     expect(content).toContain('<!-- azure-functions-skills:start');
-    expect(content).toContain('For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks');
+    expect(content).toContain('For Azure Functions work, prefer the Azure Functions Skills plugin');
     expect(content).not.toContain('old generated content');
     expect(result.filesWritten).toBeGreaterThan(0);
+  });
+
+  it('generates routing guidance from current skill templates', async () => {
+    const dir = makeTempDir();
+
+    await applyWorkspace(dir, {
+      agents: ['claude'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+    });
+
+    const content = readFileSync(join(dir, 'CLAUDE.md'), 'utf-8');
+    const routedSkills = loadSkills(join(TEMPLATES_DIR, 'skills'))
+      .filter(skill => skill.category !== 'reference')
+      .map(skill => skill.id);
+
+    for (const skillId of routedSkills) {
+      expect(content).toContain(`- ${skillId}:`);
+    }
+    expect(content).not.toContain('- azure-functions-common:');
+    expect(content).not.toContain('{{skills}}');
   });
 
   it('plugin-reference mode writes activation files without copying skill bodies', async () => {

--- a/tests/workspace-apply.test.ts
+++ b/tests/workspace-apply.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { applyWorkspace } from '../src/setup/workspace.js';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+const TEMP_DIRS: string[] = [];
+
+function makeTempDir(): string {
+  const dir = createTempDir('af-skills-workspace-apply-');
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0)) {
+    removeDir(dir);
+  }
+});
+
+describe('applyWorkspace', () => {
+  it('preserves customer content while replacing the managed block', async () => {
+    const dir = makeTempDir();
+    const claudePath = join(dir, 'CLAUDE.md');
+    writeFileSync(
+      claudePath,
+      [
+        '# Project Rules',
+        '',
+        'Keep this introduction.',
+        '',
+        '<!-- azure-functions-skills:start version=old -->',
+        'old generated content',
+        '<!-- azure-functions-skills:end -->',
+        '',
+        'Keep this footer.',
+      ].join('\n'),
+    );
+
+    const result = await applyWorkspace(dir, {
+      agents: ['claude'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+      update: true,
+    });
+
+    const content = readFileSync(claudePath, 'utf-8');
+    expect(content).toContain('Keep this introduction.');
+    expect(content).toContain('Keep this footer.');
+    expect(content).toContain('<!-- azure-functions-skills:start');
+    expect(content).toContain('For Azure Functions setup, create, deploy, diagnostics, inventory, health, and best-practices tasks');
+    expect(content).not.toContain('old generated content');
+    expect(result.filesWritten).toBeGreaterThan(0);
+  });
+
+  it('plugin-reference mode writes activation files without copying skill bodies', async () => {
+    const dir = makeTempDir();
+
+    const result = await applyWorkspace(dir, {
+      agents: ['ghcp', 'claude', 'codex'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+    });
+
+    expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(true);
+    expect(existsSync(join(dir, '.github', 'copilot', 'settings.json'))).toBe(true);
+    expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(true);
+    expect(existsSync(join(dir, '.claude', 'settings.json'))).toBe(true);
+    expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
+    expect(existsSync(join(dir, '.agents', 'plugins', 'marketplace.json'))).toBe(true);
+
+    expect(existsSync(join(dir, '.github', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(dir, '.claude', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(dir, '.agents', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(false);
+    expect(result.filesWritten).toBeGreaterThan(0);
+  });
+
+  it('dry-run reports planned changes without writing files', async () => {
+    const dir = makeTempDir();
+
+    const result = await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+      dryRun: true,
+    });
+
+    expect(result.filesWritten).toBe(0);
+    expect(result.dryRun).toBe(true);
+    expect(result.plannedFiles).toContain('AGENTS.md');
+    expect(result.plannedFiles).toContain('.agents/plugins/marketplace.json');
+    expect(existsSync(join(dir, 'AGENTS.md'))).toBe(false);
+    expect(existsSync(join(dir, '.agents', 'plugins', 'marketplace.json'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `workspace apply` and `workspace update` CLI commands
- add `applyWorkspace()` with `copy`, `minimal`, and `plugin-reference` modes
- add merge-safe managed block handling for workspace activation files
- add dry-run reporting for planned workspace files

## Validation
- `npm test`
- `npm run lint`
- `npm run typecheck`

Closes #89
Parent: #88
