### PR TITLE
feat: add plugin install and update commands

### DIFF
--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -320,7 +320,10 @@ if (command === 'setup') {
 
   if (dryRun) {
     console.log(`Planned plugin ${action}:`);
-    for (const step of result.steps) console.log(`  - ${step.target}: ${step.description}`);
+    for (const step of result.steps) {
+      console.log(`  - ${step.target}: ${step.description}`);
+      for (const command of step.commands || []) console.log(`      $ ${command}`);
+    }
   } else {
     console.log(`Plugin ${action} complete.`);
     console.log(`  Agents configured: ${result.agents.join(', ')}`);

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -22,6 +22,8 @@ function printHelp() {
 
   Commands:
     setup    Detect coding agents and install skill files into your project
+    plugin install   Register Azure Functions Skills as a native plugin
+    plugin update    Refresh plugin registration and workspace activation
     workspace apply   Apply Azure Functions routing/activation files to a workspace
     workspace update  Update existing Azure Functions managed workspace routing blocks
     chat     Launch a CLI coding agent with Azure Functions Welcome prompt
@@ -42,6 +44,16 @@ function printHelp() {
     --update           Replace existing Azure Functions managed blocks
     --dry-run          Print planned changes without writing files
 
+  Options (plugin install/update):
+    --agent <name>     Specify agent: ghcp, claude, codex (repeatable)
+    --dir <path>       Target directory (default: current directory)
+    --scope <name>     workspace or user (default: workspace)
+    --source <name>    marketplace, github, or local (default: marketplace)
+    --version <value>  Plugin version/ref to plan (default: package version)
+    --workspace        Apply workspace plugin-reference activation (default)
+    --no-workspace     Skip workspace activation
+    --dry-run          Print planned changes without writing files
+
   Options (chat):
     --agent <name>     Agent: github-copilot, claude-code, codex (auto-detected if omitted)
     --prompt <text>    Custom prompt (overrides startup template)
@@ -59,6 +71,7 @@ function printHelp() {
   Examples:
     npx @agent-loom/azure-functions-skills setup
     npx @agent-loom/azure-functions-skills setup --as-plugin
+    npx @agent-loom/azure-functions-skills plugin install --agent ghcp --dry-run
     npx @agent-loom/azure-functions-skills workspace apply --agent codex --mode plugin-reference --dry-run
     npx @agent-loom/azure-functions-skills chat
     npx @agent-loom/azure-functions-skills chat --as-plugin --agent claude-code
@@ -262,6 +275,55 @@ if (command === 'setup') {
     console.log(`Workspace ${action} complete.`);
     console.log(`  Agents configured: ${result.agents.join(', ')}`);
     console.log(`  Mode: ${result.mode}`);
+    console.log(`  Files written: ${result.filesWritten}`);
+  }
+} else if (command === 'plugin') {
+  const action = args[1];
+  if (action !== 'install' && action !== 'update') {
+    console.error(`Unknown plugin command: ${action || ''}`.trim());
+    console.error('Usage: azure-functions-skills plugin install|update [options]');
+    process.exit(1);
+  }
+
+  const { detectAgents } = await import('../lib/setup/index.js');
+  const { runPluginOperation } = await import('../lib/setup/plugin-install.js');
+  const agents = [];
+  let dir = process.cwd();
+  let scope = 'workspace';
+  let source = 'marketplace';
+  let version = undefined;
+  let workspace = true;
+  let dryRun = false;
+
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--agent' && args[i + 1]) agents.push(args[++i]);
+    else if (args[i] === '--dir' && args[i + 1]) dir = args[++i];
+    else if (args[i] === '--scope' && args[i + 1]) scope = args[++i];
+    else if (args[i] === '--source' && args[i + 1]) source = args[++i];
+    else if (args[i] === '--version' && args[i + 1]) version = args[++i];
+    else if (args[i] === '--workspace') workspace = true;
+    else if (args[i] === '--no-workspace') workspace = false;
+    else if (args[i] === '--dry-run') dryRun = true;
+  }
+
+  const detectedAgents = agents.length > 0 ? agents : await detectAgents();
+  const result = await runPluginOperation({
+    action,
+    agents: detectedAgents,
+    projectDir: dir,
+    dryRun,
+    scope,
+    source,
+    version,
+    workspace,
+  });
+
+  if (dryRun) {
+    console.log(`Planned plugin ${action}:`);
+    for (const step of result.steps) console.log(`  - ${step.target}: ${step.description}`);
+  } else {
+    console.log(`Plugin ${action} complete.`);
+    console.log(`  Agents configured: ${result.agents.join(', ')}`);
     console.log(`  Files written: ${result.filesWritten}`);
   }
 } else if (command === 'build') {

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -307,16 +307,22 @@ if (command === 'setup') {
   }
 
   const detectedAgents = agents.length > 0 ? agents : await detectAgents();
-  const result = await runPluginOperation({
-    action,
-    agents: detectedAgents,
-    projectDir: dir,
-    dryRun,
-    scope,
-    source,
-    version,
-    workspace,
-  });
+  let result;
+  try {
+    result = await runPluginOperation({
+      action,
+      agents: detectedAgents,
+      projectDir: dir,
+      dryRun,
+      scope,
+      source,
+      version,
+      workspace,
+    });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
 
   if (dryRun) {
     console.log(`Planned plugin ${action}:`);

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -44,6 +44,7 @@ export interface PluginOperationOptions {
   version?: string;
   workspace?: boolean;
   runner?: CommandRunner;
+  platform?: NodeJS.Platform;
 }
 
 export interface PluginOperationStep {
@@ -289,13 +290,13 @@ async function ensureRequiredTools(options: PluginOperationOptions): Promise<voi
 
 async function toolExists(options: PluginOperationOptions, tool: string): Promise<boolean> {
   const runner = options.runner || defaultRunner;
-  const checkCommand = toolCheckCommand(tool);
+  const checkCommand = toolCheckCommand(options, tool);
   const result = await runner(checkCommand.command, checkCommand.args, { cwd: options.projectDir });
   return result.exitCode === 0;
 }
 
-function toolCheckCommand(tool: string): PluginCommand {
-  if (process.platform === 'win32') return { command: 'where.exe', args: [tool] };
+function toolCheckCommand(options: PluginOperationOptions, tool: string): PluginCommand {
+  if (runtimePlatform(options) === 'win32') return { command: 'where.exe', args: [tool] };
   return { command: 'sh', args: ['-c', `command -v ${tool}`] };
 }
 
@@ -414,7 +415,7 @@ async function defaultRunner(command: string, args: string[]) {
     const stdout = execFileSync(command, args, {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      shell: process.platform === 'win32',
+      shell: runtimePlatform() === 'win32',
     });
     return { exitCode: 0, stdout, stderr: '' };
   } catch (error) {
@@ -425,6 +426,10 @@ async function defaultRunner(command: string, args: string[]) {
       stderr: bufferToString(err.stderr) || err.message || '',
     };
   }
+}
+
+function runtimePlatform(options?: PluginOperationOptions): NodeJS.Platform {
+  return options?.platform || process.platform;
 }
 
 function bufferToString(value: Buffer | string | undefined): string {

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import type { BuildTargetName } from '../types.js';
+import type { CommandRunner } from './prerequisites/types.js';
 import { applyWorkspace } from './workspace.js';
 
 interface PluginInstallResult {
@@ -42,12 +43,14 @@ export interface PluginOperationOptions {
   source?: PluginOperationSource;
   version?: string;
   workspace?: boolean;
+  runner?: CommandRunner;
 }
 
 export interface PluginOperationStep {
   target: BuildTargetName;
   kind: 'plugin-registration' | 'workspace-activation';
   description: string;
+  commands?: string[];
   path?: string;
 }
 
@@ -60,6 +63,11 @@ export interface PluginOperationResult {
   version: string;
   steps: PluginOperationStep[];
   filesWritten: number;
+}
+
+interface PluginCommand {
+  command: string;
+  args: string[];
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -208,11 +216,13 @@ export function planPluginOperation(options: PluginOperationOptions): PluginOper
   const steps: PluginOperationStep[] = [];
 
   for (const target of options.agents) {
+    const commands = officialPluginCommands(target, scope);
     steps.push({
       target,
       kind: 'plugin-registration',
       path: source === 'local' ? getPluginDir(target) : undefined,
       description: pluginRegistrationDescription(options.action, target, scope, source, version),
+      commands: commands.map(formatCommand),
     });
 
     if (includeWorkspace) {
@@ -241,7 +251,12 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
   if (result.dryRun) return result;
 
   for (const target of result.agents) {
-    installPlugin(target, options.projectDir);
+    for (const pluginCommand of officialPluginCommands(target, result.scope)) {
+      const commandResult = await runCommand(options, pluginCommand);
+      if (commandResult.exitCode !== 0) {
+        throw new Error(`Plugin ${options.action} failed for ${target}: ${commandResult.stderr || commandResult.stdout}`);
+      }
+    }
   }
 
   if (options.workspace !== false) {
@@ -255,6 +270,63 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
   }
 
   return result;
+}
+
+function officialPluginCommands(target: BuildTargetName, scope: PluginOperationScope): PluginCommand[] {
+  if (target === 'ghcp') {
+    return [
+      { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
+      { command: 'copilot', args: ['plugin', 'install', 'azure-functions-skills@azure-functions-skills'] },
+    ];
+  }
+
+  if (target === 'claude') {
+    return [
+      { command: 'claude', args: ['plugin', 'install', 'Azure/azure-functions-skills', '--scope', claudeScope(scope)] },
+    ];
+  }
+
+  return [
+    { command: 'codex', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
+    { command: 'codex', args: ['plugin', 'add', 'azure-functions-skills@azure-functions-skills'] },
+  ];
+}
+
+function claudeScope(scope: PluginOperationScope): string {
+  return scope === 'workspace' ? 'project' : 'user';
+}
+
+function formatCommand(pluginCommand: PluginCommand): string {
+  return [pluginCommand.command, ...pluginCommand.args].join(' ');
+}
+
+async function runCommand(options: PluginOperationOptions, pluginCommand: PluginCommand) {
+  const runner = options.runner || defaultRunner;
+  return runner(pluginCommand.command, pluginCommand.args, { cwd: options.projectDir });
+}
+
+async function defaultRunner(command: string, args: string[]) {
+  const { execFileSync } = await import('node:child_process');
+  try {
+    const stdout = execFileSync(command, args, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (error) {
+    const err = error as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
+    return {
+      exitCode: err.status ?? 1,
+      stdout: bufferToString(err.stdout),
+      stderr: bufferToString(err.stderr) || err.message || '',
+    };
+  }
+}
+
+function bufferToString(value: Buffer | string | undefined): string {
+  if (!value) return '';
+  return typeof value === 'string' ? value : value.toString('utf-8');
 }
 
 function pluginRegistrationDescription(

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -250,6 +250,8 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
   const result = planPluginOperation(options);
   if (result.dryRun) return result;
 
+  await ensureRequiredTools(options);
+
   for (const target of result.agents) {
     for (const pluginCommand of officialPluginCommands(target, options)) {
       const commandResult = await runCommand(options, pluginCommand);
@@ -270,6 +272,82 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
   }
 
   return result;
+}
+
+async function ensureRequiredTools(options: PluginOperationOptions): Promise<void> {
+  const requiredTools = unique(options.agents.flatMap(target => officialPluginCommands(target, options).map(pluginCommand => pluginCommand.command)));
+  const missingTools: string[] = [];
+
+  for (const tool of requiredTools) {
+    if (!await toolExists(options, tool)) missingTools.push(tool);
+  }
+
+  if (missingTools.length > 0) {
+    throw new Error(missingToolsMessage(options, missingTools));
+  }
+}
+
+async function toolExists(options: PluginOperationOptions, tool: string): Promise<boolean> {
+  const runner = options.runner || defaultRunner;
+  const checkCommand = toolCheckCommand(tool);
+  const result = await runner(checkCommand.command, checkCommand.args, { cwd: options.projectDir });
+  return result.exitCode === 0;
+}
+
+function toolCheckCommand(tool: string): PluginCommand {
+  if (process.platform === 'win32') return { command: 'where.exe', args: [tool] };
+  return { command: 'sh', args: ['-c', `command -v ${tool}`] };
+}
+
+function missingToolsMessage(options: PluginOperationOptions, missingTools: string[]): string {
+  return [
+    `Cannot ${options.action} Azure Functions Skills plugin for ${agentLabel(options.agents)}.`,
+    '',
+    'Missing required tools:',
+    ...missingTools.map(tool => `  - ${tool}: ${toolPurpose(tool)}`),
+    '',
+    'Install:',
+    ...missingTools.map(tool => `  - ${toolInstallLabel(tool)}: ${toolInstallUrl(tool)}`),
+    '',
+    'Then retry:',
+    `  azure-functions-skills plugin ${options.action}${options.agents.map(agent => ` --agent ${agent}`).join('')}`,
+  ].join('\n');
+}
+
+function agentLabel(agents: BuildTargetName[]): string {
+  return agents.map(agent => ({
+    ghcp: 'GitHub Copilot CLI',
+    claude: 'Claude Code',
+    codex: 'Codex',
+  })[agent]).join(', ');
+}
+
+function toolPurpose(tool: string): string {
+  if (tool === 'git') return 'required to clone https://github.com/Azure/azure-functions-skills.git for Claude plugin-from-source.';
+  if (tool === 'claude') return 'required to validate and load the Claude plugin payload.';
+  if (tool === 'copilot') return 'required to run GitHub Copilot plugin marketplace and install commands.';
+  if (tool === 'codex') return 'required to run Codex plugin marketplace and install commands.';
+  return 'required to install the plugin.';
+}
+
+function toolInstallLabel(tool: string): string {
+  if (tool === 'git') return 'Git';
+  if (tool === 'claude') return 'Claude Code';
+  if (tool === 'copilot') return 'GitHub Copilot CLI';
+  if (tool === 'codex') return 'Codex CLI';
+  return tool;
+}
+
+function toolInstallUrl(tool: string): string {
+  if (tool === 'git') return 'https://git-scm.com/downloads';
+  if (tool === 'claude') return 'https://claude.ai/download';
+  if (tool === 'copilot') return 'https://docs.github.com/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli';
+  if (tool === 'codex') return 'https://developers.openai.com/codex/cli';
+  return 'See the tool documentation.';
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 function officialPluginCommands(target: BuildTargetName, options: PluginOperationOptions): PluginCommand[] {

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -216,7 +216,7 @@ export function planPluginOperation(options: PluginOperationOptions): PluginOper
   const steps: PluginOperationStep[] = [];
 
   for (const target of options.agents) {
-    const commands = officialPluginCommands(target, scope);
+    const commands = officialPluginCommands(target, options);
     steps.push({
       target,
       kind: 'plugin-registration',
@@ -251,7 +251,7 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
   if (result.dryRun) return result;
 
   for (const target of result.agents) {
-    for (const pluginCommand of officialPluginCommands(target, result.scope)) {
+    for (const pluginCommand of officialPluginCommands(target, options)) {
       const commandResult = await runCommand(options, pluginCommand);
       if (commandResult.exitCode !== 0) {
         throw new Error(`Plugin ${options.action} failed for ${target}: ${commandResult.stderr || commandResult.stdout}`);
@@ -272,7 +272,7 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
   return result;
 }
 
-function officialPluginCommands(target: BuildTargetName, scope: PluginOperationScope): PluginCommand[] {
+function officialPluginCommands(target: BuildTargetName, options: PluginOperationOptions): PluginCommand[] {
   if (target === 'ghcp') {
     return [
       { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
@@ -281,9 +281,7 @@ function officialPluginCommands(target: BuildTargetName, scope: PluginOperationS
   }
 
   if (target === 'claude') {
-    return [
-      { command: 'claude', args: ['plugin', 'install', 'Azure/azure-functions-skills', '--scope', claudeScope(scope)] },
-    ];
+    return claudePluginCommands(options);
   }
 
   return [
@@ -292,8 +290,35 @@ function officialPluginCommands(target: BuildTargetName, scope: PluginOperationS
   ];
 }
 
-function claudeScope(scope: PluginOperationScope): string {
-  return scope === 'workspace' ? 'project' : 'user';
+function claudePluginCommands(options: PluginOperationOptions): PluginCommand[] {
+  const pluginPath = claudePluginPayloadPath(options);
+  if (options.source === 'local') {
+    return [{ command: 'claude', args: ['plugin', 'validate', pluginPath] }];
+  }
+
+  const cloneDir = claudeRepositoryCloneDir(options.projectDir);
+  const syncCommand = options.action === 'update'
+    ? { command: 'git', args: ['-C', cloneDir, 'pull', '--ff-only'] }
+    : { command: 'git', args: ['clone', 'https://github.com/Azure/azure-functions-skills.git', cloneDir] };
+
+  return [
+    syncCommand,
+    { command: 'claude', args: ['plugin', 'validate', pluginPath] },
+  ];
+}
+
+function claudePluginPayloadPath(options: PluginOperationOptions): string {
+  if (options.source === 'local') return localPluginPayloadPath();
+  return join(claudeRepositoryCloneDir(options.projectDir), '.github', 'plugins', 'azure-functions-skills');
+}
+
+function claudeRepositoryCloneDir(projectDir: string): string {
+  return join(projectDir, '.azure-functions-skills', 'source', 'azure-functions-skills');
+}
+
+function localPluginPayloadPath(): string {
+  const repoPluginPath = join(PACKAGE_ROOT, '.github', 'plugins', 'azure-functions-skills');
+  return existsSync(repoPluginPath) ? repoPluginPath : getPluginDir('claude');
 }
 
 function formatCommand(pluginCommand: PluginCommand): string {

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import type { BuildTargetName } from '../types.js';
+import { applyWorkspace } from './workspace.js';
 
 interface PluginInstallResult {
   target: BuildTargetName;
@@ -26,6 +27,39 @@ interface CodexMarketplacePlugin {
 interface CodexMarketplace {
   plugins?: CodexMarketplacePlugin[];
   [key: string]: unknown;
+}
+
+export type PluginOperationAction = 'install' | 'update';
+export type PluginOperationScope = 'workspace' | 'user';
+export type PluginOperationSource = 'marketplace' | 'local' | 'github';
+
+export interface PluginOperationOptions {
+  action: PluginOperationAction;
+  agents: BuildTargetName[];
+  projectDir: string;
+  dryRun?: boolean;
+  scope?: PluginOperationScope;
+  source?: PluginOperationSource;
+  version?: string;
+  workspace?: boolean;
+}
+
+export interface PluginOperationStep {
+  target: BuildTargetName;
+  kind: 'plugin-registration' | 'workspace-activation';
+  description: string;
+  path?: string;
+}
+
+export interface PluginOperationResult {
+  action: PluginOperationAction;
+  agents: BuildTargetName[];
+  dryRun: boolean;
+  scope: PluginOperationScope;
+  source: PluginOperationSource;
+  version: string;
+  steps: PluginOperationStep[];
+  filesWritten: number;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -163,6 +197,90 @@ export function installPlugin(target: BuildTargetName, projectDir: string): Plug
   }
 
   return result;
+}
+
+export function planPluginOperation(options: PluginOperationOptions): PluginOperationResult {
+  const dryRun = options.dryRun === true;
+  const scope = options.scope || 'workspace';
+  const source = options.source || 'marketplace';
+  const version = options.version || packageVersion();
+  const includeWorkspace = options.workspace !== false;
+  const steps: PluginOperationStep[] = [];
+
+  for (const target of options.agents) {
+    steps.push({
+      target,
+      kind: 'plugin-registration',
+      path: source === 'local' ? getPluginDir(target) : undefined,
+      description: pluginRegistrationDescription(options.action, target, scope, source, version),
+    });
+
+    if (includeWorkspace) {
+      steps.push({
+        target,
+        kind: 'workspace-activation',
+        description: `Apply workspace activation with workspace apply --agent ${target} --mode plugin-reference${options.action === 'update' ? ' --update' : ''}.`,
+      });
+    }
+  }
+
+  return {
+    action: options.action,
+    agents: options.agents,
+    dryRun,
+    scope,
+    source,
+    version,
+    steps,
+    filesWritten: 0,
+  };
+}
+
+export async function runPluginOperation(options: PluginOperationOptions): Promise<PluginOperationResult> {
+  const result = planPluginOperation(options);
+  if (result.dryRun) return result;
+
+  for (const target of result.agents) {
+    installPlugin(target, options.projectDir);
+  }
+
+  if (options.workspace !== false) {
+    const workspaceResult = await applyWorkspace(options.projectDir, {
+      agents: result.agents,
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+      update: options.action === 'update',
+    });
+    result.filesWritten += workspaceResult.filesWritten;
+  }
+
+  return result;
+}
+
+function pluginRegistrationDescription(
+  action: PluginOperationAction,
+  target: BuildTargetName,
+  scope: PluginOperationScope,
+  source: PluginOperationSource,
+  version: string,
+): string {
+  if (source === 'local') {
+    return `${capitalize(action)} ${target} plugin from local package build at ${scope} scope.`;
+  }
+  return `${capitalize(action)} ${target} plugin from ${source} source version ${version} at ${scope} scope.`;
+}
+
+function capitalize(value: string): string {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+}
+
+function packageVersion(): string {
+  try {
+    const packageJson = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf-8')) as { version?: string };
+    return packageJson.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
 }
 
 function mergeJsonFile(filePath: string, newEntries: Record<string, unknown>): Record<string, unknown> {

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -216,6 +216,8 @@ describe('CLI command integration', () => {
 
     expect(output).toContain('Planned plugin install');
     expect(output).toContain('ghcp');
+    expect(output).toContain('copilot plugin marketplace add Azure/azure-functions-skills');
+    expect(output).toContain('copilot plugin install azure-functions-skills@azure-functions-skills');
     expect(output).toContain('workspace activation');
     expect(output).toContain('0.12.1');
     expect(existsSync(join(projectDir, '.github', 'copilot-instructions.md'))).toBe(false);

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -224,6 +224,26 @@ describe('CLI command integration', () => {
     expect(existsSync(join(projectDir, '.github', 'copilot', 'settings.json'))).toBe(false);
   });
 
+  it('plugin install --dry-run shows Claude plugin-from-source payload loading', () => {
+    const projectDir = makeTempDir('af-skills-e2e-plugin-install-claude-dry-run-');
+
+    const output = runCliOutput([
+      'plugin',
+      'install',
+      '--agent', 'claude',
+      '--dir', projectDir,
+      '--dry-run',
+    ]);
+
+    expect(output).toContain('Planned plugin install');
+    expect(output).toContain('git clone https://github.com/Azure/azure-functions-skills.git');
+    expect(output).toContain('.github');
+    expect(output).toContain('plugins');
+    expect(output).toContain('claude plugin validate');
+    expect(output).toContain('workspace activation');
+    expect(existsSync(join(projectDir, 'CLAUDE.md'))).toBe(false);
+  });
+
   it('plugin update --dry-run can skip workspace activation', () => {
     const projectDir = makeTempDir('af-skills-e2e-plugin-update-dry-run-');
 

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -200,6 +200,48 @@ describe('CLI command integration', () => {
     }
   });
 
+  it('plugin install --dry-run prints plugin and workspace activation plans without writing files', () => {
+    const projectDir = makeTempDir('af-skills-e2e-plugin-install-dry-run-');
+
+    const output = runCliOutput([
+      'plugin',
+      'install',
+      '--agent', 'ghcp',
+      '--dir', projectDir,
+      '--scope', 'workspace',
+      '--source', 'marketplace',
+      '--version', '0.12.1',
+      '--dry-run',
+    ]);
+
+    expect(output).toContain('Planned plugin install');
+    expect(output).toContain('ghcp');
+    expect(output).toContain('workspace activation');
+    expect(output).toContain('0.12.1');
+    expect(existsSync(join(projectDir, '.github', 'copilot-instructions.md'))).toBe(false);
+    expect(existsSync(join(projectDir, '.github', 'copilot', 'settings.json'))).toBe(false);
+  });
+
+  it('plugin update --dry-run can skip workspace activation', () => {
+    const projectDir = makeTempDir('af-skills-e2e-plugin-update-dry-run-');
+
+    const output = runCliOutput([
+      'plugin',
+      'update',
+      '--agent', 'codex',
+      '--dir', projectDir,
+      '--source', 'local',
+      '--no-workspace',
+      '--dry-run',
+    ]);
+
+    expect(output).toContain('Planned plugin update');
+    expect(output).toContain('codex');
+    expect(output).not.toContain('workspace activation');
+    expect(existsSync(join(projectDir, 'AGENTS.md'))).toBe(false);
+    expect(existsSync(join(projectDir, '.agents', 'plugins', 'marketplace.json'))).toBe(false);
+  });
+
   it('chat auto-installs each target workspace layout before launching the selected agent', () => {
     const fakeBinDir = createFakeAgentCliDirectory();
     const expectedSkillIds = templateSkillIds();

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { getPluginDir, generateVscodeSettings, generateCodexMarketplaceEntry, generateClaudeSettings } from '../src/setup/plugin-install.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  getPluginDir,
+  generateVscodeSettings,
+  generateCodexMarketplaceEntry,
+  generateClaudeSettings,
+  planPluginOperation,
+} from '../src/setup/plugin-install.js';
 
 describe('getPluginDir', () => {
   it('returns the common plugin payload path under dist/', () => {
@@ -44,5 +52,57 @@ describe('generateClaudeSettings', () => {
     const settings = generateClaudeSettings(pluginPath);
     // Claude uses the plugin dir as an additional directory for skill discovery
     expect(settings).toBeTruthy();
+  });
+});
+
+describe('planPluginOperation', () => {
+  it('uses the package version when no version is specified', () => {
+    const packageJson = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'package.json'), 'utf-8')) as { version: string };
+
+    const plan = planPluginOperation({
+      action: 'install',
+      agents: ['ghcp'],
+      projectDir: '/workspace/project',
+      dryRun: true,
+    });
+
+    expect(plan.version).toBe(packageJson.version);
+    expect(plan.steps.map(step => step.description).join('\n')).toContain(packageJson.version);
+  });
+
+  it('plans plugin install with workspace activation without writing files', () => {
+    const plan = planPluginOperation({
+      action: 'install',
+      agents: ['ghcp'],
+      projectDir: '/workspace/project',
+      dryRun: true,
+      scope: 'workspace',
+      source: 'marketplace',
+      version: '0.12.1',
+      workspace: true,
+    });
+
+    expect(plan.action).toBe('install');
+    expect(plan.dryRun).toBe(true);
+    expect(plan.steps).toContainEqual(expect.objectContaining({ target: 'ghcp', kind: 'plugin-registration' }));
+    expect(plan.steps).toContainEqual(expect.objectContaining({ target: 'ghcp', kind: 'workspace-activation' }));
+    expect(plan.steps.map(step => step.description).join('\n')).toContain('0.12.1');
+  });
+
+  it('plans plugin update without workspace activation when disabled', () => {
+    const plan = planPluginOperation({
+      action: 'update',
+      agents: ['claude', 'codex'],
+      projectDir: '/workspace/project',
+      dryRun: true,
+      scope: 'user',
+      source: 'local',
+      workspace: false,
+    });
+
+    expect(plan.action).toBe('update');
+    expect(plan.steps.filter(step => step.kind === 'plugin-registration')).toHaveLength(2);
+    expect(plan.steps.some(step => step.kind === 'workspace-activation')).toBe(false);
+    expect(plan.steps.map(step => step.target)).toEqual(['claude', 'codex']);
   });
 });

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -24,6 +24,28 @@ function acceptingRunner(): TestRunner {
   return runner;
 }
 
+function missingToolsRunner(missingTools: string[]): TestRunner {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const runner = (async (command, args) => {
+    calls.push({ command, args });
+    const checkedTool = checkedToolName(command, args);
+    if (checkedTool) {
+      return missingTools.includes(checkedTool)
+        ? { exitCode: 1, stdout: '', stderr: `${checkedTool} not found` }
+        : { exitCode: 0, stdout: checkedTool, stderr: '' };
+    }
+    return { exitCode: 0, stdout: 'ok\n', stderr: '' };
+  }) as TestRunner;
+  runner.calls = calls;
+  return runner;
+}
+
+function checkedToolName(command: string, args: string[]): string | undefined {
+  if (command === 'where.exe') return args[0];
+  if (command === 'sh' && args[0] === '-c') return args[1]?.replace(/^command -v /, '');
+  return undefined;
+}
+
 describe('getPluginDir', () => {
   it('returns the common plugin payload path under dist/', () => {
     const dir = getPluginDir('ghcp');
@@ -150,7 +172,8 @@ describe('planPluginOperation', () => {
         runner,
       });
 
-      expect(runner.calls).toEqual([
+      const installCalls = runner.calls.filter(call => !checkedToolName(call.command, call.args));
+      expect(installCalls).toEqual([
         { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
         { command: 'copilot', args: ['plugin', 'install', 'azure-functions-skills@azure-functions-skills'] },
         { command: 'git', args: ['clone', 'https://github.com/Azure/azure-functions-skills.git', join(dir, '.azure-functions-skills', 'source', 'azure-functions-skills')] },
@@ -162,6 +185,47 @@ describe('planPluginOperation', () => {
       expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(true);
       expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
       expect(result.filesWritten).toBeGreaterThan(0);
+    } finally {
+      removeDir(dir);
+    }
+  });
+
+  it('reports missing Claude prerequisites with install guidance before running install commands', async () => {
+    const dir = createTempDir('af-skills-plugin-missing-claude-');
+    const runner = missingToolsRunner(['git', 'claude']);
+    try {
+      await expect(runPluginOperation({
+        action: 'install',
+        agents: ['claude'],
+        projectDir: dir,
+        dryRun: false,
+        workspace: true,
+        runner,
+      })).rejects.toThrow(/Cannot install Azure Functions Skills plugin for Claude Code[\s\S]*git[\s\S]*claude[\s\S]*https:\/\/git-scm\.com\/downloads[\s\S]*https:\/\/claude\.ai\/download/);
+
+      expect(runner.calls.some(call => call.command === 'git' && call.args[0] === 'clone')).toBe(false);
+      expect(runner.calls.some(call => call.command === 'claude' && call.args[0] === 'plugin')).toBe(false);
+      expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(false);
+    } finally {
+      removeDir(dir);
+    }
+  });
+
+  it('reports missing GitHub Copilot CLI with retry guidance', async () => {
+    const dir = createTempDir('af-skills-plugin-missing-ghcp-');
+    const runner = missingToolsRunner(['copilot']);
+    try {
+      await expect(runPluginOperation({
+        action: 'install',
+        agents: ['ghcp'],
+        projectDir: dir,
+        dryRun: false,
+        workspace: true,
+        runner,
+      })).rejects.toThrow(/Cannot install Azure Functions Skills plugin for GitHub Copilot CLI[\s\S]*copilot[\s\S]*GitHub Copilot CLI[\s\S]*azure-functions-skills plugin install --agent ghcp/);
+
+      expect(runner.calls.some(call => call.command === 'copilot')).toBe(false);
+      expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(false);
     } finally {
       removeDir(dir);
     }

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -231,6 +231,31 @@ describe('planPluginOperation', () => {
     }
   });
 
+  it('checks required tools with command -v on Linux-like platforms', async () => {
+    const dir = createTempDir('af-skills-plugin-linux-preflight-');
+    const runner = acceptingRunner();
+    try {
+      await runPluginOperation({
+        action: 'install',
+        agents: ['claude'],
+        projectDir: dir,
+        dryRun: false,
+        workspace: false,
+        platform: 'linux',
+        runner,
+      });
+
+      expect(runner.calls.slice(0, 2)).toEqual([
+        { command: 'sh', args: ['-c', 'command -v git'] },
+        { command: 'sh', args: ['-c', 'command -v claude'] },
+      ]);
+      const installCalls = runner.calls.filter(call => !checkedToolName(call.command, call.args));
+      expect(installCalls.map(call => call.command)).toEqual(['git', 'claude']);
+    } finally {
+      removeDir(dir);
+    }
+  });
+
   it('uses the current repository plugin payload for Claude when source is local', () => {
     const plan = planPluginOperation({
       action: 'install',

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   getPluginDir,
@@ -7,7 +7,22 @@ import {
   generateCodexMarketplaceEntry,
   generateClaudeSettings,
   planPluginOperation,
+  runPluginOperation,
 } from '../src/setup/plugin-install.js';
+import type { CommandRunner } from '../src/setup/prerequisites/types.js';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+type TestRunner = CommandRunner & { calls: Array<{ command: string; args: string[] }> };
+
+function acceptingRunner(): TestRunner {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const runner = (async (command, args) => {
+    calls.push({ command, args });
+    return { exitCode: 0, stdout: 'ok\n', stderr: '' };
+  }) as TestRunner;
+  runner.calls = calls;
+  return runner;
+}
 
 describe('getPluginDir', () => {
   it('returns the common plugin payload path under dist/', () => {
@@ -86,7 +101,67 @@ describe('planPluginOperation', () => {
     expect(plan.dryRun).toBe(true);
     expect(plan.steps).toContainEqual(expect.objectContaining({ target: 'ghcp', kind: 'plugin-registration' }));
     expect(plan.steps).toContainEqual(expect.objectContaining({ target: 'ghcp', kind: 'workspace-activation' }));
+    expect(plan.steps.find(step => step.target === 'ghcp' && step.kind === 'plugin-registration')?.commands).toEqual([
+      'copilot plugin marketplace add Azure/azure-functions-skills',
+      'copilot plugin install azure-functions-skills@azure-functions-skills',
+    ]);
     expect(plan.steps.map(step => step.description).join('\n')).toContain('0.12.1');
+  });
+
+  it('plans official plugin install commands for each coding agent', () => {
+    const plan = planPluginOperation({
+      action: 'install',
+      agents: ['ghcp', 'claude', 'codex'],
+      projectDir: '/workspace/project',
+      dryRun: true,
+      scope: 'workspace',
+      workspace: false,
+    });
+
+    const pluginSteps = plan.steps.filter(step => step.kind === 'plugin-registration');
+    expect(pluginSteps.map(step => [step.target, step.commands])).toEqual([
+      ['ghcp', [
+        'copilot plugin marketplace add Azure/azure-functions-skills',
+        'copilot plugin install azure-functions-skills@azure-functions-skills',
+      ]],
+      ['claude', [
+        'claude plugin install Azure/azure-functions-skills --scope project',
+      ]],
+      ['codex', [
+        'codex plugin marketplace add Azure/azure-functions-skills',
+        'codex plugin add azure-functions-skills@azure-functions-skills',
+      ]],
+    ]);
+  });
+
+  it('runs official plugin install commands before workspace activation', async () => {
+    const dir = createTempDir('af-skills-plugin-official-install-');
+    const runner = acceptingRunner();
+    try {
+      const result = await runPluginOperation({
+        action: 'install',
+        agents: ['ghcp', 'claude', 'codex'],
+        projectDir: dir,
+        dryRun: false,
+        scope: 'workspace',
+        workspace: true,
+        runner,
+      });
+
+      expect(runner.calls).toEqual([
+        { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
+        { command: 'copilot', args: ['plugin', 'install', 'azure-functions-skills@azure-functions-skills'] },
+        { command: 'claude', args: ['plugin', 'install', 'Azure/azure-functions-skills', '--scope', 'project'] },
+        { command: 'codex', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
+        { command: 'codex', args: ['plugin', 'add', 'azure-functions-skills@azure-functions-skills'] },
+      ]);
+      expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(true);
+      expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(true);
+      expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
+      expect(result.filesWritten).toBeGreaterThan(0);
+    } finally {
+      removeDir(dir);
+    }
   });
 
   it('plans plugin update without workspace activation when disabled', () => {

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -108,7 +108,7 @@ describe('planPluginOperation', () => {
     expect(plan.steps.map(step => step.description).join('\n')).toContain('0.12.1');
   });
 
-  it('plans official plugin install commands for each coding agent', () => {
+  it('plans official plugin install commands for GHCP and Codex plus Claude plugin-from-source validation', () => {
     const plan = planPluginOperation({
       action: 'install',
       agents: ['ghcp', 'claude', 'codex'],
@@ -119,13 +119,15 @@ describe('planPluginOperation', () => {
     });
 
     const pluginSteps = plan.steps.filter(step => step.kind === 'plugin-registration');
-    expect(pluginSteps.map(step => [step.target, step.commands])).toEqual([
+    const normalizedSteps = pluginSteps.map(step => [step.target, step.commands?.map(command => command.replaceAll('\\', '/'))]);
+    expect(normalizedSteps).toEqual([
       ['ghcp', [
         'copilot plugin marketplace add Azure/azure-functions-skills',
         'copilot plugin install azure-functions-skills@azure-functions-skills',
       ]],
       ['claude', [
-        'claude plugin install Azure/azure-functions-skills --scope project',
+        'git clone https://github.com/Azure/azure-functions-skills.git /workspace/project/.azure-functions-skills/source/azure-functions-skills',
+        'claude plugin validate /workspace/project/.azure-functions-skills/source/azure-functions-skills/.github/plugins/azure-functions-skills',
       ]],
       ['codex', [
         'codex plugin marketplace add Azure/azure-functions-skills',
@@ -151,7 +153,8 @@ describe('planPluginOperation', () => {
       expect(runner.calls).toEqual([
         { command: 'copilot', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
         { command: 'copilot', args: ['plugin', 'install', 'azure-functions-skills@azure-functions-skills'] },
-        { command: 'claude', args: ['plugin', 'install', 'Azure/azure-functions-skills', '--scope', 'project'] },
+        { command: 'git', args: ['clone', 'https://github.com/Azure/azure-functions-skills.git', join(dir, '.azure-functions-skills', 'source', 'azure-functions-skills')] },
+        { command: 'claude', args: ['plugin', 'validate', join(dir, '.azure-functions-skills', 'source', 'azure-functions-skills', '.github', 'plugins', 'azure-functions-skills')] },
         { command: 'codex', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
         { command: 'codex', args: ['plugin', 'add', 'azure-functions-skills@azure-functions-skills'] },
       ]);
@@ -162,6 +165,23 @@ describe('planPluginOperation', () => {
     } finally {
       removeDir(dir);
     }
+  });
+
+  it('uses the current repository plugin payload for Claude when source is local', () => {
+    const plan = planPluginOperation({
+      action: 'install',
+      agents: ['claude'],
+      projectDir: '/workspace/project',
+      source: 'local',
+      dryRun: true,
+      workspace: false,
+    });
+
+    const command = plan.steps[0].commands?.[0] || '';
+    expect(command).toContain('claude plugin validate');
+    expect(command).toContain('.github');
+    expect(command).toContain('plugins');
+    expect(command).toContain('azure-functions-skills');
   });
 
   it('plans plugin update without workspace activation when disabled', () => {


### PR DESCRIPTION
## Summary
- Adds `plugin install` and `plugin update` CLI commands for native plugin lifecycle planning and execution.
- Runs host-specific plugin install/source commands before workspace activation:
  - GHCP: `copilot plugin marketplace add Azure/azure-functions-skills` then `copilot plugin install azure-functions-skills@azure-functions-skills`
  - Claude: clone or use the repo plugin payload at `.github/plugins/azure-functions-skills`, validate it with `claude plugin validate`, and load it with Claude's `--plugin-dir`/README plugin-from-source flow
  - Codex: `codex plugin marketplace add Azure/azure-functions-skills` then `codex plugin add azure-functions-skills@azure-functions-skills`
- Checks required tools before execution and reports actionable install guidance when `git`, `claude`, `copilot`, or `codex` is missing.
- Supports dry-run planning plus `--agent`, `--dir`, `--scope`, `--source`, `--version`, `--workspace`, and `--no-workspace` flags.
- Reuses workspace plugin-reference activation after successful plugin installation/source validation.
- Keeps legacy `setup --as-plugin` compatibility intact.
- Includes Linux preflight coverage for tool checks.

## Validation
- `npm test` (114 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run compile`
- Missing-tool smoke with restricted PATH verified friendly messages for missing `git`/`claude` and `copilot`
- Happy-path smoke:
  - `plugin install --dry-run` for GHCP/Claude/Codex printed expected commands
  - Claude `plugin install --source local` validated the local plugin payload and wrote workspace activation files
  - GHCP `plugin install` completed; `copilot plugin list` shows `azure-functions-skills@azure-functions-skills (v0.12.1)` installed
  - Codex `plugin install` completed; `codex plugin list` shows `azure-functions-skills@azure-functions-skills` installed and enabled
  - `claude -p --plugin-dir <payload>` loaded the plugin and reported visible Azure Functions skills

Closes #90
