### PR TITLE
feat: protect workspace routing updates

### DIFF
--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -43,6 +43,7 @@ function printHelp() {
     --merge-strategy <name> managed-block, include-file, fail-if-exists, append
     --update           Replace existing Azure Functions managed blocks
     --dry-run          Print planned changes without writing files
+    --yes              Approve modifying existing instruction files without prompting
 
   Options (plugin install/update):
     --agent <name>     Specify agent: ghcp, claude, codex (repeatable)
@@ -53,6 +54,7 @@ function printHelp() {
     --workspace        Apply workspace plugin-reference activation (default)
     --no-workspace     Skip workspace activation
     --dry-run          Print planned changes without writing files
+    --yes              Approve workspace activation changes to existing instruction files
 
   Options (chat):
     --agent <name>     Agent: github-copilot, claude-code, codex (auto-detected if omitted)
@@ -250,6 +252,7 @@ if (command === 'setup') {
   let mergeStrategy = 'managed-block';
   let dryRun = false;
   let update = action === 'update';
+  let yes = false;
 
   for (let i = 2; i < args.length; i++) {
     if (args[i] === '--agent' && args[i + 1]) agents.push(args[++i]);
@@ -258,15 +261,23 @@ if (command === 'setup') {
     else if (args[i] === '--merge-strategy' && args[i + 1]) mergeStrategy = args[++i];
     else if (args[i] === '--dry-run') dryRun = true;
     else if (args[i] === '--update') update = true;
+    else if (args[i] === '--yes') yes = true;
   }
 
-  const result = await applyWorkspace(dir, {
-    agents: agents.length > 0 ? agents : undefined,
-    mode,
-    mergeStrategy,
-    update,
-    dryRun,
-  });
+  let result;
+  try {
+    result = await applyWorkspace(dir, {
+      agents: agents.length > 0 ? agents : undefined,
+      mode,
+      mergeStrategy,
+      update,
+      dryRun,
+      yes,
+    });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
 
   if (dryRun) {
     console.log('Planned workspace changes:');
@@ -294,6 +305,7 @@ if (command === 'setup') {
   let version = undefined;
   let workspace = true;
   let dryRun = false;
+  let yes = false;
 
   for (let i = 2; i < args.length; i++) {
     if (args[i] === '--agent' && args[i + 1]) agents.push(args[++i]);
@@ -304,6 +316,7 @@ if (command === 'setup') {
     else if (args[i] === '--workspace') workspace = true;
     else if (args[i] === '--no-workspace') workspace = false;
     else if (args[i] === '--dry-run') dryRun = true;
+    else if (args[i] === '--yes') yes = true;
   }
 
   const detectedAgents = agents.length > 0 ? agents : await detectAgents();
@@ -318,6 +331,7 @@ if (command === 'setup') {
       source,
       version,
       workspace,
+      yes,
     });
   } catch (err) {
     console.error(err.message);

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -45,6 +45,7 @@ export interface PluginOperationOptions {
   workspace?: boolean;
   runner?: CommandRunner;
   platform?: NodeJS.Platform;
+  yes?: boolean;
 }
 
 export interface PluginOperationStep {
@@ -268,6 +269,7 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
       mode: 'plugin-reference',
       mergeStrategy: 'managed-block',
       update: options.action === 'update',
+      yes: options.yes,
     });
     result.filesWritten += workspaceResult.filesWritten;
   }

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadSkills } from '../build/loader.js';
+import { loadMcpServers, loadSkills } from '../build/loader.js';
 import { applySetup, detectAgents } from './index.js';
-import type { CliAgentName, MergeStrategy, WorkspaceApplyOptions, WorkspaceApplyResult, WorkspaceMode } from '../types.js';
+import type { CliAgentName, McpServer, MergeStrategy, WorkspaceApplyOptions, WorkspaceApplyResult, WorkspaceMode } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', '..', 'templates');
@@ -21,6 +21,7 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
   const mode = options.mode || 'copy';
   const mergeStrategy = options.mergeStrategy || 'managed-block';
   const dryRun = options.dryRun === true;
+  const approved = options.yes === true;
 
   if (mode === 'copy') {
     if (dryRun) {
@@ -42,13 +43,13 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
     };
   }
 
-  const plannedFiles = agents.flatMap(agent => activationFiles(agent, mode));
+  const plannedFiles = agents.flatMap(agent => activationFiles(agent, mode, options));
   if (dryRun) {
     return {
       agents,
       mode,
       filesWritten: 0,
-      plannedFiles: plannedFiles.map(file => file.path),
+      plannedFiles: plannedFiles.flatMap(file => plannedWorkspacePaths(file, mergeStrategy)),
       dryRun,
     };
   }
@@ -57,11 +58,18 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
   for (const file of plannedFiles) {
     const fullPath = join(targetDir, file.path);
     const content = file.merge
-      ? mergeInstructionFile(fullPath, file.content, mergeStrategy, options.update === true)
+      ? mergeInstructionFile(fullPath, file.content, mergeStrategy, options.update === true, approved)
       : mergeJsonLikeFile(fullPath, file.content);
     mkdirSync(dirname(fullPath), { recursive: true });
     writeFileSync(fullPath, content);
     filesWritten++;
+
+    if (file.merge && mergeStrategy === 'include-file') {
+      const includeFullPath = join(targetDir, includeInstructionPath(file.path));
+      mkdirSync(dirname(includeFullPath), { recursive: true });
+      writeFileSync(includeFullPath, ensureTrailingNewline(file.content));
+      filesWritten++;
+    }
   }
 
   return {
@@ -79,27 +87,37 @@ function plannedCopyFiles(agent: CliAgentName): string[] {
   return ['AGENTS.md', '.agents/skills/<skill-id>/SKILL.md'];
 }
 
-function activationFiles(agent: CliAgentName, mode: WorkspaceMode): PlannedFile[] {
+function activationFiles(agent: CliAgentName, mode: WorkspaceMode, options: WorkspaceApplyOptions): PlannedFile[] {
   const files: PlannedFile[] = [];
   if (agent === 'ghcp') {
     files.push({ path: '.github/copilot-instructions.md', content: routingBlock(agent), merge: true });
     if (mode === 'plugin-reference') files.push({ path: '.github/copilot/settings.json', content: JSON.stringify(ghcpPluginSettings(), null, 2) });
+    if (options.includeMcp) files.push({ path: '.vscode/mcp.json', content: JSON.stringify(ghcpMcpSettings(), null, 2) });
+    if (options.includeHooks) files.push({ path: '.github/hooks/welcome-setup.json', content: JSON.stringify(crossPlatformHooks(), null, 2) });
   }
 
   if (agent === 'claude') {
     files.push({ path: 'CLAUDE.md', content: routingBlock(agent), merge: true });
     if (mode === 'plugin-reference') files.push({ path: '.claude/settings.json', content: JSON.stringify(claudePluginSettings(), null, 2) });
+    if (options.includeMcp) files.push({ path: '.claude/settings.json', content: JSON.stringify(claudeMcpSettings(), null, 2) });
   }
 
   if (agent === 'codex') {
     files.push({ path: 'AGENTS.md', content: routingBlock(agent), merge: true });
     if (mode === 'plugin-reference') files.push({ path: '.agents/plugins/marketplace.json', content: JSON.stringify(codexMarketplace(), null, 2) });
+    if (options.includeMcp) files.push({ path: '.codex/config.toml', content: codexMcpConfigToml() });
+    if (options.includeHooks) files.push({ path: '.codex/hooks.json', content: JSON.stringify(crossPlatformHooks(), null, 2) });
   }
 
   return files;
 }
 
-function mergeInstructionFile(filePath: string, generatedContent: string, strategy: MergeStrategy, update: boolean): string {
+function plannedWorkspacePaths(file: PlannedFile, strategy: MergeStrategy): string[] {
+  if (file.merge && strategy === 'include-file') return [file.path, includeInstructionPath(file.path)];
+  return [file.path];
+}
+
+function mergeInstructionFile(filePath: string, generatedContent: string, strategy: MergeStrategy, update: boolean, approved: boolean): string {
   const block = managedBlock(generatedContent);
   if (!existsSync(filePath)) return `${block}\n`;
 
@@ -112,6 +130,10 @@ function mergeInstructionFile(filePath: string, generatedContent: string, strate
 
   if (strategy === 'fail-if-exists') {
     throw new Error(`Refusing to modify existing customer-owned file: ${filePath}`);
+  }
+
+  if (!approved) {
+    throw new Error(`Refusing to modify existing customer-owned file without approval: ${filePath}. Re-run with --yes or use --merge-strategy fail-if-exists.`);
   }
 
   if (strategy === 'append' || strategy === 'managed-block') {
@@ -178,6 +200,64 @@ function skillRoutingList(): string {
     .sort((left, right) => left.id.localeCompare(right.id))
     .map(skill => `- ${skill.id}: ${skill.description || skill.title}`)
     .join('\n');
+}
+
+function mcpServers(): McpServer[] {
+  return loadMcpServers(join(TEMPLATES_DIR, 'mcp', 'servers.yaml'));
+}
+
+function ghcpMcpSettings() {
+  const servers: Record<string, { type: string; command: string; args: string[] }> = {};
+  for (const server of mcpServers()) {
+    servers[server.id] = {
+      type: server.type || 'stdio',
+      command: server.command,
+      args: server.args,
+    };
+  }
+  return { servers };
+}
+
+function claudeMcpSettings() {
+  const servers: Record<string, { command: string; args: string[] }> = {};
+  for (const server of mcpServers()) {
+    servers[server.id] = {
+      command: server.command,
+      args: server.args,
+    };
+  }
+  return { mcpServers: servers };
+}
+
+function codexMcpConfigToml(): string {
+  const lines = [
+    '# Azure Functions MCP Servers',
+    '# Generated by azure-functions-skills workspace apply',
+    '',
+  ];
+
+  for (const server of mcpServers()) {
+    lines.push(`[mcp_servers.${server.id}]`);
+    lines.push(`command = "${server.command}"`);
+    if (server.args.length > 0) lines.push(`args = [${server.args.map(arg => `"${arg}"`).join(', ')}]`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function crossPlatformHooks() {
+  return {
+    hooks: {
+      SessionStart: [
+        {
+          type: 'command',
+          command: 'node -e "const r=require(\'child_process\').execSync;let o=\'⚡ Welcome to Azure Functions!\\n\';for(const [n,c,u] of [[\'Azure CLI\',\'az --version\',\'https://aka.ms/installazurecli\'],[\'Core Tools\',\'func --version\',\'npm i -g azure-functions-core-tools@4\'],[\'Node.js\',\'node --version\',\'https://nodejs.org\']]){try{r(c,{stdio:\'ignore\'});o+=`✅ ${n}\\n`}catch{o+=`❌ ${n} — install: ${u}\\n`}};console.log(JSON.stringify({hookSpecificOutput:{hookEventName:\'SessionStart\',additionalContext:o}}))"',
+          timeout: 15,
+        },
+      ],
+    },
+  };
 }
 
 function ghcpPluginSettings() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface WorkspaceApplyOptions {
   mergeStrategy?: MergeStrategy;
   update?: boolean;
   dryRun?: boolean;
+  yes?: boolean;
   includeMcp?: boolean;
   includeHooks?: boolean;
   includeAgent?: boolean;

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -221,6 +221,24 @@ describe('CLI command integration', () => {
     }
   });
 
+  it('workspace apply --yes appends routing to an existing Claude instructions file', () => {
+    const projectDir = makeTempDir('af-skills-e2e-workspace-yes-');
+    writeFileSync(join(projectDir, 'CLAUDE.md'), '# Existing Claude rules\n');
+
+    runCli([
+      'workspace',
+      'apply',
+      '--agent', 'claude',
+      '--dir', projectDir,
+      '--mode', 'plugin-reference',
+      '--yes',
+    ]);
+
+    const content = readFileSync(join(projectDir, 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('# Existing Claude rules');
+    expect(content).toContain('<!-- azure-functions-skills:start');
+  });
+
   it('plugin install --dry-run prints plugin and workspace activation plans without writing files', () => {
     const projectDir = makeTempDir('af-skills-e2e-plugin-install-dry-run-');
 

--- a/tests/workspace-apply.test.ts
+++ b/tests/workspace-apply.test.ts
@@ -23,6 +23,38 @@ afterEach(() => {
 });
 
 describe('applyWorkspace', () => {
+  it('refuses to append to existing Claude instructions without approval', async () => {
+    const dir = makeTempDir();
+    const claudePath = join(dir, 'CLAUDE.md');
+    writeFileSync(claudePath, ['# Project Rules', '', 'Keep this file careful.'].join('\n'));
+
+    await expect(applyWorkspace(dir, {
+      agents: ['claude'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+    })).rejects.toThrow(/Refusing to modify existing customer-owned file/);
+
+    expect(readFileSync(claudePath, 'utf-8')).not.toContain('azure-functions-skills:start');
+  });
+
+  it('appends a managed block to existing Claude instructions when approved', async () => {
+    const dir = makeTempDir();
+    const claudePath = join(dir, 'CLAUDE.md');
+    writeFileSync(claudePath, ['# Project Rules', '', 'Keep this file careful.'].join('\n'));
+
+    const result = await applyWorkspace(dir, {
+      agents: ['claude'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+      yes: true,
+    });
+
+    const content = readFileSync(claudePath, 'utf-8');
+    expect(content).toContain('Keep this file careful.');
+    expect(content).toContain('<!-- azure-functions-skills:start');
+    expect(result.filesWritten).toBeGreaterThan(0);
+  });
+
   it('preserves customer content while replacing the managed block', async () => {
     const dir = makeTempDir();
     const claudePath = join(dir, 'CLAUDE.md');
@@ -116,5 +148,53 @@ describe('applyWorkspace', () => {
     expect(result.plannedFiles).toContain('.agents/plugins/marketplace.json');
     expect(existsSync(join(dir, 'AGENTS.md'))).toBe(false);
     expect(existsSync(join(dir, '.agents', 'plugins', 'marketplace.json'))).toBe(false);
+  });
+
+  it('adds MCP and host hooks only when explicitly requested', async () => {
+    const dir = makeTempDir();
+
+    await applyWorkspace(dir, {
+      agents: ['ghcp', 'claude', 'codex'],
+      mode: 'plugin-reference',
+      includeMcp: true,
+      includeHooks: true,
+    });
+
+    expect(existsSync(join(dir, '.vscode', 'mcp.json'))).toBe(true);
+    expect(existsSync(join(dir, '.github', 'hooks', 'welcome-setup.json'))).toBe(true);
+    expect(existsSync(join(dir, '.claude', 'settings.json'))).toBe(true);
+    expect(existsSync(join(dir, '.codex', 'config.toml'))).toBe(true);
+    expect(existsSync(join(dir, '.codex', 'hooks.json'))).toBe(true);
+
+    const codexHooks = readFileSync(join(dir, '.codex', 'hooks.json'), 'utf-8');
+    expect(codexHooks).toContain('node -e');
+    expect(codexHooks).not.toContain('bash -c');
+  });
+
+  it('include-file strategy creates an include target and avoids duplicate include lines', async () => {
+    const dir = makeTempDir();
+    const agentsPath = join(dir, 'AGENTS.md');
+    writeFileSync(agentsPath, ['# Project Agents', '', 'Keep this file compact.'].join('\n'));
+
+    await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'include-file',
+      yes: true,
+    });
+    await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'include-file',
+      yes: true,
+    });
+
+    const content = readFileSync(agentsPath, 'utf-8');
+    const includeLine = 'See .azure-functions-skills/AGENTS.azure-functions.md for Azure Functions routing.';
+    expect(content.split(includeLine)).toHaveLength(2);
+
+    const includeTarget = join(dir, '.azure-functions-skills', 'AGENTS.azure-functions.md');
+    expect(existsSync(includeTarget)).toBe(true);
+    expect(readFileSync(includeTarget, 'utf-8')).toContain('Azure Functions Skills');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `--yes` approval for workspace/plugin activation changes to existing instruction files.
- Refuses to append Azure Functions routing to existing `CLAUDE.md` / `AGENTS.md` without approval when no managed block exists.
- Keeps existing managed blocks idempotent and still supports `workspace update` replacing only the managed block.
- Makes `include-file` strategy generate the referenced `.azure-functions-skills/*.azure-functions.md` routing file.
- Adds opt-in workspace MCP/hooks generation through `includeMcp` and `includeHooks`; Codex hooks use a cross-platform Node command instead of bash.

## Validation
- `npm test` (121 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run verify:plugin-payload`

Closes #92
