### PR TITLE
ci: add 1ES pipeline configuration for npm publish

### DIFF
--- a/azure-pipelines/code-mirror.yml
+++ b/azure-pipelines/code-mirror.yml
@@ -1,0 +1,18 @@
+trigger:
+    branches:
+        include:
+            - main
+            - release/*
+
+resources:
+    repositories:
+        - repository: eng
+          type: git
+          name: engineering
+          ref: refs/tags/release
+
+variables:
+    - template: ci/variables/cfs.yml@eng
+
+extends:
+    template: ci/code-mirror.yml@eng

--- a/azure-pipelines/official-build.yml
+++ b/azure-pipelines/official-build.yml
@@ -1,0 +1,62 @@
+parameters:
+    - name: IsPrerelease
+      type: boolean
+      default: true
+
+trigger:
+    batch: true
+    branches:
+        include:
+            - main
+
+# CI only, does not trigger on PRs.
+pr: none
+
+schedules:
+    - cron: '30 10 * * *'
+      displayName: Nightly build
+      always: true
+      branches:
+          include:
+              - main
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        pool:
+            name: 1es-pool-azfunc
+            image: 1es-windows-2022
+            os: windows
+
+        sdl:
+            codeql:
+                runSourceLanguagesInSourceAnalysis: true
+
+        stages:
+            - stage: WindowsUnitTests
+              dependsOn: []
+              jobs:
+                  - template: /azure-pipelines/templates/test.yml@self
+
+            - stage: LinuxUnitTests
+              dependsOn: []
+              jobs:
+                  - template: /azure-pipelines/templates/test.yml@self
+              pool:
+                  name: 1es-pool-azfunc
+                  image: 1es-ubuntu-22.04
+                  os: linux
+
+            - stage: Build
+              dependsOn: []
+              jobs:
+                  - template: /azure-pipelines/templates/build.yml@self
+                    parameters:
+                        IsPrerelease: ${{ parameters.IsPrerelease }}

--- a/azure-pipelines/pre-release.yml
+++ b/azure-pipelines/pre-release.yml
@@ -1,0 +1,57 @@
+parameters:
+    - name: NpmPublishTag
+      displayName: 'Tag'
+      type: string
+      default: 'preview'
+    - name: NpmPublishDryRun
+      displayName: 'Dry Run'
+      type: boolean
+      default: true
+
+trigger: none
+pr: none
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        sdl:
+            sourceAnalysisPool:
+                name: 1es-pool-azfunc
+                image: 1es-windows-2022
+                os: windows
+            codeql:
+                runSourceLanguagesInSourceAnalysis: true
+        pool:
+            name: 1es-pool-azfunc
+            image: 1es-windows-2022
+            os: windows
+
+        stages:
+            - stage: Build
+              jobs:
+                  - template: /azure-pipelines/templates/build.yml@self
+                    parameters:
+                        # Version to be published is specified in branch
+                        IsPrerelease: false
+            - stage: Release
+              dependsOn: Build
+              jobs:
+                  - job: Release
+                    steps:
+                        - task: DownloadPipelineArtifact@2
+                          inputs:
+                              artifact: drop
+                              path: $(Pipeline.Workspace)/drop
+                          displayName: 'Download artifact'
+                        - template: /azure-pipelines/templates/npm-publish-steps.yml@self
+                          parameters:
+                              tgzPath: '$(Pipeline.Workspace)/drop'
+                              NpmPublishTag: ${{ parameters.NpmPublishTag }}
+                              NpmPublishDryRun: ${{ parameters.NpmPublishDryRun }}

--- a/azure-pipelines/public-build.yml
+++ b/azure-pipelines/public-build.yml
@@ -1,0 +1,67 @@
+# This build is used for public PR and CI builds.
+
+trigger:
+    batch: true
+    branches:
+        include:
+            - main
+
+pr:
+    branches:
+        include:
+            - main
+
+schedules:
+    - cron: '30 10 * * *'
+      displayName: Nightly build
+      always: true
+      branches:
+          include:
+              - main
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+    parameters:
+        pool:
+            name: 1es-pool-azfunc-public
+            image: 1es-windows-2022
+            os: windows
+
+        sdl:
+            codeql:
+                compiled:
+                    enabled: true
+                runSourceLanguagesInSourceAnalysis: true
+
+        settings:
+            # PR's from forks do not have sufficient permissions to set tags.
+            skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
+        stages:
+            - stage: WindowsUnitTests
+              dependsOn: []
+              jobs:
+                  - template: /azure-pipelines/templates/test.yml@self
+
+            - stage: LinuxUnitTests
+              dependsOn: []
+              jobs:
+                  - template: /azure-pipelines/templates/test.yml@self
+              pool:
+                  name: 1es-pool-azfunc-public
+                  image: 1es-ubuntu-22.04
+                  os: linux
+
+            - stage: Build
+              dependsOn: []
+              jobs:
+                  - template: /azure-pipelines/templates/build.yml@self
+                    parameters:
+                        IsPrerelease: true

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,0 +1,83 @@
+parameters:
+    - name: NpmPublishTag
+      displayName: 'Tag'
+      type: string
+      default: 'latest'
+    - name: NpmPublishDryRun
+      displayName: 'Dry Run'
+      type: boolean
+      default: true
+
+trigger: none
+pr: none
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+    pipelines:
+        - pipeline: officialBuild
+          project: internal
+          source: functions-skills.official
+          branch: main
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        sdl:
+            sourceAnalysisPool:
+                name: 1es-pool-azfunc
+                image: 1es-windows-2022
+                os: windows
+            codeql:
+                runSourceLanguagesInSourceAnalysis: true
+
+        stages:
+            - stage: Release
+              pool:
+                  name: 1es-pool-azfunc
+                  image: 1es-ubuntu-22.04
+                  os: linux
+              jobs:
+                  - job: Release
+                    steps:
+                        - download: officialBuild
+                        - template: /azure-pipelines/templates/npm-publish-steps.yml@self
+                          parameters:
+                              tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
+                              NpmPublishTag: ${{ parameters.NpmPublishTag }}
+                              NpmPublishDryRun: ${{ parameters.NpmPublishDryRun }}
+            - stage: GitHubTagAndRelease
+              dependsOn: Release
+              pool:
+                  name: 1es-pool-azfunc
+                  image: 1es-windows-2022
+                  os: windows
+              jobs:
+                  - job: GitHubTagAndRelease
+                    steps:
+                        - download: officialBuild
+                        - task: DownloadPipelineArtifact@2
+                          inputs:
+                              artifact: drop
+                              path: $(Pipeline.Workspace)/drop
+                          displayName: 'Download drop artifact'
+                        - powershell: |
+                              $files = Get-ChildItem "$(Pipeline.Workspace)\drop" -Filter "*.tgz"
+                              if ($files.Count -ne 1) {
+                                  Write-Error "Expected one .tgz file, found $($files.Count)"
+                                  exit 1
+                              }
+                              $file = $files[0].Name
+                              if ($file -match '.*-(\d+\.\d+\.\d+.*)\.tgz') {
+                                  $version = $Matches[1]
+                                  Write-Host "Parsed version: $version"
+                                  Write-Host "##vso[task.setvariable variable=version]$version"
+                              } else {
+                                  Write-Error "Filename did not match expected pattern"
+                                  exit 1
+                              }
+                          displayName: 'Extract version from .tgz filename'
+                        - template: /azure-pipelines/templates/github-release.yml@self

--- a/azure-pipelines/templates/build.yml
+++ b/azure-pipelines/templates/build.yml
@@ -1,0 +1,48 @@
+parameters:
+    - name: IsPrerelease
+      type: boolean
+      default: true
+
+jobs:
+    - job:
+      templateContext:
+          outputs:
+              - output: pipelineArtifact
+                path: $(Build.ArtifactStagingDirectory)/dropOutput
+                artifact: drop
+                sbomBuildDropPath: '$(Build.ArtifactStagingDirectory)/dropInput'
+                sbomPackageName: 'Azure Functions Skills CLI'
+                sbomBuildComponentPath: '$(Build.SourcesDirectory)/node_modules'
+      steps:
+          - task: NodeTool@0
+            inputs:
+                versionSpec: 22.x
+            displayName: 'Install Node.js'
+          - script: npm ci
+            displayName: 'npm ci'
+          - script: npm audit --production
+            displayName: 'Run vulnerability scan'
+          - script: npm run build
+            displayName: 'npm run build'
+          - task: CopyFiles@2
+            displayName: 'Copy files to staging'
+            inputs:
+                sourceFolder: '$(Build.SourcesDirectory)'
+                contents: |
+                    bin/**
+                    lib/**
+                    src/**
+                    templates/**
+                    LICENSE
+                    package.json
+                    README.md
+                targetFolder: '$(Build.ArtifactStagingDirectory)/dropInput'
+                cleanTargetFolder: true
+          - script: npm prune --production
+            displayName: 'npm prune --production'
+          - script: npm pack
+            displayName: 'npm pack'
+            workingDirectory: '$(Build.ArtifactStagingDirectory)/dropInput'
+          - script: mkdir dropOutput && mv dropInput/*.tgz dropOutput
+            displayName: 'Move package to dropOutput'
+            workingDirectory: '$(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines/templates/github-release.yml
+++ b/azure-pipelines/templates/github-release.yml
@@ -1,0 +1,47 @@
+steps:
+    - powershell: |
+        $githubToken = "$(GithubPat)"
+        $newVersion = "$(version)"
+        Write-Host "Debug: Version from pipeline variable is '$newVersion'"
+
+        # Create GitHub credential
+        git config --global user.name "AzureFunctionsSkills"
+        git config --global user.email "azfunc@microsoft.com"
+
+        # Clone Repository
+        git clone https://$githubToken@github.com/Azure/azure-functions-skills
+        Write-Host "Cloned azure-functions-skills into local"
+        Set-Location "azure-functions-skills"
+        git checkout "origin/release/$newVersion"
+
+        # Create release tag X.Y.Z
+        Write-Host "Creating release tag $newVersion"
+        git tag -a "$newVersion" -m "$newVersion"
+
+        # Push tag to remote
+        git push origin $newVersion
+
+      displayName: 'Create and push release tag x.y.z'
+    - powershell: |
+        $githubUser = "$(GithubUser)"
+        $githubToken = "$(GithubPat)"
+        $newVersion = "$(version)"
+
+        # Create GitHub credential
+        $credential = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("${githubUser}:${githubToken}"))
+
+        # Create Release Note
+        Write-Host "Creating release note in GitHub"
+        $body = (@{tag_name="$newVersion";name="Release $newVersion";body="- Fill in Release Note Here";draft=$true} | ConvertTo-Json -Compress)
+        $response = Invoke-WebRequest -Headers @{"Cache-Control"="no-cache";"Content-Type"="application/json";"Authorization"="Basic $credential"} -Method Post -Body "$body" -Uri "https://api.github.com/repos/Azure/azure-functions-skills/releases"
+
+        # Return Value
+        if ($response.StatusCode -ne 201) {
+            Write-Host "Failed to create release note in GitHub"
+            exit -1
+        }
+
+        $draftUrl = $response | ConvertFrom-Json | Select -expand url
+        Write-Host "Release draft created in $draftUrl"
+
+      displayName: 'Create GitHub release draft'

--- a/azure-pipelines/templates/npm-publish-steps.yml
+++ b/azure-pipelines/templates/npm-publish-steps.yml
@@ -1,0 +1,23 @@
+parameters:
+    tgzPath: ''
+    NpmPublishTag: ''
+    NpmPublishDryRun: false
+
+steps:
+    - task: NodeTool@0
+      displayName: 'Install Node.js'
+      inputs:
+          versionSpec: 22.x
+
+    - script: mv *.tgz package.tgz
+      displayName: 'Rename tgz file'
+      workingDirectory: '${{ parameters.tgzPath }}'
+
+    - task: Npm@1
+      displayName: 'npm publish'
+      inputs:
+          command: custom
+          workingDir: '${{ parameters.tgzPath }}'
+          verbose: true
+          customCommand: 'publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ lower(parameters.NpmPublishDryRun) }}'
+          customEndpoint: azure-functions-skills-npm

--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -1,0 +1,25 @@
+jobs:
+    - job: UnitTests
+
+      strategy:
+          matrix:
+              Node18:
+                  NODE_VERSION: '18.x'
+              Node20:
+                  NODE_VERSION: '20.x'
+              Node22:
+                  NODE_VERSION: '22.x'
+
+      steps:
+          - task: NodeTool@0
+            inputs:
+                versionSpec: $(NODE_VERSION)
+            displayName: 'Install Node.js'
+          - script: npm ci
+            displayName: 'npm ci'
+          - script: npm run lint
+            displayName: 'npm run lint'
+          - script: npm run typecheck
+            displayName: 'npm run typecheck'
+          - script: npm test
+            displayName: 'Run unit tests'

--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: e8fdf03b-44f7-48d3-8653-a744c922a342
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\Azure Functions


### PR DESCRIPTION
## Summary

Add 1ES pipeline YAML files and es-metadata.yml to enable official npm publishing via Azure DevOps (azfunc/internal).

## Files Added

| File | Purpose |
|---|---|
| es-metadata.yml | 1ES Inventory as Code metadata (Service Tree mapping) |
| azure-pipelines/code-mirror.yml | GitHub to ADO mirror sync pipeline |
| azure-pipelines/public-build.yml | PR/CI builds in azfunc/public (unofficial, zero-trust) |
| azure-pipelines/official-build.yml | Official builds in azfunc/internal |
| azure-pipelines/pre-release.yml | Preview npm publish (manual trigger, preview tag) |
| azure-pipelines/release.yml | Production npm publish (latest tag) + GitHub Release |
| azure-pipelines/templates/build.yml | Shared build + npm pack + SBOM |
| azure-pipelines/templates/test.yml | Unit tests (Node 18/20/22 matrix) |
| azure-pipelines/templates/npm-publish-steps.yml | npm publish via ADO service connection |
| azure-pipelines/templates/github-release.yml | GitHub tag + release draft creation |

## ADO Setup Required After Merge

1. azfunc/internal: Register code-mirror pipeline (GitHub source)
2. azfunc/public: Register public-build pipeline (GitHub source)
3. azfunc/internal: Register official-build pipeline (ADO mirror)
4. azfunc/internal: Register pre-release pipeline (ADO mirror)
5. azfunc/internal: Register release pipeline (ADO mirror)
6. azfunc/internal: Create npm service connection azure-functions-skills-npm
7. azfunc/internal: Add GithubPat / GithubUser variables for release pipeline

## Reference

Pipeline structure follows azure-functions-nodejs-library conventions and 1ES Pipeline Templates.
ADO mirror repo: https://dev.azure.com/azfunc/internal/_git/azure.azure-functions-skills