### PR TITLE
docs(readme): simplify Quick Start install/chat examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is **focused on Azure Functions**. For deployment of *any* Azure resource (Fu
 <summary><strong>GitHub Copilot CLI</strong></summary>
 
 ```bash
-npx @azure/functions-skills install --agent ghcp --dir ./my-app
+npx @azure/functions-skills install --agent ghcp
 ```
 
 </details>
@@ -34,7 +34,7 @@ npx @azure/functions-skills install --agent ghcp --dir ./my-app
 <summary><strong>Claude Code</strong></summary>
 
 ```bash
-npx @azure/functions-skills install --agent claude --dir ./my-app
+npx @azure/functions-skills install --agent claude
 ```
 
 </details>
@@ -43,15 +43,17 @@ npx @azure/functions-skills install --agent claude --dir ./my-app
 <summary><strong>Codex CLI</strong></summary>
 
 ```bash
-npx @azure/functions-skills install --agent codex --dir ./my-app
+npx @azure/functions-skills install --agent codex
 ```
 
 </details>
 
+> Installs at **user scope** (available to every project on this machine). Prefer to scope the skills to the current project only? Add `--local` to install them under the working directory instead.
+
 ### 2. Open the agent
 
 ```bash
-npx @azure/functions-skills chat --dir ./my-app
+npx @azure/functions-skills chat
 ```
 
 The first time, the agent greets you with a welcome message, shows the available skills, and suggests the next workflow based on your project state.


### PR DESCRIPTION
## Why

Per the README first-step minimalism policy: present the fewest options up front so first-time readers don't have to choose, and link out for the full surface. Two small adjustments to the Quick Start:

- Drop `--dir ./my-app` from the three install commands and from chat. The flag defaults to the current working directory, so the explicit value is noise for a first-time reader.
- Add a single-line callout under the install collapsibles: default is **user scope** (machine-wide), add `--local` for **project scope** (skill bodies copied into the workspace).

## Out of scope

`docs/cli-reference.md` still uses `--dir ./my-app` in its examples; that file is the detail page and benefits from showing how the flag is used. Not touched in this PR.