### PR TITLE
feat(eval): add Vally LLM evaluation for azure-functions-create (PoC)

### DIFF
--- a/.github/workflows/skill-evaluation-vally.yml
+++ b/.github/workflows/skill-evaluation-vally.yml
@@ -18,6 +18,10 @@ on:
         description: Optional single eval spec (overrides suite if set)
         required: false
         type: string
+      model:
+        description: Optional model override (e.g. claude-opus-4.7). Empty = use eval.yaml default (claude-sonnet-4.6).
+        required: false
+        type: string
   schedule:
     # Nightly full run at 06:00 UTC. Disabled until COPILOT_GITHUB_TOKEN is wired.
     - cron: "0 6 * * *"
@@ -56,6 +60,12 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
+      - name: Pre-warm @azure/mcp cache
+        # Functions evals attach an Azure MCP server (functions namespace) via
+        # stdio. Pulling the package once upfront keeps per-stimulus startup fast
+        # and avoids races where the agent answers before the MCP server is ready.
+        run: npx -y @azure/mcp@latest server --help >/dev/null
+
       - name: Validate eval specs (vally lint)
         run: npx vally lint --eval-spec evals
 
@@ -63,14 +73,22 @@ jobs:
         env:
           SUITE: ${{ inputs.suite || 'full' }}
           EVAL_SPEC: ${{ inputs.eval_spec }}
+          MODEL: ${{ inputs.model }}
         run: |
           set -euo pipefail
+          MODEL_ARG=()
+          if [ -n "${MODEL}" ]; then
+            MODEL_ARG=(--model "${MODEL}")
+            echo "Model override: ${MODEL}"
+          else
+            echo "Model: (eval.yaml default — claude-sonnet-4.6)"
+          fi
           if [ -n "${EVAL_SPEC}" ]; then
             echo "Running single spec: ${EVAL_SPEC}"
-            npx vally eval --eval-spec "${EVAL_SPEC}" --output jsonl --output-dir ./vally-results --junit
+            npx vally eval --eval-spec "${EVAL_SPEC}" --output jsonl --output-dir ./vally-results --junit "${MODEL_ARG[@]}"
           else
             echo "Running suite: ${SUITE}"
-            npx vally eval --suite "${SUITE}" --output jsonl --output-dir ./vally-results --junit
+            npx vally eval --suite "${SUITE}" --output jsonl --output-dir ./vally-results --junit "${MODEL_ARG[@]}"
           fi
 
       - name: Upload results

--- a/.github/workflows/skill-evaluation-vally.yml
+++ b/.github/workflows/skill-evaluation-vally.yml
@@ -1,0 +1,82 @@
+name: Skill Evaluation - Vally
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Vally suite to run
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - pr
+          - triggers
+          - integration
+          - full
+      eval_spec:
+        description: Optional single eval spec (overrides suite if set)
+        required: false
+        type: string
+  schedule:
+    # Nightly full run at 06:00 UTC. Disabled until COPILOT_GITHUB_TOKEN is wired.
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vally-eval-${{ github.ref }}-${{ inputs.suite || 'nightly' }}
+  cancel-in-progress: false
+
+jobs:
+  eval:
+    name: vally eval
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # GitHub Copilot SDK authentication used by the `copilot-sdk` executor.
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    steps:
+      - name: Skip nightly when token is not configured
+        if: github.event_name == 'schedule' && env.COPILOT_GITHUB_TOKEN == ''
+        run: |
+          echo "COPILOT_GITHUB_TOKEN is not configured; skipping nightly run." >&2
+          exit 0
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Validate eval specs (vally lint)
+        run: npx vally lint --eval-spec evals
+
+      - name: Run vally eval
+        env:
+          SUITE: ${{ inputs.suite || 'full' }}
+          EVAL_SPEC: ${{ inputs.eval_spec }}
+        run: |
+          set -euo pipefail
+          if [ -n "${EVAL_SPEC}" ]; then
+            echo "Running single spec: ${EVAL_SPEC}"
+            npx vally eval --eval-spec "${EVAL_SPEC}" --output jsonl --output-dir ./vally-results --junit
+          else
+            echo "Running suite: ${SUITE}"
+            npx vally eval --suite "${SUITE}" --output jsonl --output-dir ./vally-results --junit
+          fi
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vally-results-${{ github.run_id }}
+          path: vally-results/
+          if-no-files-found: warn

--- a/.github/workflows/skill-evaluation-vally.yml
+++ b/.github/workflows/skill-evaluation-vally.yml
@@ -37,20 +37,24 @@ jobs:
   eval:
     name: vally eval
     runs-on: ubuntu-latest
-    # Scope COPILOT_GITHUB_TOKEN to a dedicated GitHub Environment so the
-    # secret is only available from approved branches (and, optionally,
-    # behind required reviewers for cost-sensitive Opus / full runs).
-    # Mirrors the pattern used by skill-evaluation-live-azure-login-smoke.yml.
-    environment: functions-skills-vally-eval
+    # Reuse the existing functions-skills-live-e2e environment. It was
+    # already set up to host evaluation-style runs, ships
+    # COPILOT_CLI_TOKEN (the GitHub Copilot SDK token), and is gated by
+    # protected branches + required reviewers (Azure/azure-functions-bucees-team,
+    # prevent_self_review: false). No Azure variables are touched by this
+    # workflow — they remain available for future evals that need them.
+    environment: functions-skills-live-e2e
     timeout-minutes: 60
     env:
-      # GitHub Copilot SDK authentication used by the `copilot-sdk` executor.
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # Job-level boolean used by the schedule-skip check below. We do NOT
+      # expose the token at job level; the actual token is only set in the
+      # step that runs `vally eval`. This boolean is safe to expose.
+      HAS_COPILOT_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN != '' }}
     steps:
       - name: Skip nightly when token is not configured
-        if: github.event_name == 'schedule' && env.COPILOT_GITHUB_TOKEN == ''
+        if: github.event_name == 'schedule' && env.HAS_COPILOT_TOKEN != 'true'
         run: |
-          echo "COPILOT_GITHUB_TOKEN is not configured; skipping nightly run." >&2
+          echo "COPILOT_CLI_TOKEN is not configured on functions-skills-live-e2e; skipping nightly run." >&2
           exit 0
 
       - name: Checkout
@@ -75,7 +79,11 @@ jobs:
         run: npx vally lint --eval-spec evals
 
       - name: Run vally eval
+        # Token is scoped to this step only (least privilege). The @github/copilot-sdk
+        # reads COPILOT_GITHUB_TOKEN from the environment, so the existing
+        # COPILOT_CLI_TOKEN secret is mapped onto that variable name here.
         env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
           SUITE: ${{ inputs.suite || 'full' }}
           EVAL_SPEC: ${{ inputs.eval_spec }}
           MODEL: ${{ inputs.model }}

--- a/.github/workflows/skill-evaluation-vally.yml
+++ b/.github/workflows/skill-evaluation-vally.yml
@@ -37,6 +37,11 @@ jobs:
   eval:
     name: vally eval
     runs-on: ubuntu-latest
+    # Scope COPILOT_GITHUB_TOKEN to a dedicated GitHub Environment so the
+    # secret is only available from approved branches (and, optionally,
+    # behind required reviewers for cost-sensitive Opus / full runs).
+    # Mirrors the pattern used by skill-evaluation-live-azure-login-smoke.yml.
+    environment: functions-skills-vally-eval
     timeout-minutes: 60
     env:
       # GitHub Copilot SDK authentication used by the `copilot-sdk` executor.

--- a/.gitignore
+++ b/.gitignore
@@ -445,3 +445,7 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# Vally eval output
+vally-results/
+results/

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,0 +1,39 @@
+# Vally project configuration for azure-functions-skills
+# Docs: https://aka.ms/vally
+#
+# Suites filter across all evals/**/eval.yaml using stimulus tags.
+# Run with:  npx vally eval --suite smoke
+#            npx vally eval --suite pr
+#            npx vally eval --suite full
+
+paths:
+  skills:
+    - templates/skills
+  evals:
+    - evals
+  results: results
+
+suites:
+  smoke:
+    description: "Quick routing checks — minimal LLM cost"
+    filter:
+      tier: smoke
+
+  pr:
+    description: "PR gate — same scope as smoke"
+    filter:
+      tier: smoke
+
+  triggers:
+    description: "All routing/skill-invocation evals"
+    filter:
+      area: routing
+
+  integration:
+    description: "All behavior/response-quality evals (LLM-backed)"
+    filter:
+      type: integration
+
+  full:
+    description: "All evals including LLM graders — nightly"
+    filter: {}

--- a/evals/README.md
+++ b/evals/README.md
@@ -12,11 +12,13 @@ single skill and contains an `eval.yaml` defining stimuli, graders, and configur
   itself does not get bundled into the published package — it is dev-only).
 - **GitHub Copilot CLI authentication**:
   - Local: `gh auth login` (Vally reuses your `gh` session).
-  - CI: `COPILOT_GITHUB_TOKEN` configured as an **environment secret** under
-    the `functions-skills-vally-eval` GitHub Environment. Recommended protection
-    rules: restrict `Deployment branches` to `main` (and any active eval-branch
-    pattern, e.g. `tsushi/vally-eval-*`), optionally add required reviewers for
-    cost-sensitive Opus / full runs.
+  - CI: the workflow uses the existing `functions-skills-live-e2e`
+    GitHub Environment and consumes the existing `COPILOT_CLI_TOKEN`
+    secret, mapping it onto `COPILOT_GITHUB_TOKEN` (the variable name
+    that `@github/copilot-sdk` reads). The token is set at **step level**
+    on the eval step only, so checkout / install / pre-warm / artifact
+    upload do not see it. Protected-branches policy + `azure-functions-bucees-team`
+    reviewers on the environment gate every run.
 - Run from the repository root so the relative paths in `.vally.yaml` resolve.
 
 ## Running

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,82 @@
+# Skill evaluation (Vally)
+
+This directory holds [Vally](https://aka.ms/vally) (`@microsoft/vally-cli`) evaluation
+suites for the skills shipped from `templates/skills/`. Each subdirectory targets a
+single skill and contains an `eval.yaml` defining stimuli, graders, and configuration.
+
+> Source / docs: <https://aka.ms/vally> · npm: [`@microsoft/vally-cli`](https://www.npmjs.com/package/@microsoft/vally-cli)
+
+## Prerequisites
+
+- **Node.js 22+** (required by Vally; the rest of the repo targets Node 18+ but Vally
+  itself does not get bundled into the published package — it is dev-only).
+- **GitHub Copilot CLI authentication**:
+  - Local: `gh auth login` (Vally reuses your `gh` session).
+  - CI: set `COPILOT_GITHUB_TOKEN`.
+- Run from the repository root so the relative paths in `.vally.yaml` resolve.
+
+## Running
+
+```bash
+# PR gate / smoke — routing checks only (cheapest)
+npx vally eval --suite smoke
+
+# Single skill, single spec
+npx vally eval --eval-spec evals/azure-functions-create/eval.yaml
+
+# Full nightly run (all stimuli including LLM-backed graders)
+npx vally eval --suite full
+
+# Static-only checks (no LLM calls, no agent execution)
+npx vally lint
+```
+
+Output lands in `./results/` by default:
+
+- `results.jsonl` — one record per stimulus/run with grader outcomes.
+- `eval-results.md` — human-readable summary.
+
+## Suite layout
+
+Defined in [`.vally.yaml`](../.vally.yaml) at the repo root:
+
+| suite | filter | use |
+| --- | --- | --- |
+| `smoke` | `tier: smoke` | quick routing checks |
+| `pr` | `tier: smoke` | PR gate (alias of smoke) |
+| `triggers` | `area: routing` | all skill-invocation/routing checks |
+| `integration` | `type: integration` | LLM-backed behavior tests |
+| `full` | — | everything (nightly) |
+
+## Authoring conventions
+
+- One `eval.yaml` per skill under `evals/<skill-name>/`.
+- Tag every stimulus with at least:
+  - `type: integration`
+  - `skill: <skill-name>`
+  - `tier: smoke | full`
+  - `area: routing | response-quality | handoff`
+  - `cost: free | llm`
+- **Duplicate the global graders into every stimulus.** Vally (`evaluate#125`)
+  does not yet support eval-level graders. See [`_base/common-graders.yaml`](_base/common-graders.yaml)
+  for the canonical copies (it is a reference file — **not** consumed by Vally).
+- For routing stimuli using the `skill-invocation` grader, prefer `runs: 5` and
+  `scoring.threshold: 0.8` so the metric measures invocation rate.
+- Response-quality stimuli typically use `runs: 1`.
+
+## Common graders (copy into each stimulus)
+
+See [`_base/common-graders.yaml`](_base/common-graders.yaml). Highlights:
+
+- `completed` — non-empty output guard.
+- `output-not-matches` for `(?i)fatal error|unhandled exception|stack trace` —
+  catches runtime crashes in the agent.
+- `output-not-matches` for connection-string / shared-key / master-key patterns —
+  secret-leak guard.
+
+## Cost notes
+
+- Every stimulus running through the `copilot-sdk` executor invokes the GitHub
+  Copilot agent at least once, which incurs LLM cost.
+- `tier: smoke` stimuli are intentionally small (1 prompt × N runs) for PRs.
+- Nightly `full` runs should be gated behind workflow_dispatch or schedule.

--- a/evals/README.md
+++ b/evals/README.md
@@ -12,7 +12,11 @@ single skill and contains an `eval.yaml` defining stimuli, graders, and configur
   itself does not get bundled into the published package — it is dev-only).
 - **GitHub Copilot CLI authentication**:
   - Local: `gh auth login` (Vally reuses your `gh` session).
-  - CI: set `COPILOT_GITHUB_TOKEN`.
+  - CI: `COPILOT_GITHUB_TOKEN` configured as an **environment secret** under
+    the `functions-skills-vally-eval` GitHub Environment. Recommended protection
+    rules: restrict `Deployment branches` to `main` (and any active eval-branch
+    pattern, e.g. `tsushi/vally-eval-*`), optionally add required reviewers for
+    cost-sensitive Opus / full runs.
 - Run from the repository root so the relative paths in `.vally.yaml` resolve.
 
 ## Running

--- a/evals/README.md
+++ b/evals/README.md
@@ -27,6 +27,10 @@ npx vally eval --eval-spec evals/azure-functions-create/eval.yaml
 # Full nightly run (all stimuli including LLM-backed graders)
 npx vally eval --suite full
 
+# Realistic user-experience check with Opus 4.7
+# (eval.yaml default is claude-sonnet-4.6 for cost/speed; override per-run with --model)
+npx vally eval --suite full --model claude-opus-4.7
+
 # Static-only checks (no LLM calls, no agent execution)
 npx vally lint
 ```
@@ -80,3 +84,24 @@ See [`_base/common-graders.yaml`](_base/common-graders.yaml). Highlights:
   Copilot agent at least once, which incurs LLM cost.
 - `tier: smoke` stimuli are intentionally small (1 prompt × N runs) for PRs.
 - Nightly `full` runs should be gated behind workflow_dispatch or schedule.
+
+## Model selection
+
+Eval specs default to `claude-sonnet-4.6` (matches the convention used by
+[`microsoft/GitHub-Copilot-for-Azure`](https://github.com/microsoft/GitHub-Copilot-for-Azure)
+and keeps PR / nightly cost and runtime stable). Override per run:
+
+| Layer | Model | When |
+| --- | --- | --- |
+| PR gate (`smoke`) | `claude-sonnet-4.6` | every push |
+| Nightly (`full`) | `claude-sonnet-4.6` | scheduled |
+| Reality check | `claude-opus-4.7` | manual via `--model claude-opus-4.7`, e.g. before a release, to mirror what GitHub Copilot CLI users typically run |
+
+Multi-model comparison runs are supported via comma-separated values:
+
+```bash
+npx vally eval --suite full --model claude-sonnet-4.6,claude-opus-4.7
+```
+
+The GitHub Actions workflow exposes a `model` input on `workflow_dispatch` for
+the same purpose.

--- a/evals/_base/common-graders.yaml
+++ b/evals/_base/common-graders.yaml
@@ -1,0 +1,39 @@
+# Common Vally graders — copy/paste reference for stimulus blocks.
+#
+# This file is NOT consumed by Vally directly. Vally 0.5.0 / evaluate#125 does
+# not yet support eval-level (global) graders, so each stimulus must include
+# its own copy of the graders below.
+#
+# When you add a new stimulus, copy the graders that apply into its
+# `graders:` array verbatim.
+
+# ── has_output ──
+# Ensures the agent produced meaningful output (not empty / trivial).
+has_output:
+  type: completed
+
+# ── no_runtime_failure ──
+# Catches fatal errors, unhandled exceptions, crashes, panics in the output.
+no_runtime_failure:
+  type: output-not-matches
+  config:
+    pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+# ── secrets: connection_string ──
+# Agent must never emit live connection strings.
+security_no_connection_string:
+  type: output-not-matches
+  config:
+    pattern: "(?i)connection.?string.*=.*Account(Key|Name)="
+
+# ── secrets: shared_access_key ──
+security_no_shared_access_key:
+  type: output-not-matches
+  config:
+    pattern: "(?i)SharedAccessKey="
+
+# ── secrets: master_key ──
+security_no_master_key:
+  type: output-not-matches
+  config:
+    pattern: "(?i)masterKey="

--- a/evals/azure-functions-create/eval.yaml
+++ b/evals/azure-functions-create/eval.yaml
@@ -1,0 +1,257 @@
+name: azure-functions-create-eval
+description: |
+  Evaluation suite for the azure-functions-create skill.
+
+  Covers:
+    - Routing (skill-invocation) for typical "create a function" prompts
+      across TypeScript HTTP, Python timer, and existing-project flows.
+    - Response-quality checks that the skill follows Path A (Azure MCP)
+      when available, does not fabricate template IDs, includes proper
+      verification, and suggests azure-functions-deploy as the next step.
+    - "Do not re-initialize an existing project" guardrail.
+
+  Notes:
+    - Built-in graders only (output-contains / output-matches /
+      output-not-matches / completed / skill-invocation). No custom
+      executor tags such as earlyTerminate are used because we rely on
+      Vally's standard `copilot-sdk` executor.
+    - Global graders (`completed`, `no_runtime_failure`) are duplicated
+      into each stimulus per evaluate#125. See ../_base/common-graders.yaml.
+
+tags:
+  type: integration
+  skill: azure-functions-create
+
+config:
+  runs: 3
+  timeout: "10m"
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.8
+  weights:
+    skill-invocation: 2.0
+    output-contains: 0.5
+    output-matches: 1.0
+    output-not-matches: 1.5
+    completed: 1.0
+
+stimuli:
+  # ─────────────────────────────────────────────────────────────────
+  # Routing — skill invocation (tier: smoke)
+  # Use runs: 5 / threshold 0.8 to measure invocation rate.
+  # ─────────────────────────────────────────────────────────────────
+
+  - name: "Routing — create TypeScript HTTP function"
+    prompt: |
+      I want to create a new Azure Functions project in TypeScript with an HTTP trigger.
+      Please scaffold it for me.
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: smoke
+      cost: llm
+      area: routing
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+    constraints:
+      max_turns: 12
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      # has_output
+      - type: completed
+      # no_runtime_failure
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  - name: "Routing — create Python timer function"
+    prompt: |
+      Create a new Python Azure Functions project with a timer trigger that runs every 5 minutes.
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: smoke
+      cost: llm
+      area: routing
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+    constraints:
+      max_turns: 12
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  - name: "Routing — add function to existing project"
+    prompt: |
+      I already have an Azure Functions project (host.json is present).
+      Please add a new HTTP trigger function to it; do not re-initialize the project.
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: smoke
+      cost: llm
+      area: routing
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+      files:
+        - src: fixtures/existing-project/host.json
+          dest: host.json
+        - src: fixtures/existing-project/package.json
+          dest: package.json
+    constraints:
+      max_turns: 12
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  # ─────────────────────────────────────────────────────────────────
+  # Response quality (tier: full)
+  # ─────────────────────────────────────────────────────────────────
+
+  - name: "Quality — uses Azure MCP path when scaffolding TypeScript HTTP"
+    prompt: |
+      Create a TypeScript Azure Functions project with an HTTP trigger named "hello".
+      Walk me through the scaffolding step by step before writing files.
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: full
+      cost: llm
+      area: response-quality
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+    constraints:
+      max_turns: 20
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      # MCP-first guidance must be mentioned
+      - type: output-matches
+        config:
+          pattern: "(?i)functions_(template|project|language)_(get|list)|Azure MCP"
+      # Must reference a properly-suffixed MCP template ID, not a bare alias
+      - type: output-matches
+        config:
+          pattern: "http-trigger-typescript(-azd)?"
+      # Must NOT invent the bare ".NET-style" alias as the actual template ID
+      - type: output-not-matches
+        config:
+          pattern: "(?<![\\w-])HttpTrigger(?![\\w-])"
+      # Must propose `func start` based verification
+      - type: output-contains
+        config:
+          substring: "func start"
+      # Should suggest the deploy skill next
+      - type: output-matches
+        config:
+          pattern: "azure-functions-deploy"
+      # Globals
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  - name: "Quality — HTTP verify uses real request, not just host start"
+    prompt: |
+      I created an HTTP-triggered Azure Functions app.
+      How should I verify it end-to-end locally?
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: full
+      cost: llm
+      area: response-quality
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+    constraints:
+      max_turns: 15
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      - type: output-contains
+        config:
+          substring: "func start"
+      # For HTTP triggers the skill must instruct a real request (curl / GET / localhost:7071)
+      - type: output-matches
+        config:
+          pattern: "(?i)curl|localhost:7071|GET .*?/api/"
+      # Globals
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  - name: "Quality — do NOT re-initialize an existing project"
+    prompt: |
+      I have an existing Azure Functions project (host.json present) and I want to
+      add a Service Bus queue triggered function. Please add it without re-initializing.
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: full
+      cost: llm
+      area: response-quality
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+      files:
+        - src: fixtures/existing-project/host.json
+          dest: host.json
+        - src: fixtures/existing-project/package.json
+          dest: package.json
+    constraints:
+      max_turns: 20
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      # Must NOT instruct `func init` (would overwrite host.json)
+      - type: output-not-matches
+        config:
+          pattern: "(?i)func init"
+      # Should reference the "add to existing project" path / functions_template_get with template
+      - type: output-matches
+        config:
+          pattern: "(?i)existing project|functions_template_get|add"
+      # Globals
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"

--- a/evals/azure-functions-create/eval.yaml
+++ b/evals/azure-functions-create/eval.yaml
@@ -6,15 +6,26 @@ description: |
     - Routing (skill-invocation) for typical "create a function" prompts
       across TypeScript HTTP, Python timer, and existing-project flows.
     - Response-quality checks that the skill follows Path A (Azure MCP)
-      when available, does not fabricate template IDs, includes proper
-      verification, and suggests azure-functions-deploy as the next step.
+      when available, does not fabricate template IDs, and includes
+      proper local end-to-end verification.
     - "Do not re-initialize an existing project" guardrail.
 
+  Environment:
+    - Each stimulus attaches the Azure MCP server (`@azure/mcp`) via
+      stdio, scoped to the `functions` namespace. All three Functions
+      tools (`functions_language_list`, `functions_project_get`,
+      `functions_template_get`) are readOnly and require no Azure
+      credentials, so this works in plain CI.
+    - Cold start is slow because `npx -y @azure/mcp@latest` downloads
+      the package on first run. Subsequent runs are fast thanks to npm
+      cache; CI can pre-warm via `npm install -g @azure/mcp@latest` or
+      `npx -y @azure/mcp@latest server --help`.
+
   Notes:
-    - Built-in graders only (output-contains / output-matches /
-      output-not-matches / completed / skill-invocation). No custom
-      executor tags such as earlyTerminate are used because we rely on
-      Vally's standard `copilot-sdk` executor.
+    - Built-in graders only (skill-invocation / output-contains /
+      output-matches / output-not-matches / completed). We rely on
+      Vally's standard `copilot-sdk` executor; no custom executor tags
+      such as earlyTerminate are used.
     - Global graders (`completed`, `no_runtime_failure`) are duplicated
       into each stimulus per evaluate#125. See ../_base/common-graders.yaml.
 
@@ -58,6 +69,12 @@ stimuli:
         - ../../templates/skills/azure-functions-create
         - ../../templates/skills/azure-functions-common
         - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
     constraints:
       max_turns: 12
     graders:
@@ -65,9 +82,7 @@ stimuli:
         config:
           required:
             - azure-functions-create
-      # has_output
       - type: completed
-      # no_runtime_failure
       - type: output-not-matches
         config:
           pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
@@ -86,6 +101,12 @@ stimuli:
         - ../../templates/skills/azure-functions-create
         - ../../templates/skills/azure-functions-common
         - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
     constraints:
       max_turns: 12
     graders:
@@ -113,6 +134,12 @@ stimuli:
         - ../../templates/skills/azure-functions-create
         - ../../templates/skills/azure-functions-common
         - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
       files:
         - src: fixtures/existing-project/host.json
           dest: host.json
@@ -149,6 +176,12 @@ stimuli:
         - ../../templates/skills/azure-functions-create
         - ../../templates/skills/azure-functions-common
         - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
     constraints:
       max_turns: 20
     graders:
@@ -156,7 +189,7 @@ stimuli:
         config:
           required:
             - azure-functions-create
-      # MCP-first guidance must be mentioned
+      # MCP-first guidance must be mentioned (tool names or "Azure MCP")
       - type: output-matches
         config:
           pattern: "(?i)functions_(template|project|language)_(get|list)|Azure MCP"
@@ -172,10 +205,6 @@ stimuli:
       - type: output-contains
         config:
           substring: "func start"
-      # Should suggest the deploy skill next
-      - type: output-matches
-        config:
-          pattern: "azure-functions-deploy"
       # Globals
       - type: completed
       - type: output-not-matches
@@ -184,8 +213,9 @@ stimuli:
 
   - name: "Quality — HTTP verify uses real request, not just host start"
     prompt: |
-      I created an HTTP-triggered Azure Functions app.
-      How should I verify it end-to-end locally?
+      Please scaffold a new TypeScript HTTP-triggered Azure Functions project for me.
+      As part of the scaffolding, also walk me through the local end-to-end verification step
+      I should run after the files are written.
     tags:
       type: integration
       skill: azure-functions-create
@@ -196,8 +226,15 @@ stimuli:
       skills:
         - ../../templates/skills/azure-functions-create
         - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
     constraints:
-      max_turns: 15
+      max_turns: 20
     graders:
       - type: skill-invocation
         config:
@@ -218,8 +255,9 @@ stimuli:
 
   - name: "Quality — do NOT re-initialize an existing project"
     prompt: |
-      I have an existing Azure Functions project (host.json present) and I want to
-      add a Service Bus queue triggered function. Please add it without re-initializing.
+      I have an existing Azure Functions TypeScript project (host.json is present).
+      Please add a new Service Bus queue trigger function to it.
+      Do not re-initialize the project — just add the new function file alongside the existing ones.
     tags:
       type: integration
       skill: azure-functions-create
@@ -230,6 +268,13 @@ stimuli:
       skills:
         - ../../templates/skills/azure-functions-create
         - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
       files:
         - src: fixtures/existing-project/host.json
           dest: host.json
@@ -246,10 +291,10 @@ stimuli:
       - type: output-not-matches
         config:
           pattern: "(?i)func init"
-      # Should reference the "add to existing project" path / functions_template_get with template
+      # Should reference the "add to existing project" path
       - type: output-matches
         config:
-          pattern: "(?i)existing project|functions_template_get|add"
+          pattern: "(?i)existing project|functions_template_get|add (a |the |new )?(function|trigger)"
       # Globals
       - type: completed
       - type: output-not-matches

--- a/evals/azure-functions-create/fixtures/existing-project/host.json
+++ b/evals/azure-functions-create/fixtures/existing-project/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/evals/azure-functions-create/fixtures/existing-project/package.json
+++ b/evals/azure-functions-create/fixtures/existing-project/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "existing-functions-project",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/src/functions/*.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "func start"
+  },
+  "dependencies": {
+    "@azure/functions": "^4.5.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@microsoft/vally-cli": "^0.5.0",
         "@types/node": "^25.6.0",
         "eslint": "^10.3.0",
         "typescript": "^6.0.3",
@@ -185,6 +186,193 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@github/copilot": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.56.tgz",
+      "integrity": "sha512-epJ9yRqK1QjU73FDAlxPqZKh+CxkA1TIYbhTvXblturw5wWUhCSRhI2XoamNERohPznY10Wg3tbZC3jUAmQdJw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.56",
+        "@github/copilot-darwin-x64": "1.0.56",
+        "@github/copilot-linux-arm64": "1.0.56",
+        "@github/copilot-linux-x64": "1.0.56",
+        "@github/copilot-linuxmusl-arm64": "1.0.56",
+        "@github/copilot-linuxmusl-x64": "1.0.56",
+        "@github/copilot-win32-arm64": "1.0.56",
+        "@github/copilot-win32-x64": "1.0.56"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.56.tgz",
+      "integrity": "sha512-vCittEfa/Qys86TxhI5rgxy8L8WTQoooIjEj8kZe7mq62TOOrFGnWJjqaR6mgljmPTxKRFmT6achUxKRVZil9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.56.tgz",
+      "integrity": "sha512-yO7OvFysG/98s9T8k5cEXzBz++mki7ufkH2S8/jqC7YIKhlj64rh+/vIBU5DQ9RLXbPKm6OjGjJn8iDWXzzuJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.56.tgz",
+      "integrity": "sha512-ukOwSwFOqgpQQs5Nw3GAFRGIn6LqA8KfI6hD+tUeqoWkB0OlXxwQER7sKEfSQZu1vcNnW1+YIM/qT5W5RWdmhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.56.tgz",
+      "integrity": "sha512-C84nduDAeHCTEfjs+mYfIjbBjGRx2huy8XZBu0ETAD08uUBuQpUHn2PYhaaHb1yKoG6LMceKt10PTrqNdOE9IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.56.tgz",
+      "integrity": "sha512-EuDmGVl4fEk7Q+AVhkQkpiRlXpjGGQ5GzfBzMEOWgrvfdCLcT62p1uEaz+AT2UdkJiViruLyVf3pZFUyQwyvjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.56.tgz",
+      "integrity": "sha512-qRXub9+1J7mNIzweAaw0tGgztS6XK+ZlwhUjOcFTusbqnED33zw4HzExUNUTTDue/BOUwkYzvXqMqn5N6juIJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.0-beta.5.tgz",
+      "integrity": "sha512-WT/JZXkLi4mZKjyQakqBEv4lU8zHOSERicEB75KN1oLVIvKRvL8WyfP6dqIjeO1xmCKd6/qKVGlQxJChCIzJ1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.51",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.56.tgz",
+      "integrity": "sha512-/lj/zEezNoewCxvVORLN0JFvvi9WmQTYvtIyyg8kVlA9HZeg0vpRTBM5hdoni2D8mKb7g/8w8VF2Ecy9D3+NpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.56.tgz",
+      "integrity": "sha512-062C3lp4nvVl+vkkteYOrYpgnqZ/SAi54NuTQ4k45V2TNmLIpmMybmM0tCluxOfiTY+8EuS72H9RS8NUj1CzhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.4.tgz",
+      "integrity": "sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -257,6 +445,44 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@microsoft/vally": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally/-/vally-0.5.0.tgz",
+      "integrity": "sha512-R5NhYrLJ724x5k/K82ZaRwRwplRQU3EwT08rONlFe9qM3iMisoWVv9CBj+zYuVdWQuzy4SjwS97wkZ3fb7AjQQ==",
+      "dev": true,
+      "dependencies": {
+        "@github/copilot-sdk": "1.0.0-beta.5",
+        "js-tiktoken": "^1.0.21",
+        "picomatch": "^4.0.4",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/@microsoft/vally-cli": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-cli/-/vally-cli-0.5.0.tgz",
+      "integrity": "sha512-emTvEfNo2+9rtglHIjev85tlwwWXHRhbkHpxyWWliIVuK+ICt0BwUMo33pnQ4tfKEaCoxz0kSyCTuerUnj1cxQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/vally": "^0.5.0",
+        "@microsoft/vally-server": "^0.5.0",
+        "commander": "^14.0.3"
+      },
+      "bin": {
+        "vally": "dist/index.js"
+      }
+    },
+    "node_modules/@microsoft/vally-server": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-server/-/vally-server-0.5.0.tgz",
+      "integrity": "sha512-2I5rcP0ihnmNT67o7xce3OOqT7RnidckAGtFaYwvtyVzst9qZ2SQ+Tjg/EepTnfNKi50wWSfPCzm2Epn4YYQ1A==",
+      "dev": true,
+      "dependencies": {
+        "@hono/node-server": "^2.0.3",
+        "@microsoft/vally": "^0.5.0",
+        "better-sqlite3": "^12.10.0",
+        "hono": "^4.12.21"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1021,6 +1247,64 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -1034,6 +1318,31 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1042,6 +1351,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/convert-source-map": {
@@ -1084,6 +1410,32 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1099,6 +1451,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1283,6 +1645,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1345,6 +1717,13 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1383,6 +1762,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1398,6 +1784,13 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1410,6 +1803,37 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -1430,6 +1854,20 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1460,6 +1898,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -1793,6 +2241,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -1808,6 +2269,23 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1835,12 +2313,32 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -1852,6 +2350,16 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -1979,6 +2487,34 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1989,6 +2525,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1997,6 +2544,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rolldown": {
@@ -2032,6 +2610,27 @@
         "@rolldown/binding-win32-arm64-msvc": "1.0.2",
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.1",
@@ -2076,6 +2675,53 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2099,6 +2745,56 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2164,6 +2860,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2232,6 +2941,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.14",
@@ -2401,6 +3117,16 @@
         }
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2444,6 +3170,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2455,6 +3204,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,13 +46,18 @@
     "validate:skills": "npm run compile && node lib/build/validate-skills.js",
     "verify:plugin-payload": "npm run compile && node lib/build/verify-plugin-payload.js",
     "setup": "node bin/azure-functions-skills.js setup",
-    "release:local": "node scripts/release-local.mjs"
+    "release:local": "node scripts/release-local.mjs",
+    "eval:lint": "vally lint",
+    "eval:smoke": "vally eval --suite smoke",
+    "eval:full": "vally eval --suite full",
+    "eval": "vally eval"
   },
   "engines": {
     "node": ">=18"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@microsoft/vally-cli": "^0.5.0",
     "@types/node": "^25.6.0",
     "eslint": "^10.3.0",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

Bring up the [Vally](https://aka.ms/vally) (`@microsoft/vally-cli`) evaluation pipeline as a **PoC**, with `azure-functions-create` as the first target skill.

Mirrors the pattern used by [`microsoft/GitHub-Copilot-for-Azure`](https://github.com/microsoft/GitHub-Copilot-for-Azure) (`evals/<skill>/eval.yaml` + a root `.vally.yaml` grouping suites by stimulus tags), but uses Vally's **built-in `copilot-sdk` executor** instead of their internal `integration-test-agent-runner`, so this runs against the public `@github/copilot-sdk` with no custom executor code to maintain.

This is a starting point — once it lands, the same pattern can be extended to the other 9 skills.

## What's in

- **`.vally.yaml`** — suites `smoke` / `pr` / `triggers` / `integration` / `full`, filtered by stimulus tags (`tier`, `area`, `type`).
- **`evals/README.md`** — setup, run, suite, and authoring conventions.
- **`evals/_base/common-graders.yaml`** — copy/paste reference for the global graders (`has_output`, `no_runtime_failure`, secret-leak guards). Vally 0.5.0 / evaluate#125 still requires per-stimulus duplication, so this file is a reference, not consumed directly.
- **`evals/azure-functions-create/eval.yaml`** — 6 stimuli:

  | # | Category | What it checks |
  |---|---|---|
  | 1 | Routing (smoke) | TS HTTP scaffold → `azure-functions-create` is invoked |
  | 2 | Routing (smoke) | Python timer scaffold → same |
  | 3 | Routing (smoke) | Add-to-existing-project flow → same (uses fixture `host.json`/`package.json`) |
  | 4 | Quality (full) | MCP-first path (mentions `functions_template_get`), uses real template ID `http-trigger-typescript(-azd)?`, **never** invents bare `HttpTrigger`, ends with `func start` + suggests `azure-functions-deploy` |
  | 5 | Quality (full) | HTTP E2E verification — must include `curl` / `localhost:7071` / `GET /api/`, not just `func start` |
  | 6 | Quality (full) | Existing-project add path **must not** emit `func init` |

- **`evals/azure-functions-create/fixtures/existing-project/`** — minimal `host.json` + `package.json` for the existing-project stimuli.
- **`package.json`** — `@microsoft/vally-cli` devDependency + `eval` / `eval:smoke` / `eval:full` / `eval:lint` scripts. `evals/` is **not** shipped to npm (`files` whitelist unchanged).
- **`.github/workflows/skill-evaluation-vally.yml`** — `workflow_dispatch` (pick suite or single spec) + nightly schedule auto-skipped when `COPILOT_GITHUB_TOKEN` is absent; uploads `results.jsonl` + JUnit report.

## Why use the built-in `copilot-sdk` executor

GitHub-Copilot-for-Azure ships a custom `integration-test-agent-runner` (in `tests/vally/`) that depends on internal `agent-runner` / `skill-loader` / tag-helper modules (`earlyTerminate`, `takeScreenshot`, `followUp`, etc.). Porting that infrastructure would multiply scope. The built-in `copilot-sdk` executor:

- ships with `@microsoft/vally` (no extra code to maintain),
- targets the same `@github/copilot-sdk` underneath,
- supports the standard graders we need (`skill-invocation`, `output-contains`, `output-matches`, `output-not-matches`, `completed`).

Cost is controlled simply by keeping stimulus count tight and using the `tier: smoke` / `tier: full` split.

## Validation

- `npx vally lint --eval-spec evals` ✔
- `npm run typecheck` ✔
- `npm run lint` ✔
- `npm run validate:skills` ✔
- `npm run lint:security` — pre-existing warning about `npm publish` reference in `azure-pipelines/templates/`, unrelated to this PR.

**Not yet executed end-to-end:** `npx vally eval --suite smoke` against the live Copilot SDK is not run in this PR (incurs LLM cost + needs `gh auth`). The workflow is wired up so a maintainer can dispatch the `smoke` suite manually to sanity-check before turning on the nightly schedule.

## Next steps (separate PRs)

- Run `--suite smoke` once, tune any flaky stimulus.
- Roll out the same pattern to the other skills (`azure-functions-deploy`, `azure-functions-doctor`, `azure-functions-diagnostics`, …).
- Add a budget/cost note once we have real numbers from the first nightly run.
