### PR TITLE
ci(eval): install func + azd on runner + add azure-functions-setup eval (re-target #150 onto main)

### DIFF
--- a/.github/workflows/skill-evaluation-vally.yml
+++ b/.github/workflows/skill-evaluation-vally.yml
@@ -69,6 +69,30 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
+      - name: Install Azure Functions Core Tools (func)
+        # Required by the azure-functions-setup skill prerequisite checks
+        # and by any eval that asks the agent to run / verify the host.
+        run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+
+      - name: Install Azure Developer CLI (azd)
+        # Required by the azure-functions-setup skill prerequisite checks
+        # and by deployment-related evals.
+        run: curl -fsSL https://aka.ms/install-azd.sh | bash
+
+      - name: Verify prerequisites
+        # Fail fast if the installs above did not land — keeps
+        # CI-environment regressions from masquerading as model failures
+        # in the azure-functions-setup eval.
+        run: |
+          set -euo pipefail
+          echo "node:    $(node --version)"
+          echo "npm:     $(npm --version)"
+          echo "az:      $(az --version | head -1)"
+          echo "azd:     $(azd version)"
+          echo "func:    $(func --version)"
+          echo "python3: $(python3 --version)"
+          echo "dotnet:  $(dotnet --version)"
+
       - name: Pre-warm @azure/mcp cache
         # Functions evals attach an Azure MCP server (functions namespace) via
         # stdio. Pulling the package once upfront keeps per-stimulus startup fast

--- a/evals/README.md
+++ b/evals/README.md
@@ -74,6 +74,28 @@ Defined in [`.vally.yaml`](../.vally.yaml) at the repo root:
   `scoring.threshold: 0.8` so the metric measures invocation rate.
 - Response-quality stimuli typically use `runs: 1`.
 
+## CI runner prerequisites
+
+The `Skill Evaluation - Vally` workflow installs the following before running
+evals, so any stimulus that triggers a prerequisite check (e.g. the
+`azure-functions-setup` eval) reflects the agent / skill behavior rather than a
+missing runner tool:
+
+| Tool | Provided by |
+| --- | --- |
+| Node.js 22 | `actions/setup-node@v4` |
+| `npm` | Node.js |
+| `az` (Azure CLI) | runner image (pre-installed) |
+| `python3` | runner image (pre-installed) |
+| `dotnet` | runner image (pre-installed) |
+| `func` (Azure Functions Core Tools 4.x) | `npm install -g azure-functions-core-tools@4` step |
+| `azd` (Azure Developer CLI) | `https://aka.ms/install-azd.sh` step |
+
+The workflow runs `Verify prerequisites` immediately after these installs, so a
+broken provisioning step fails the job before the LLM is invoked. The
+`azure-functions-setup` eval then sanity-checks that the agent observes the
+same tools from inside the session.
+
 ## Common graders (copy into each stimulus)
 
 See [`_base/common-graders.yaml`](_base/common-graders.yaml). Highlights:

--- a/evals/azure-functions-setup/eval.yaml
+++ b/evals/azure-functions-setup/eval.yaml
@@ -1,0 +1,147 @@
+name: azure-functions-setup-eval
+description: |
+  Evaluation suite for the azure-functions-setup skill.
+
+  Doubles as a CI environment sanity check: when the agent runs the
+  prerequisite-version commands listed in the skill (az, azd, func,
+  node, python3, dotnet), every one of those tools must actually be
+  present on the runner. If any of them is missing the eval will
+  surface it through the `prereq_*_ok` graders below.
+
+  Stimuli are intentionally low-cost (1 routing + 1 quality, runs: 3)
+  so this suite stays cheap enough to run on every PR alongside the
+  other smoke stimuli.
+
+  Notes:
+    - Built-in graders only. Global graders (`completed`,
+      `no_runtime_failure`) are duplicated into each stimulus per
+      evaluate#125. See ../_base/common-graders.yaml.
+
+tags:
+  type: integration
+  skill: azure-functions-setup
+
+config:
+  runs: 3
+  timeout: "5m"
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.8
+  weights:
+    skill-invocation: 2.0
+    output-matches: 1.0
+    output-not-matches: 1.5
+    completed: 1.0
+
+stimuli:
+  # ─────────────────────────────────────────────────────────────────
+  # Routing (tier: smoke) — does a "check my environment" prompt
+  # activate the setup skill?
+  # ─────────────────────────────────────────────────────────────────
+
+  - name: "Routing — check Azure Functions environment"
+    prompt: |
+      Check whether my development environment is ready for Azure Functions —
+      list each required tool and its version, and tell me what is missing.
+    tags:
+      type: integration
+      skill: azure-functions-setup
+      tier: smoke
+      cost: llm
+      area: routing
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-setup
+        - ../../templates/skills/azure-functions-common
+    constraints:
+      max_turns: 12
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-setup
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  # ─────────────────────────────────────────────────────────────────
+  # Response quality (tier: smoke) — environment sanity check
+  # The skill instructs the agent to run version probes for six
+  # prerequisites. Each grader below asserts that the corresponding
+  # tool reported a usable version (not "missing" / "not found" /
+  # "command not found"). On a correctly provisioned CI runner all
+  # six must pass.
+  # ─────────────────────────────────────────────────────────────────
+
+  - name: "Quality — all six prerequisites present"
+    prompt: |
+      Please verify that my environment is set up for Azure Functions development.
+      Run the prerequisite version checks for Azure CLI, Azure Developer CLI,
+      Azure Functions Core Tools, Node.js, Python, and .NET SDK, and report
+      each result individually.
+    tags:
+      type: integration
+      skill: azure-functions-setup
+      tier: smoke
+      cost: llm
+      area: response-quality
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-setup
+        - ../../templates/skills/azure-functions-common
+    constraints:
+      max_turns: 15
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-setup
+
+      # Each tool must appear in the agent's report with a ✅-style
+      # OK marker (the skill template uses ✅ / "ready" / "installed").
+      # We accept any positive marker; we only fail when the tool is
+      # explicitly missing (caught by the prereq_no_missing grader
+      # below).
+      - name: prereq_az_mentioned
+        type: output-matches
+        config:
+          pattern: "(?i)Azure CLI"
+      - name: prereq_azd_mentioned
+        type: output-matches
+        config:
+          pattern: "(?i)Azure Developer CLI|\\bazd\\b"
+      - name: prereq_func_mentioned
+        type: output-matches
+        config:
+          pattern: "(?i)Core Tools|\\bfunc\\b"
+      - name: prereq_node_mentioned
+        type: output-matches
+        config:
+          pattern: "(?i)Node\\.?js"
+      - name: prereq_python_mentioned
+        type: output-matches
+        config:
+          pattern: "(?i)Python"
+      - name: prereq_dotnet_mentioned
+        type: output-matches
+        config:
+          pattern: "(?i)\\.NET( SDK)?|dotnet"
+
+      # Hard failure: any of the six prerequisites reported as missing
+      # means the CI environment is broken. This is the grader that
+      # actually validates the runner; the version-prober ran by the
+      # agent will produce "command not found" / "not installed" / "❌"
+      # output that the model paraphrases in its final answer.
+      - name: prereq_no_missing
+        type: output-not-matches
+        config:
+          pattern: "(?i)(command not found|not installed|missing|❌)\\s*(:|—|-)?\\s*(azure cli|az\\b|azure developer cli|azd\\b|core tools|func\\b|node\\.?js|python|\\.net|dotnet)"
+
+      # Globals
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"


### PR DESCRIPTION
## Summary

**Reopens the content of #150 against `main`.** PR #150 was accidentally targeted at the `tsushi/vally-eval-create` feature branch instead of `main`. When #141 was squash-merged into `main` first, that branch was retired and #150's changes never propagated to `main` — confirmed by:

- [CI run 26695373490](https://github.com/Azure/azure-functions-skills/actions/runs/26695373490/job/78678897610) on `main` only discovered **3 stimuli from `azure-functions-create`** (no `azure-functions-setup` stimuli)
- `gh api repos/.../contents/evals?ref=main` returns only `_base`, `azure-functions-create`, `README.md`
- The workflow on `main` is missing the `Install Azure Functions Core Tools (func)` / `Install Azure Developer CLI (azd)` / `Verify prerequisites` steps

This PR cherry-picks the original commit (`52c8052`) onto `main` cleanly. No content change vs. the original #150.

## What's in (unchanged from #150)

### Workflow (`.github/workflows/skill-evaluation-vally.yml`)

- **Install `func`** — `npm install -g azure-functions-core-tools@4 --unsafe-perm true`.
- **Install `azd`** — `curl -fsSL https://aka.ms/install-azd.sh | bash`.
- **Verify prerequisites** — prints `node / npm / az / azd / func / python3 / dotnet` versions with `set -euo pipefail`, so a broken provisioning step fails the job before any LLM is invoked.

Step order after this PR:

```
Checkout → Setup Node 22 → npm ci → Install func → Install azd
→ Verify prerequisites → Pre-warm @azure/mcp → vally lint → vally eval → Upload results
```

### New eval (`evals/azure-functions-setup/eval.yaml`)

| Stimulus | Tier | runs | What it checks |
|---|---|---|---|
| Routing — check Azure Functions environment | smoke | 3 | `azure-functions-setup` skill is invoked for a generic "check my environment" prompt |
| Quality — all six prerequisites present | smoke | 3 | Agent's report (1) mentions each of `Azure CLI / azd / Core Tools / Node.js / Python / .NET SDK` and (2) does **not** report any of them as `command not found` / `not installed` / `missing` / `❌` |

The `prereq_no_missing` grader is the one that actually validates the runner. If a future change drops `func` / `azd` from the runner image, this stimulus turns red without us having to teach Vally about runner provisioning.

### Docs (`evals/README.md`)

- New **CI runner prerequisites** section.

## Validation

- `npx vally lint --eval-spec evals` ✔ (both `azure-functions-create` and `azure-functions-setup` valid)
- Cherry-picked cleanly onto `main` (no conflicts).

End-to-end CI verification happens after merge via `workflow_dispatch` on `main`.

## Related

- #141 — parent PR (merged)
- #150 — orphaned PR with the same content (closed)
- #149 — `azure-functions-create` skill description issue
