### PR TITLE
feat(eval): Tier 3 live deploy eval for azure-functions-deploy + cleanup safety net

### DIFF
--- a/.github/workflows/cleanup-stale-vally-resources.yml
+++ b/.github/workflows/cleanup-stale-vally-resources.yml
@@ -1,0 +1,188 @@
+name: Cleanup Stale Vally Resources
+
+# Safety net: deletes Azure resource groups tagged `vally-eval=true`
+# whose `createdAt` tag is older than the configured age. This runs
+# even if the Skill Evaluation - Vally Live workflow forgets to clean
+# up (e.g. because keep_resources=true was used for debugging or the
+# workflow itself was cancelled mid-cleanup).
+#
+# Scope:
+#   Subscription = vars.AZURE_SUBSCRIPTION_ID on functions-skills-live-e2e.
+#   Tag filter   = vally-eval=true   AND   createdAt < (now - max_age_hours).
+#
+# Required identity:
+#   The federated identity behind vars.AZURE_CLIENT_ID must hold a
+#   role that allows `Microsoft.Resources/subscriptions/resourceGroups/delete`
+#   (Contributor on the subscription is the simplest fit).
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_age_hours:
+        description: Delete resource groups whose createdAt tag is older than this many hours.
+        required: false
+        type: string
+        default: "24"
+      dry_run:
+        description: When true, list candidates but do not delete.
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Daily at 03:00 UTC. Runs against the reviewer-gated environment,
+    # which means scheduled runs currently sit waiting for approval
+    # until a non-gated identity is provisioned. Approving once a day
+    # is the interim manual step.
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: vally-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: cleanup stale vally resource groups
+    runs-on: ubuntu-latest
+    environment: functions-skills-live-e2e
+    timeout-minutes: 30
+    env:
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+    steps:
+      - name: Mask Azure identifiers
+        shell: bash
+        run: |
+          set -euo pipefail
+          for value in "$AZURE_CLIENT_ID" "$AZURE_TENANT_ID" "$AZURE_SUBSCRIPTION_ID"; do
+            if [ -n "$value" ]; then echo "::add-mask::$value"; fi
+          done
+
+      - name: Validate Azure configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required configuration: $name" >&2
+              exit 1
+            fi
+          done
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Find stale resource groups
+        id: find
+        shell: bash
+        env:
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '24' }}
+        run: |
+          set -euo pipefail
+
+          # Compute cutoff in epoch seconds. Tag values are ISO-8601
+          # strings (we write them at RG creation time).
+          NOW_EPOCH="$(date -u +%s)"
+          CUTOFF_EPOCH="$((NOW_EPOCH - MAX_AGE_HOURS * 3600))"
+          echo "Cutoff: $(date -u -d "@$CUTOFF_EPOCH" +%Y-%m-%dT%H:%M:%SZ) ($CUTOFF_EPOCH)"
+
+          # List every RG tagged vally-eval=true, projecting name + createdAt.
+          mapfile -t CANDIDATES < <(
+            az group list \
+              --tag vally-eval=true \
+              --query "[].{name:name, createdAt:tags.createdAt}" \
+              -o tsv
+          )
+
+          STALE_NAMES=()
+          if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+            echo "No resource groups tagged vally-eval=true found."
+          else
+            for line in "${CANDIDATES[@]}"; do
+              # tsv columns: name<TAB>createdAt
+              NAME="$(echo "$line" | cut -f1)"
+              CREATED_AT="$(echo "$line" | cut -f2)"
+              if [ -z "$CREATED_AT" ] || [ "$CREATED_AT" = "None" ]; then
+                # No createdAt tag → treat as stale immediately (safer
+                # to delete than to let an unknown RG accumulate cost).
+                echo "  STALE (no createdAt): $NAME"
+                STALE_NAMES+=("$NAME")
+                continue
+              fi
+              CREATED_EPOCH="$(date -u -d "$CREATED_AT" +%s 2>/dev/null || echo 0)"
+              if [ "$CREATED_EPOCH" -lt "$CUTOFF_EPOCH" ]; then
+                echo "  STALE ($CREATED_AT): $NAME"
+                STALE_NAMES+=("$NAME")
+              else
+                echo "  fresh ($CREATED_AT): $NAME"
+              fi
+            done
+          fi
+
+          # Join with newlines for the next step.
+          {
+            echo "stale_count=${#STALE_NAMES[@]}"
+            echo 'stale_names<<EOF'
+            printf '%s\n' "${STALE_NAMES[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Delete stale resource groups
+        if: steps.find.outputs.stale_count != '0'
+        shell: bash
+        env:
+          STALE_NAMES: ${{ steps.find.outputs.stale_names }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          DELETED=()
+          SKIPPED=()
+          while IFS= read -r NAME; do
+            [ -z "$NAME" ] && continue
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] would delete: $NAME"
+              SKIPPED+=("$NAME")
+            else
+              echo "Deleting: $NAME"
+              if az group delete --name "$NAME" --yes --no-wait; then
+                DELETED+=("$NAME")
+              else
+                echo "::warning::Failed to issue delete for $NAME"
+              fi
+            fi
+          done <<< "$STALE_NAMES"
+          {
+            echo "## Cleanup summary"
+            echo ""
+            echo "- Mode: $([ "$DRY_RUN" = "true" ] && echo "dry-run" || echo "delete")"
+            echo "- Stale groups: ${{ steps.find.outputs.stale_count }}"
+            echo "- Delete submitted: ${#DELETED[@]}"
+            echo "- Dry-run skipped:  ${#SKIPPED[@]}"
+            if [ "${#DELETED[@]}" -gt 0 ]; then
+              echo ""
+              echo "### Deleted"
+              printf -- '- `%s`\n' "${DELETED[@]}"
+            fi
+            if [ "${#SKIPPED[@]}" -gt 0 ]; then
+              echo ""
+              echo "### Dry-run candidates"
+              printf -- '- `%s`\n' "${SKIPPED[@]}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report nothing-to-do
+        if: steps.find.outputs.stale_count == '0'
+        shell: bash
+        run: |
+          echo "## Cleanup summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No stale resource groups found." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/skill-evaluation-vally-live.yml
+++ b/.github/workflows/skill-evaluation-vally-live.yml
@@ -1,0 +1,253 @@
+name: Skill Evaluation - Vally Live
+
+# Live (Tier 3) Vally eval that ACTUALLY DEPLOYS to Azure.
+# Reviewer-gated via the functions-skills-live-e2e environment.
+
+on:
+  workflow_dispatch:
+    inputs:
+      eval_spec:
+        description: |
+          Single eval spec to run (path under repo root, e.g.
+          evals/azure-functions-deploy/eval.yaml). Empty = run the full
+          'live' suite.
+        required: false
+        type: string
+      model:
+        description: Optional model override (e.g. claude-opus-4.7). Empty = eval.yaml default.
+        required: false
+        type: string
+      keep_resources:
+        description: |
+          DEBUG ONLY. When true, the Azure resources created by this
+          run are NOT cleaned up at the end of the job. The safety net
+          workflow (cleanup-stale-vally-resources) will still nuke them
+          after 24h via the vally-eval=true tag.
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Nightly full live run at 07:00 UTC (after the regular Vally workflow).
+    # Currently runs the full 'live' suite; gated by the environment's
+    # required reviewers so a scheduled run still needs approval until a
+    # non-gated identity is provisioned.
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+  id-token: write    # required for azure/login@v3 federated credentials
+
+concurrency:
+  # Live runs touch real subscription resources; never cancel a running
+  # one because of a newer dispatch.
+  group: vally-live-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  live-eval:
+    name: vally live eval
+    runs-on: ubuntu-latest
+    environment: functions-skills-live-e2e
+    timeout-minutes: 90
+    env:
+      HAS_COPILOT_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN != '' }}
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_LOCATION: eastus2
+
+    steps:
+      - name: Skip nightly when token is not configured
+        if: github.event_name == 'schedule' && env.HAS_COPILOT_TOKEN != 'true'
+        run: |
+          echo "COPILOT_CLI_TOKEN is not configured; skipping nightly live run." >&2
+          exit 0
+
+      - name: Mask Azure identifiers
+        shell: bash
+        run: |
+          set -euo pipefail
+          for value in "$AZURE_CLIENT_ID" "$AZURE_TENANT_ID" "$AZURE_SUBSCRIPTION_ID"; do
+            if [ -n "$value" ]; then echo "::add-mask::$value"; fi
+          done
+
+      - name: Validate required Azure configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required configuration: $name" >&2
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Azure Functions Core Tools (func)
+        run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+
+      - name: Install Azure Developer CLI (azd)
+        run: curl -fsSL https://aka.ms/install-azd.sh | bash
+
+      - name: Verify prerequisites
+        run: |
+          set -euo pipefail
+          echo "node:    $(node --version)"
+          echo "npm:     $(npm --version)"
+          echo "az:      $(az --version | head -1)"
+          echo "azd:     $(azd version)"
+          echo "func:    $(func --version)"
+
+      - name: Pre-warm @azure/mcp cache
+        run: npx -y @azure/mcp@latest server --help >/dev/null
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: azd login via federated token
+        shell: bash
+        run: |
+          set -euo pipefail
+          azd auth login \
+            --client-id "$AZURE_CLIENT_ID" \
+            --federated-credential-provider github \
+            --tenant-id "$AZURE_TENANT_ID"
+
+      - name: Compute run identifiers
+        id: ids
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHORT_RUN_ID="${GITHUB_RUN_ID: -8}"
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          ENV_NAME="afsvally-${SHORT_RUN_ID}-${SHORT_SHA}"
+          RG_NAME="rg-${ENV_NAME}"
+          CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          {
+            echo "env_name=$ENV_NAME"
+            echo "rg_name=$RG_NAME"
+            echo "created_at=$CREATED_AT"
+          } >> "$GITHUB_OUTPUT"
+          echo "AZURE_ENV_NAME=$ENV_NAME"
+          echo "AZURE_RESOURCE_GROUP=$RG_NAME"
+
+      - name: Pre-create tagged resource group
+        # Pre-creating the RG with vally-eval=true tags is how the
+        # cleanup safety net finds stale resources. azd / Bicep
+        # additions inside this RG inherit the same tag scope at the
+        # RG level even if the agent's templates do not set tags.
+        shell: bash
+        env:
+          RG_NAME: ${{ steps.ids.outputs.rg_name }}
+          CREATED_AT: ${{ steps.ids.outputs.created_at }}
+        run: |
+          set -euo pipefail
+          az group create \
+            --name "$RG_NAME" \
+            --location "$AZURE_LOCATION" \
+            --tags \
+              vally-eval=true \
+              "createdAt=$CREATED_AT" \
+              "run-id=$GITHUB_RUN_ID" \
+              "workflow=skill-evaluation-vally-live" \
+              "keep=${{ inputs.keep_resources || 'false' }}" \
+            --output none
+          echo "Created resource group: $RG_NAME"
+
+      - name: Run vally eval (live)
+        env:
+          # Step-scoped token (matches the regular Vally workflow).
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+          # azd / agent picked up from process env.
+          AZURE_ENV_NAME: ${{ steps.ids.outputs.env_name }}
+          AZURE_RESOURCE_GROUP: ${{ steps.ids.outputs.rg_name }}
+          EVAL_SPEC: ${{ inputs.eval_spec }}
+          MODEL: ${{ inputs.model }}
+        run: |
+          set -euo pipefail
+          MODEL_ARG=()
+          if [ -n "${MODEL:-}" ]; then
+            MODEL_ARG=(--model "$MODEL")
+          fi
+          if [ -n "${EVAL_SPEC:-}" ]; then
+            echo "Running single live spec: $EVAL_SPEC"
+            npx vally eval \
+              --eval-spec "$EVAL_SPEC" \
+              --output jsonl --output-dir ./vally-results --junit \
+              "${MODEL_ARG[@]}"
+          else
+            echo "Running live suite"
+            npx vally eval \
+              --suite live \
+              --output jsonl --output-dir ./vally-results --junit \
+              "${MODEL_ARG[@]}"
+          fi
+
+      - name: Cleanup Azure resources
+        if: always() && inputs.keep_resources != true
+        shell: bash
+        env:
+          ENV_NAME: ${{ steps.ids.outputs.env_name }}
+          RG_NAME: ${{ steps.ids.outputs.rg_name }}
+        run: |
+          set +e
+          echo "Attempting azd down for $ENV_NAME ..."
+          # azd down only works if the agent wrote .azure/<env>/ — in
+          # most failure modes that file is missing, so we always rely
+          # on the az group delete fallback below.
+          if [ -d ".azure/$ENV_NAME" ]; then
+            azd down --force --purge --no-prompt || true
+          fi
+          echo "Deleting resource group $RG_NAME (no-wait) ..."
+          az group delete --name "$RG_NAME" --yes --no-wait || {
+            echo "::error::Failed to delete resource group $RG_NAME — clean it up manually with: az group delete --name $RG_NAME --yes --no-wait"
+            exit 1
+          }
+          echo "Resource group $RG_NAME deletion submitted."
+
+      - name: Skip cleanup (keep_resources=true)
+        if: always() && inputs.keep_resources == true
+        shell: bash
+        env:
+          RG_NAME: ${{ steps.ids.outputs.rg_name }}
+        run: |
+          set -euo pipefail
+          echo "::warning::Azure resources NOT cleaned up (keep_resources=true). Resource group: $RG_NAME"
+          {
+            echo "## ⚠️ Azure resources kept for debugging"
+            echo ""
+            echo "**Resource group:** \`$RG_NAME\`"
+            echo ""
+            echo "Clean up manually when finished:"
+            echo ""
+            echo '```bash'
+            echo "az group delete --name $RG_NAME --yes --no-wait"
+            echo '```'
+            echo ""
+            echo "Otherwise the [cleanup-stale-vally-resources](../../actions/workflows/cleanup-stale-vally-resources.yml) safety net workflow will remove it after 24h."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vally-live-results-${{ github.run_id }}
+          path: vally-results/
+          if-no-files-found: warn

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -34,6 +34,14 @@ suites:
     filter:
       type: integration
 
+  live:
+    description: "Tier 3 — actually deploys Azure resources (manual / nightly only)"
+    filter:
+      tier: live
+
   full:
-    description: "All evals including LLM graders — nightly"
-    filter: {}
+    description: "All evals (including LLM graders, EXCLUDING live deploy) — nightly"
+    filter:
+      tier:
+        - smoke
+        - full

--- a/evals/README.md
+++ b/evals/README.md
@@ -56,7 +56,8 @@ Defined in [`.vally.yaml`](../.vally.yaml) at the repo root:
 | `pr` | `tier: smoke` | PR gate (alias of smoke) |
 | `triggers` | `area: routing` | all skill-invocation/routing checks |
 | `integration` | `type: integration` | LLM-backed behavior tests |
-| `full` | — | everything (nightly) |
+| `full` | `tier: [smoke, full]` | everything **except** live — nightly |
+| `live` | `tier: live` | **Tier 3 — deploys real Azure resources.** Manual / nightly only, via the dedicated [Skill Evaluation - Vally Live](../.github/workflows/skill-evaluation-vally-live.yml) workflow |
 
 ## Authoring conventions
 
@@ -112,6 +113,23 @@ See [`_base/common-graders.yaml`](_base/common-graders.yaml). Highlights:
   Copilot agent at least once, which incurs LLM cost.
 - `tier: smoke` stimuli are intentionally small (1 prompt × N runs) for PRs.
 - Nightly `full` runs should be gated behind workflow_dispatch or schedule.
+- `tier: live` stimuli additionally **create real Azure resources**. They run
+  only from the separate [Skill Evaluation - Vally Live](../.github/workflows/skill-evaluation-vally-live.yml)
+  workflow. See [`azure-functions-deploy/README.md`](azure-functions-deploy/README.md)
+  for the resource lifecycle, `keep_resources` debug option, and the
+  [cleanup-stale-vally-resources](../.github/workflows/cleanup-stale-vally-resources.yml)
+  safety net.
+
+## Live (Tier 3) workflow inputs
+
+The live workflow exposes the following `workflow_dispatch` inputs so a
+reviewer can iterate on one skill at a time:
+
+| input | type | default | effect |
+| --- | --- | --- | --- |
+| `eval_spec` | string | empty | path to a single eval spec (e.g. `evals/azure-functions-deploy/eval.yaml`); empty = run the full `live` suite |
+| `model` | string | empty | override the `claude-sonnet-4.6` default (e.g. `claude-opus-4.7`) |
+| `keep_resources` | boolean | `false` | **DEBUG ONLY.** Skip the per-run Azure cleanup step. The 24-hour safety net will still delete the resource group via the `vally-eval=true` tag |
 
 ## Model selection
 

--- a/evals/azure-functions-deploy/README.md
+++ b/evals/azure-functions-deploy/README.md
@@ -1,0 +1,68 @@
+# azure-functions-deploy — live evaluation
+
+This eval **deploys real Azure resources**. It runs only from the
+[Skill Evaluation - Vally Live](../../.github/workflows/skill-evaluation-vally-live.yml)
+workflow under the `functions-skills-live-e2e` GitHub Environment, which is gated
+by required reviewers (`Azure/azure-functions-bucees-team`,
+`prevent_self_review: false`).
+
+## What it tests
+
+| # | Stimulus | What it asserts |
+| --- | --- | --- |
+| 1 | Live — deploy TypeScript HTTP FC1 to Azure | `azure-functions-deploy` skill is invoked, agent runs the prepare → validate → deploy hand-off (or `azd up` directly), output contains a `*.azurewebsites.net` Function App URL, and no Azure error patterns appear |
+
+## Fixture
+
+Each stimulus seeds its workspace with the official Azure-Samples
+[`functions-quickstart-typescript-azd`](https://github.com/Azure-Samples/functions-quickstart-typescript-azd)
+template via `environment.commands`. The commit is pinned to
+`cba39229…` so the fixture is reproducible even if upstream changes.
+
+This intentionally separates "deploy" testing from "scaffold" testing:
+the project is already deploy-ready when the agent starts.
+
+## Resource lifecycle
+
+The live workflow:
+
+1. Pre-creates a resource group named `rg-afsvally-<runId>-<sha>` in
+   `eastus2`, tagged with `vally-eval=true`, `createdAt=<ISO>`,
+   `run-id=<id>`. These tags are how the safety net workflow finds
+   stale RGs.
+2. Sets `AZURE_RESOURCE_GROUP`, `AZURE_ENV_NAME`, `AZURE_LOCATION`,
+   `AZURE_SUBSCRIPTION_ID` for the eval step so the agent reuses the
+   pre-tagged RG.
+3. Runs `vally eval`.
+4. **Cleanup**:
+   - Default (`keep_resources: false`): `azd down --force --purge --no-prompt`,
+     falling back to `az group delete --yes --no-wait`. Runs in
+     `if: always()` so it executes even if the eval failed.
+   - Debug (`keep_resources: true`): cleanup step is skipped. A warning
+     annotation and the `az group delete` command for that run are
+     written to `$GITHUB_STEP_SUMMARY` so a human can investigate and
+     clean up later.
+5. The [cleanup-stale-vally-resources](../../.github/workflows/cleanup-stale-vally-resources.yml)
+   safety net workflow deletes any RG tagged `vally-eval=true` that is
+   older than 24h, so even forgotten `keep_resources` runs cannot linger.
+
+## Per-skill / per-spec invocation
+
+The live workflow accepts an `eval_spec` input:
+
+| input | effect |
+| --- | --- |
+| empty | run the entire `live` suite (`.vally.yaml` filter `tier: live`) |
+| `evals/azure-functions-deploy/eval.yaml` | run only this spec |
+
+Use this to iterate on a single skill without paying for the others.
+
+## Cost guardrails
+
+- Flex Consumption (FC1) plan only — scales to zero, idle cost ≈ 0.
+- `runs: 1` per stimulus.
+- One Function App + one storage account + one App Insights workspace
+  per run.
+- All resources deleted at the end of the run (or within 24h by the
+  safety net).
+- Subscription-level budget alert tracked in a follow-up issue.

--- a/evals/azure-functions-deploy/eval.yaml
+++ b/evals/azure-functions-deploy/eval.yaml
@@ -1,0 +1,134 @@
+name: azure-functions-deploy-live-eval
+description: |
+  Live (Tier 3) evaluation for the azure-functions-deploy skill.
+
+  This eval ACTUALLY DEPLOYS resources to Azure. It only runs from the
+  Skill Evaluation - Vally Live workflow under the
+  functions-skills-live-e2e GitHub Environment (reviewer-gated).
+
+  Fixture:
+    Each stimulus runs in a fresh Vally workspace seeded by
+    `environment.commands` with the official Azure-Samples Flex
+    Consumption TypeScript HTTP quickstart pinned to a known commit.
+    That gives us a deploy-ready project so the stimulus exercises
+    the deploy skill, not the create skill.
+
+  Environment variables (provided by the workflow):
+    AZURE_ENV_NAME        unique azd env name (e.g. afsvally-<runid>-<sha>)
+    AZURE_LOCATION        eastus2
+    AZURE_SUBSCRIPTION_ID
+    AZURE_RESOURCE_GROUP  pre-created by the workflow with tags
+                          vally-eval=true so the cleanup safety net
+                          can find it later
+
+  Notes:
+    - Built-in graders only. Global graders (`completed`,
+      `no_runtime_failure`) are duplicated into each stimulus per
+      evaluate#125.
+    - tier: live → suite filter excludes from smoke/pr/full so this
+      never runs accidentally from the regular Vally workflow.
+
+tags:
+  type: integration
+  skill: azure-functions-deploy
+
+config:
+  runs: 1
+  timeout: "30m"
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.95
+  weights:
+    skill-invocation: 2.0
+    output-matches: 1.0
+    output-not-matches: 1.5
+    completed: 1.0
+
+stimuli:
+  - name: "Live — deploy TypeScript HTTP FC1 to Azure"
+    prompt: |
+      The current workspace contains a deploy-ready Azure Functions project
+      (TypeScript, HTTP trigger, targeting Flex Consumption / FC1).
+
+      Please deploy it to my Azure subscription using the
+      azure-functions-deploy workflow.
+
+      Environment variables that are already set in this session:
+        - AZURE_ENV_NAME          (use as the azd environment name)
+        - AZURE_LOCATION          (eastus2)
+        - AZURE_SUBSCRIPTION_ID
+        - AZURE_RESOURCE_GROUP    (pre-created with tags; reuse, do not delete)
+
+      Use the existing resource group; do not create a new one. After the
+      deploy finishes, report the Function App's HTTPS hostname so I can
+      verify it.
+
+      Do NOT run `azd down` — the workflow handles cleanup outside this
+      session.
+
+    tags:
+      type: integration
+      skill: azure-functions-deploy
+      tier: live
+      cost: azure
+      area: e2e-deploy
+
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-deploy
+        - ../../templates/skills/azure-functions-common
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
+      commands:
+        # Materialize the deploy-ready fixture inside the per-stimulus
+        # workspace. Pinned commit so the fixture is reproducible across
+        # runs even if upstream changes.
+        - "git init -q ."
+        - "git remote add origin https://github.com/Azure-Samples/functions-quickstart-typescript-azd.git"
+        - "git fetch --depth 1 -q origin cba392291ff7b6c994548aabaa8c06eb4055be54"
+        - "git checkout -q FETCH_HEAD"
+        - "rm -rf .git"
+
+    constraints:
+      max_turns: 40
+      max_duration: "25m"
+
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-deploy
+
+      # Must mention the Azure Skills hand-off in some form (the deploy
+      # skill's primary contract).
+      - type: output-matches
+        config:
+          pattern: "(?i)azure-(prepare|validate|deploy)|azd up"
+
+      # Must emit the Function App's azurewebsites.net hostname (proof
+      # that the deploy completed and got a URL back).
+      - type: output-matches
+        config:
+          pattern: "https?://[a-z0-9-]+\\.azurewebsites\\.net"
+
+      # Skill explicitly says: do not verify HTTP triggers with HEAD.
+      - type: output-not-matches
+        config:
+          pattern: "curl\\s+-I\\s+https?://"
+
+      # Common deployment failure signals.
+      - type: output-not-matches
+        config:
+          pattern: "(?i)quota exceeded|InvalidTemplateDeployment|AuthorizationFailed|SubscriptionNotRegistered|InsufficientPermissions"
+
+      # Globals
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"


### PR DESCRIPTION
## Summary

First **Tier 3 (live)** Vally eval — actually deploys to Azure — for the `azure-functions-deploy` skill, plus the two surrounding workflows that make it safe to run from CI:

| Component | Purpose |
| --- | --- |
| `evals/azure-functions-deploy/eval.yaml` | Single stimulus: clone the official `Azure-Samples/functions-quickstart-typescript-azd` template at a pinned commit into the workspace, ask the agent to deploy it, and grade against routing + `*.azurewebsites.net` hostname + Azure failure patterns |
| `.github/workflows/skill-evaluation-vally-live.yml` | Reviewer-gated workflow that runs the live eval. Inputs: `eval_spec` (per-skill selection), `model`, `keep_resources` (debug) |
| `.github/workflows/cleanup-stale-vally-resources.yml` | Daily safety net that deletes any RG tagged `vally-eval=true` older than 24h |
| `.vally.yaml` | New `live` suite; existing `full` suite tightened to `tier: [smoke, full]` so live is **opt-in only** |
| Issue #153 | Follow-up: configure subscription-level budget alert |

## Spec → implementation map

Reflects the user decisions from the spec discussion:

| Decision | Implementation |
| --- | --- |
| 1. T3, but allow per-skill selection in CI | `workflow_dispatch input eval_spec` — empty runs the `live` suite, set to a single path to iterate on one skill |
| 2. FC1 only | Fixture template = `Azure-Samples/functions-quickstart-typescript-azd` (FC1) |
| 3. `eastus2` | Set as `AZURE_LOCATION` env in the workflow |
| 4. Budget alert as separate English issue | #153 |
| 5. Safety net in same PR | `cleanup-stale-vally-resources.yml` included |
| 6. Reviewer gate is enough for `keep_resources` access control | `functions-skills-live-e2e` env (existing, `Azure/azure-functions-bucees-team`, `prevent_self_review: false`) |

## Resource lifecycle

```
workflow start
  ├─ azure/login@v3              (OIDC, federated)
  ├─ azd auth login              (--federated-credential-provider github)
  ├─ az group create $RG_NAME    (eastus2, tags vally-eval=true createdAt=<ISO> run-id=<id>)
  ├─ vally eval                  (agent runs azd up into $RG_NAME)
  └─ if always():
       if keep_resources != true:
         azd down --force --purge   (best effort, when .azure/<env>/ exists)
         az group delete --yes --no-wait   (fallback / primary)
       else:
         emit ::warning:: + step summary with manual delete command

24h later, regardless of run outcome:
  cleanup-stale-vally-resources.yml
    ├─ list groups tagged vally-eval=true
    ├─ parse createdAt tag, compare to now - max_age_hours
    └─ delete every stale group (or print dry-run list)
```

### Why both per-run cleanup AND a daily safety net

- Per-run cleanup keeps the steady state quiet (resources gone within minutes of a run finishing).
- Safety net protects against `keep_resources: true` being forgotten, the per-run cleanup step itself failing, or the eval job being cancelled mid-cleanup.
- Issue #153 adds a *third* layer (subscription budget alert) so even a coordinated failure of both is bounded.

## Security posture (unchanged from #141 / #150)

- `COPILOT_GITHUB_TOKEN` (mapped from `COPILOT_CLI_TOKEN`) is set **only at step level** on `Run vally eval (live)`. Checkout / install / azure-login / cleanup steps never see it.
- Azure identifiers are masked at job start with `::add-mask::`.
- The cleanup workflow holds no Copilot token at all; it only needs Azure creds.
- Both new workflows are pinned to `functions-skills-live-e2e`, so any execution requires reviewer approval.

## Validation

- `npx vally lint --eval-spec evals` ✔ (all three eval.yaml files valid: create, setup, deploy)
- YAML parse of both new workflow files ✔
- Per-suite filter check: `live` matches only the new stimulus; `full` excludes it.

End-to-end validation requires merging to `main` and a reviewer dispatching the new workflow. Recommended first run:

```
workflow_dispatch:
  eval_spec:       evals/azure-functions-deploy/eval.yaml
  model:           (empty)
  keep_resources:  false
```

## Out of scope (separate PRs / issues)

- **#149** — `azure-functions-create` skill description bug (independent).
- **#153** — Azure subscription budget alert (follow-up).
- Additional live evals for `azure-functions-doctor`, `azure-functions-diagnostics`, etc. — one per follow-up PR, once this pattern is proven.
- Tier 2 (plan/preview) layer that could run in the PR gate without creating resources — a future option once this PR is stable.
