### PR TITLE
chore: add AGENTS.md, custom instructions, and reusable prompts for dev harness

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,27 @@
+# Copilot Instructions
+
+This repository is the **Azure Functions Skills** CLI and plugin system — it equips coding agents (GitHub Copilot, Claude Code, Codex) with Azure Functions–specific knowledge.
+
+## Key Rules
+
+- **TypeScript strict mode** — no `any` types; use interfaces and generics.
+- **ESM only** — `import`/`export`, never `require()`.
+- **TDD** for code changes — write tests first (`npm test`, `npm run test:watch`).
+- **Lint before commit** — `npm run lint` and `npm run typecheck`.
+- **Templates are canonical** — edit `templates/`, then `npm run build:plugin-payload`. Never hand-edit generated files.
+- **CLI usability** — commands must be intuitive; error messages must be actionable.
+- **E2E for CLI changes** — verify with `node bin/azure-functions-skills.js <cmd> --dir <isolated-workspace>`.
+
+## Security
+
+- No secrets in code.
+- Never run Vally evals on PR code — prompt injection risk. Use GitHub Environment with reviewer gate.
+- Never run `doctor --deep` on untrusted workspaces.
+
+## Full Gate
+
+```bash
+npm run check   # lint + typecheck + security lint + skill validation + tests + build
+```
+
+See `AGENTS.md` at repo root for the complete development standards.

--- a/.github/instructions/cli.instructions.md
+++ b/.github/instructions/cli.instructions.md
@@ -1,0 +1,36 @@
+---
+applyTo: "bin/**,src/setup/**,src/chat/**"
+---
+
+# CLI Development Rules
+
+## Usability First
+
+- The CLI is designed with usability as the top priority.
+- Commands must be intuitive — users should never feel lost or confused.
+- Error messages must be specific and actionable: tell the user *what went wrong* and *what to do next*.
+- Provide helpful defaults so common workflows require minimal flags.
+
+## Output
+
+- Keep output concise and scannable.
+- Use color and formatting consistently (success = green, error = red, warning = yellow).
+- Progress indicators for long-running operations.
+- Respect `--quiet` and `--json` flags where applicable.
+
+## After Changes
+
+- Always compile: `npm run compile`
+- Run unit tests: `npm test`
+- **E2E verification is mandatory**: test the actual CLI command in an isolated workspace.
+  ```bash
+  node bin/azure-functions-skills.js <cmd> --dir <isolated-workspace>
+  ```
+- Never run `setup` or `chat` from the repo root — it pollutes the working tree.
+
+## Architecture
+
+- CLI entry point: `bin/azure-functions-skills.js`
+- Domain modules: `src/doctor/`, `src/setup/`, `src/chat/`, `src/build/`
+- Keep option parsing in `bin/`; keep business logic in `src/`.
+- Separate concerns — do not mix I/O, validation, and domain logic in one function.

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -1,0 +1,30 @@
+---
+applyTo: "templates/**"
+---
+
+# Skill and Template Development Rules
+
+## Canonical Source
+
+- `templates/` is the single source of truth for all agents, skills, hooks, prompts, MCP, and routing definitions.
+- Generated files under `.github/plugins/`, `.plugin/`, and `.claude-plugin/` are derived — never hand-edit them.
+
+## Workflow
+
+1. Edit the canonical source under `templates/`.
+2. Validate: `npm run validate:skills`
+3. Regenerate: `npm run build:plugin-payload`
+4. Verify: `npm run verify:plugin-payload`
+5. Run full gate: `npm run check`
+
+## Skill Content
+
+- Skill Markdown (`SKILL.md`) is loaded as LLM agent instructions. Write clearly and unambiguously.
+- Include `references/` for checklists, examples, and supporting material.
+- Tag skills with proper YAML front matter (name, title, description, category).
+
+## Security
+
+- Skill content can instruct an LLM agent with file-write and shell-execution permissions. Review every change carefully for prompt injection risks.
+- Never include executable commands that could be harmful if run verbatim by an agent.
+- CI runs `npm run lint:security` (including `lint-skill-content.mjs`) to scan for dangerous patterns.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,33 @@
+---
+applyTo: "tests/**"
+---
+
+# Testing Rules
+
+## Framework
+
+- This project uses **Vitest** for all unit tests.
+- Test files: `tests/*.test.ts`
+- Fixtures: `tests/fixtures/`
+- Run: `npm test` (single run) or `npm run test:watch` (TDD mode)
+
+## TDD Workflow
+
+1. **Red**: Write a failing test that describes the expected behavior.
+2. **Green**: Write the minimal implementation to make the test pass.
+3. **Refactor**: Improve code quality without changing behavior.
+4. Repeat for each unit of work.
+
+## Test Quality
+
+- Test behavior, not implementation details.
+- Cover edge cases and boundary values.
+- Include both happy path and error path tests.
+- Use descriptive test names: `describe('functionName', () => { it('should do X when Y', ...) })`.
+- Keep tests independent — no shared mutable state between tests.
+
+## Fixtures
+
+- Bad-app fixtures for doctor checks live in `tests/fixtures/doctor-bad-apps/`.
+- Expected results are documented in `tests/fixtures/doctor-bad-apps/expected-results.md`.
+- When adding a new doctor check, add a corresponding fixture and update expected results.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: "**/*.ts"
+---
+
+# TypeScript Code Generation Rules
+
+## Strict Mode
+
+- All code must pass `tsc --noEmit` with the project's strict tsconfig.
+- Never use `any`. Use proper interfaces, generics, or `unknown` with type guards.
+- Prefer `readonly` properties where mutation is not needed.
+
+## Module System
+
+- This project uses ESM (`"type": "module"` in package.json).
+- Use `import`/`export` — never `require()`.
+- Use named exports; avoid default exports.
+
+## Error Handling
+
+- Throw typed errors with descriptive messages.
+- Catch errors at appropriate boundaries; do not swallow errors silently.
+- Prefix intentionally unused caught errors with `_` (e.g., `catch (_err)`).
+
+## Style
+
+- Prefix intentionally unused parameters with `_`.
+- Remove unused imports, variables, and functions.
+- Keep functions small and focused on a single responsibility.
+- Extract shared logic into helper functions — do not duplicate code.
+
+## TDD
+
+- Write failing tests first, then implement.
+- When the task is purely configuration or documentation, TDD is not required.

--- a/.github/prompts/checklist-plan.prompt.md
+++ b/.github/prompts/checklist-plan.prompt.md
@@ -1,0 +1,16 @@
+---
+description: "Create a checklist-driven implementation plan and execute step by step"
+name: "checklist-plan"
+---
+
+Analyze the task and create an implementation plan following this structure:
+
+1. **Investigate** — survey the affected files and understand the current behavior.
+2. **Plan** — produce a numbered checklist in `plan.md` with clear, actionable steps.
+3. **Execute** — work through each step one at a time; mark each item done as you go.
+4. **Verify** — after all steps, run `npm run check` and confirm everything passes.
+
+For code changes, follow TDD: write a failing test before implementing each step.
+For non-code tasks (skills, CI, docs), skip TDD but still verify at the end.
+
+Update the checklist after completing each step so progress is always visible.

--- a/.github/prompts/cli-e2e.prompt.md
+++ b/.github/prompts/cli-e2e.prompt.md
@@ -1,0 +1,17 @@
+---
+description: "Verify CLI changes with end-to-end execution"
+name: "cli-e2e"
+---
+
+Verify CLI changes by running actual commands in an isolated workspace:
+
+1. Compile: `npm run compile`
+2. Verify help: `node bin/azure-functions-skills.js --help`
+3. Run the modified subcommand with `--dir <isolated-workspace>` to avoid repo root pollution.
+4. For setup/chat flows, create a temporary workspace first:
+   ```bash
+   node bin/azure-functions-skills.js setup --agent ghcp --dir <temp-dir> --skip-prerequisites
+   node bin/azure-functions-skills.js chat --agent github-copilot --dir <temp-dir> --skip-prerequisites -- -p "List skills"
+   ```
+5. Confirm output is correct, no errors, and messages are user-friendly.
+6. Check that the command behaves intuitively — no confusing prompts or ambiguous output.

--- a/.github/prompts/cross-review.prompt.md
+++ b/.github/prompts/cross-review.prompt.md
@@ -1,0 +1,18 @@
+---
+description: "Cross-model self-review using /rubber-duck with a different model family"
+name: "cross-review"
+---
+
+Perform a cross-model self-review after implementation:
+
+1. Check the current model with `/model`.
+2. Switch to a different model family for independent validation:
+   - If currently using Claude (Ops family) → switch to the latest top-tier GPT model.
+   - If currently using GPT → switch to the latest top-tier Claude model.
+3. Run `/rubber-duck` to walk through the implementation and catch blind spots.
+4. Review the feedback for:
+   - Correctness and robustness
+   - Edge cases and error handling
+   - Architectural soundness
+   - Test coverage gaps
+5. Address any valid findings before finalizing.

--- a/.github/prompts/dev-tdd.prompt.md
+++ b/.github/prompts/dev-tdd.prompt.md
@@ -1,0 +1,18 @@
+---
+description: "Implement a feature using TDD (Red → Green → Refactor)"
+name: "dev-tdd"
+---
+
+Follow the TDD cycle to implement the requested feature:
+
+1. **Red** — write a failing test that describes the expected behavior.
+2. **Green** — write the minimal code to make the test pass.
+3. **Refactor** — improve code quality without changing behavior (DRY, clear naming, proper abstractions).
+4. Run `npm test` after each cycle to confirm the test suite stays green.
+5. Repeat for each unit of work until the feature is complete.
+
+After all cycles:
+- Run `npm run lint` to catch style issues.
+- Run `npm run typecheck` to confirm type safety.
+- Ensure proper separation of concerns — no god functions, no duplicated logic.
+- If CLI behavior changed, verify with an E2E run in an isolated workspace.

--- a/.github/prompts/doctor-check.prompt.md
+++ b/.github/prompts/doctor-check.prompt.md
@@ -1,0 +1,18 @@
+---
+description: "Add a new doctor check with TDD and fixtures"
+name: "doctor-check"
+---
+
+Add a new doctor check following the established pattern:
+
+1. **Test first** — add a test case in `tests/doctor-checks.test.ts` for the new check.
+2. **Implement** — add a `DoctorCheck` to `src/doctor/checks.ts` with `id`, `category`, `defaultSeverity`, `appliesTo`, and `run`.
+3. **Register** — add the check to `ALL_CHECKS`.
+4. **Fixture** — add a bad-app fixture in `tests/fixtures/doctor-bad-apps/` that triggers the check.
+5. **Expected results** — update `tests/fixtures/doctor-bad-apps/expected-results.md`.
+6. **Verify**:
+   ```bash
+   npm test
+   npm run lint
+   ```
+7. Optionally run a manual E2E with the doctor-e2e scripts (see `docs/bad-app-fixtures.md`).

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,0 +1,17 @@
+---
+description: "Run a self-review checklist before opening a PR"
+name: "pr-review"
+---
+
+Review the current changes against this checklist:
+
+1. **Architecture** — is the separation of concerns appropriate? Are responsibilities clearly divided?
+2. **Duplication** — does the code follow DRY? Is any logic repeated that should be extracted?
+3. **Test coverage** — are edge cases, boundary values, and error paths tested?
+4. **Security** — no secrets exposed, no unsafe input handling, no prompt injection vectors in skill content.
+5. **Usability** (CLI changes) — are commands intuitive? Are error messages actionable?
+6. **Lint & types** — does `npm run lint` and `npm run typecheck` pass cleanly?
+7. **Documentation** — do affected docs (README, cli-reference.md, doctor-guide.md) need updates?
+8. **Generated files** — if templates changed, was `npm run build:plugin-payload` run?
+
+After the checklist, use `/rubber-duck` with a different model family for a cross-model review.

--- a/.github/prompts/skill-dev.prompt.md
+++ b/.github/prompts/skill-dev.prompt.md
@@ -1,0 +1,17 @@
+---
+description: "Scaffold and validate a new skill end to end"
+name: "skill-dev"
+---
+
+Create a new skill following the established workflow:
+
+1. Scaffold: `npm run new:skill` and follow the prompts.
+2. Edit `templates/skills/<skill-name>/SKILL.md` — write clear, unambiguous instructions.
+3. Add supporting material in `references/` (checklists, examples, patterns).
+4. Validate: `npm run validate:skills`
+5. Regenerate plugin payload: `npm run build:plugin-payload`
+6. Verify payload consistency: `npm run verify:plugin-payload`
+7. Run full gate: `npm run check`
+8. Optionally add a Vally evaluation spec under `evals/<skill-name>/eval.yaml`.
+
+Review the skill content carefully — it will be loaded as LLM agent instructions with elevated permissions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# Azure Functions Skills — Development Standards
+
+> These instructions apply to all coding agents working in this repository.
+
+## Project Overview
+
+- **What**: CLI tool + plugin system that equips coding agents with Azure Functions–specific knowledge
+- **Stack**: TypeScript (strict), Node.js 18+, ESM
+- **Targets**: GitHub Copilot CLI, Claude Code, Codex CLI
+- **Testing**: Vitest for unit tests, Vally for skill evaluation (LLM-backed)
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Build | `npm run build` |
+| Compile only | `npm run compile` |
+| Unit tests | `npm test` |
+| Tests (watch) | `npm run test:watch` |
+| Lint | `npm run lint` |
+| Type check | `npm run typecheck` |
+| Security lint | `npm run lint:security` |
+| Skill validation | `npm run validate:skills` |
+| Plugin payload verify | `npm run verify:plugin-payload` |
+| Full gate | `npm run check` |
+| Eval smoke | `npm run eval:smoke` |
+
+## Code Style
+
+- TypeScript strict mode — avoid `any` types; use proper interfaces and generics.
+- Named exports; no default exports.
+- Prefix intentionally unused parameters with `_`.
+- Conventional commits: `feat:`, `fix:`, `test:`, `docs:`, `chore:`, `refactor:`.
+- Remove unused imports, variables, and functions before committing.
+
+## Architecture
+
+- Separate concerns by domain: `src/doctor/`, `src/setup/`, `src/chat/`, `src/build/`.
+- Avoid duplicate code — extract shared logic into helpers.
+- `templates/` is the canonical source; generated payloads are derived.
+- Never hand-edit files under `.github/plugins/`, `.plugin/`, or `.claude-plugin/`. Change `templates/`, then regenerate with `npm run build:plugin-payload`.
+
+## Testing
+
+- **TDD**: Write tests first. Every new function or module must have tests before implementation.
+- Unit tests live in `tests/*.test.ts`.
+- Use `npm run test:watch` during TDD cycles.
+- Run `npm test` before every commit.
+- CLI changes require E2E verification: `node bin/azure-functions-skills.js <cmd> --dir <isolated-workspace>`.
+- When the task is not code-related (skills, CI config, documentation), TDD is not required.
+
+## Security
+
+- No secrets in code — use environment variables or secret managers.
+- No npm lifecycle scripts except `prepack`. Adding `postinstall`, `preinstall`, etc. is forbidden.
+- Run `npm run lint:security` for supply-chain checks.
+- **Never run Vally evals on PR code.** PR code is unreviewed and may contain prompt injection attacks. Skill content is loaded as LLM instructions and the agent has file-write and shell-execution permissions. Always use a GitHub Environment with a reviewer gate so only reviewed code is evaluated.
+- Never run `doctor --deep` on untrusted workspaces.
+
+## Boundaries
+
+- Never edit generated files under `.github/plugins/`, `.plugin/`, `.claude-plugin/`.
+- Never commit `local.settings.json` or `.env` files.
+- Do not run `setup` or `chat` from the repo root — use `--dir <isolated-workspace>` to avoid pollution.
+- Do not touch `templates/agents/AGENTS.md` — that is the user-facing template, not this repo's dev standards.
+
+## Before Committing
+
+1. `npm run lint`
+2. `npm run typecheck`
+3. `npm test`
+4. CLI changes → E2E verify with real agent
+5. Template changes → `npm run build:plugin-payload` then `npm run verify:plugin-payload`
+
+## After Implementation
+
+- Use `/rubber-duck` for self-review with a different model family.
+  - If the current model is Claude (Ops family), switch to a GPT-family top model.
+  - If the current model is GPT, switch to a Claude top model.
+  - Use `/model` to switch, then `/rubber-duck` to review.
+
+## Language Policy
+
+- Respond in the user's language.
+- PRs, source code, and documentation included in PRs must be in English unless otherwise specified.
+- Temporary files created for user explanation (reports, proposals, etc.) should use the user's language.
+
+## Multi-Account (EMU + Public)
+
+- Some contributors use both GitHub EMU (enterprise) and public GitHub accounts.
+- If work stalls due to authentication or permission errors, check whether the active account matches the target repository.
+- Switch accounts with `/user switch` or `gh auth login` to match the repo's organization.
+- EMU orgs require SSO authentication; public repos use personal accounts.


### PR DESCRIPTION
## What

Add development harness configuration files so coding agents (GitHub Copilot CLI, Claude Code, Codex) automatically receive project-specific guidance when working in this repository.

## Files Added (13 files, 375 lines)

### AGENTS.md (repo root)
Development standards auto-loaded by all coding agents. Covers:
- Project overview and key commands
- Code style, architecture, and TDD workflow
- Security policy: **Vally evals must never run on PR code** (prompt injection risk); use GitHub Environment with reviewer gate
- Language policy (respond in user's language; PRs/code/docs in English)
- Multi-account (EMU + public) guidance

### .github/instructions/ (4 files)
Context-specific instructions loaded by Copilot CLI based on file patterns:
- **typescript.instructions.md** — strict mode, ESM, error handling, TDD
- **cli.instructions.md** — usability-first design, E2E verification mandatory
- **skills.instructions.md** — canonical template workflow, security review
- **testing.instructions.md** — Vitest, TDD cycle, fixture conventions

### .github/prompts/ (7 files)
Reusable workflow prompts invocable via slash commands:
- **/checklist-plan** — implementation plan with step-by-step checklist
- **/dev-tdd** — TDD (Red → Green → Refactor) workflow
- **/pr-review** — self-review checklist before opening PR
- **/cli-e2e** — CLI change E2E verification
- **/skill-dev** — new skill scaffold-to-validation workflow
- **/cross-review** — cross-model review (Claude ↔ GPT)
- **/doctor-check** — add a doctor check with TDD and fixtures

### .github/copilot-instructions.md
Concise global instructions for VS Code Copilot Chat users.

## Why

- No repo-root AGENTS.md existed — agents had no project-specific guidance
- No custom instructions or reusable prompts were configured
- User requirements: TDD workflow, lint enforcement, E2E for CLI changes, cross-model review, usability focus

## How to Test

\\\ash
# Verify files are recognized
npx @anthropic-ai/copilot-cli /env    # or /instructions in Copilot CLI
\\\

Lint passes (\
pm run lint\). No code changes — documentation/configuration only.