### PR TITLE
fix(eval): use tool-calls grader for deploy assertion + security regression guard

### DIFF
--- a/evals/azure-functions-deploy/README.md
+++ b/evals/azure-functions-deploy/README.md
@@ -10,7 +10,19 @@ by required reviewers (`Azure/azure-functions-bucees-team`,
 
 | # | Stimulus | What it asserts |
 | --- | --- | --- |
-| 1 | Live — deploy TypeScript HTTP FC1 to Azure | `azure-functions-deploy` skill is invoked, agent runs the prepare → validate → deploy hand-off (or `azd up` directly), output contains a `*.azurewebsites.net` Function App URL, and no Azure error patterns appear |
+| 1 | Live — deploy TypeScript HTTP FC1 to Azure | `azure-functions-deploy` skill is invoked; the agent **actually invokes `azd up`/`provision`/`deploy`** (verified via the `tool-call` grader against the trajectory, not the final message); the agent does **not** run `azd down` (cleanup is the workflow's job); the final summary contains a `*.azurewebsites.net` Function App URL; no known Azure failure patterns; **no silent security regression** (agent must not silently fall back from Managed Identity to a storage connection string) |
+
+### Why the deploy check uses `tool-call`, not `output-matches`
+
+`trajectory.output` is the agent's **final assistant message only** — a
+result-focused summary. Even on a successful deploy the agent's last
+message may not echo the literal string `azd up`. We learned this the
+hard way on [run #26702663944](https://github.com/Azure/azure-functions-skills/actions/runs/26702663944):
+the deploy succeeded end-to-end (a real `*.azurewebsites.net` URL was
+returned) but `output-matches /azd up/` failed because the summary
+focused on "what was provisioned" rather than "how I did it". The
+`tool-call` grader sees every bash command issued during the session,
+which is the right place to assert on agent behavior.
 
 ## Fixture
 

--- a/evals/azure-functions-deploy/eval.yaml
+++ b/evals/azure-functions-deploy/eval.yaml
@@ -42,6 +42,7 @@ scoring:
   threshold: 0.95
   weights:
     skill-invocation: 2.0
+    tool-calls: 2.0
     output-matches: 1.0
     output-not-matches: 1.5
     completed: 1.0
@@ -105,11 +106,26 @@ stimuli:
           required:
             - azure-functions-deploy
 
-      # Must mention the Azure Skills hand-off in some form (the deploy
-      # skill's primary contract).
-      - type: output-matches
+      # The deploy must actually happen via azd. We check the agent's
+      # tool calls directly (not the final assistant message) because
+      # `trajectory.output` is just the last message — a result-focused
+      # summary that may not echo command names like `azd up` even on
+      # a successful deploy. The tool-call grader sees every bash
+      # command the agent issued during the session.
+      - type: tool-calls
         config:
-          pattern: "(?i)azure-(prepare|validate|deploy)|azd up"
+          required:
+            - name: "^(bash|powershell|read_bash|run)$"
+              command: "\\bazd\\s+(up|provision|deploy)\\b"
+
+      # Agent must NOT tear down the resources it created — cleanup is
+      # owned by the workflow, not the agent. (Skill spec already says
+      # this in the prompt; this is the enforcement.)
+      - type: tool-calls
+        config:
+          disallowed:
+            - name: "^(bash|powershell|read_bash|run)$"
+              command: "\\bazd\\s+down\\b"
 
       # Must emit the Function App's azurewebsites.net hostname (proof
       # that the deploy completed and got a URL back).
@@ -126,6 +142,17 @@ stimuli:
       - type: output-not-matches
         config:
           pattern: "(?i)quota exceeded|InvalidTemplateDeployment|AuthorizationFailed|SubscriptionNotRegistered|InsufficientPermissions"
+
+      # Security regression guard: the FC1 quickstart template uses
+      # Managed Identity for both deployment storage and runtime
+      # storage. If the agent silently falls back to connection strings
+      # (e.g. because of missing roleAssignments/write), this grader
+      # turns red so we notice the security posture drop. The check is
+      # against the final summary because the agent typically reports
+      # the workaround it took.
+      - type: output-not-matches
+        config:
+          pattern: "(?i)connection string instead of managed identity|switching .* to use .* connection string"
 
       # Globals
       - type: completed


### PR DESCRIPTION
## Summary

Follow-up to [run #26702663944](https://github.com/Azure/azure-functions-skills/actions/runs/26702663944/job/78698266380) where the live deploy succeeded end-to-end (a real `*.azurewebsites.net` URL was returned and 5 of 6 graders passed) but the eval was marked **failed** because one `output-matches` grader expected the literal string `azd up` or `azure-(prepare|validate|deploy)` in the agent's final message.

The agent **did** call `azd up` (55 tool calls including 39 `bash` invocations), but its final summary was result-focused ("Deployment complete! Your Function App is live at https://...") and never echoed the command name. `trajectory.output` is only the last assistant message, so an `output-matches` grader against process keywords is the wrong primitive — we should check the trajectory itself.

## Changes

### `evals/azure-functions-deploy/eval.yaml`

1. **Replace** the failing `output-matches /azd up|azure-(prepare|validate|deploy)/` grader with a `tool-calls` grader:
   ```yaml
   - type: tool-calls
     config:
       required:
         - name: "^(bash|powershell|read_bash|run)$"
           command: "\\bazd\\s+(up|provision|deploy)\\b"
   ```
   This sees every command the agent issued during the session — the right place to assert agent behavior.

2. **Add** a `tool-calls disallowed` grader for `azd down`. Cleanup is owned by the workflow, not the agent; the prompt already says "do not run `azd down`", this enforces it.

3. **Add** an `output-not-matches` grader that catches the **security regression** observed in the failing run: the SP lacked `Microsoft.Authorization/roleAssignments/write`, so the agent silently switched the FC1 quickstart's Managed Identity wiring to a storage **connection string**. That posture drop is now caught as a failed grader instead of staying invisible. (The SP has since been granted `Role Based Access Control Administrator` so the MI path should work; this grader is the guard against future regressions.)

4. **`scoring.weights`**: add `tool-calls: 2.0` (parity with `skill-invocation`).

### `evals/azure-functions-deploy/README.md`

Document the rationale ("why the deploy check uses `tool-call`, not `output-matches`") with a back-reference to the failed run for future maintainers who hit the same trap.

## Validation

- `npx vally lint --eval-spec evals/azure-functions-deploy/eval.yaml` ✔
- Confirmed grader type spelling — the built-in is `tool-calls` (plural).

End-to-end validation requires another `workflow_dispatch` of the live workflow on `main` after merge. Expected outcome (given the SP role fix already applied):

| grader | expectation |
| --- | --- |
| `skill-invocation` (azure-functions-deploy) | ✅ |
| `tool-calls` required (`azd up`/`provision`/`deploy`) | ✅ — agent now graded on actual behavior |
| `tool-calls` disallowed (`azd down`) | ✅ |
| `output-matches` (`*.azurewebsites.net`) | ✅ |
| `output-not-matches` (HEAD) | ✅ |
| `output-not-matches` (Azure failure patterns) | ✅ |
| `output-not-matches` (MI → connection-string regression) | ✅ — should pass now that SP has RBAC Admin |
| `completed` | ✅ |
| `output-not-matches` (panics) | ✅ |

If the MI-fallback grader fires on the next run, that means the SP still cannot assign roles — needs a separate look at the actual Bicep + role definitions used by the quickstart.

## Related

- #154 — parent PR introducing the live deploy eval and workflows (merged).
- #149 — `azure-functions-create` skill description (separate signal).
- #153 — budget alert follow-up.
