### PR TITLE
chore(release): 0.0.4-preview

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Azure Functions coding agent skills and MCP guidance",
-    "version": "0.0.3-preview"
+    "version": "0.0.4-preview"
   },
   "plugins": [
     {
       "name": "azure-functions-skills",
       "source": "./.github/plugins/azure-functions-skills",
       "description": "Azure Functions skills for setup, create, and deploy workflows",
-      "version": "0.0.3-preview",
+      "version": "0.0.4-preview",
       "category": "Development",
       "tags": [
         "azure-functions",

--- a/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.4-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/"
 }

--- a/.github/plugins/azure-functions-skills/.codex-plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.4-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.github/plugins/azure-functions-skills/.plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.4-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.github/plugins/azure-functions-skills/plugin.json
+++ b/.github/plugins/azure-functions-skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.4-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.plugin/marketplace.json
+++ b/.plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Azure Functions coding agent skills and MCP guidance",
-    "version": "0.0.3-preview"
+    "version": "0.0.4-preview"
   },
   "plugins": [
     {
       "name": "azure-functions-skills",
       "source": "./.github/plugins/azure-functions-skills",
       "description": "Azure Functions skills for setup, create, and deploy workflows",
-      "version": "0.0.3-preview",
+      "version": "0.0.4-preview",
       "category": "Development",
       "tags": [
         "azure-functions",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.4-preview",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/functions-skills",
-      "version": "0.0.3-preview",
+      "version": "0.0.4-preview",
       "license": "MIT",
       "bin": {
         "azure-functions-skills": "bin/azure-functions-skills.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.4-preview",
   "description": "AI assistant plugins for Azure Functions — one-command setup for GitHub Copilot, Claude Code, and Codex",
   "type": "module",
   "bin": {

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -288,9 +288,10 @@ describe('CLI command integration', () => {
   });
 
   it('--version prints package version', () => {
+    const expectedVersion = JSON.parse(readFileSync(join(ROOT_DIR, 'package.json'), 'utf-8')).version;
     const output = runCliOutput(['--version']);
     expect(output).toMatch(/^\d+\.\d+\.\d+/);
-    expect(output).toContain('0.0.3-preview');
+    expect(output).toContain(expectedVersion);
   });
 
   it('prints focused help for top-level help and command help forms', () => {


### PR DESCRIPTION
Published @azure/functions-skills 0.0.4-preview to npm and prepared the release branch for tagging.

This PR only bumps package metadata to 0.0.4-preview so we can tag and draft the GitHub release from the v0.0.4-preview tag workflow.