### PR TITLE
fix(eval): exclude read_bash from command-based tool-call graders

### DIFF
--- a/evals/azure-functions-deploy/eval.yaml
+++ b/evals/azure-functions-deploy/eval.yaml
@@ -111,11 +111,12 @@ stimuli:
       # `trajectory.output` is just the last message — a result-focused
       # summary that may not echo command names like `azd up` even on
       # a successful deploy. The tool-call grader sees every bash
-      # command the agent issued during the session.
+      # command the agent issued during the session. Only include tools
+      # with a `command` argument here; read_bash only has `shellId`.
       - type: tool-calls
         config:
           required:
-            - name: "^(bash|powershell|read_bash|run)$"
+            - name: "^(bash|powershell|run)$"
               command: "\\bazd\\s+(up|provision|deploy)\\b"
 
       # Agent must NOT tear down the resources it created — cleanup is
@@ -124,7 +125,7 @@ stimuli:
       - type: tool-calls
         config:
           disallowed:
-            - name: "^(bash|powershell|read_bash|run)$"
+            - name: "^(bash|powershell|run)$"
               command: "\\bazd\\s+down\\b"
 
       # Must emit the Function App's azurewebsites.net hostname (proof


### PR DESCRIPTION
Fixes the live deploy eval grader failure seen in run 26777956035.

The deployment completed successfully, but the command-based tool-call grader included read_bash. That tool only has shellId, not command, so Vally reported a grader error instead of evaluating the disallowed azd down check.

Changes:
- Restrict command regex checks to bash, powershell, and run tools.
- Add a comment documenting why read_bash must not be included.

Validation:
- npm run eval:lint