### PR TITLE
fix: update setup runtime install guidance

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-setup/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-setup/SKILL.md
@@ -18,8 +18,9 @@ Run each check and report results:
 az --version        # Azure CLI ≥ 2.60
 azd version         # Azure Developer CLI, required for Azure Skills deployment workflows
 func --version      # Azure Functions Core Tools ≥ 4.x
-node --version      # Node.js ≥ 18 (if Node project)
-python3 --version   # Python ≥ 3.9 (if Python project)
+node --version      # Node.js 24 or 22 for new Node.js/TypeScript projects
+python --version    # Python 3.13 preferred; 3.10-3.13 supported for Python projects
+python3 --version   # Use this fallback when python is not on PATH
 dotnet --version    # .NET SDK ≥ 8.0 (if .NET project)
 ```
 
@@ -62,17 +63,23 @@ Azure Functions Environment Check
 
 For each failing check, provide:
 1. **What's wrong** — one-line description
-2. **How to fix** — exact install/fix command
+2. **How to fix** — exact install/fix command for the user's OS and shell
 3. **Docs link** — Microsoft Learn URL
 
-| Tool | Install Command | Docs |
-|------|----------------|------|
-| Azure CLI | `curl -sL https://aka.ms/InstallAzureCLIDeb \| sudo bash` | https://learn.microsoft.com/cli/azure/install-azure-cli |
-| Azure Developer CLI | See docs for OS-specific install | https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd |
-| Core Tools | `npm install -g azure-functions-core-tools@4 --unsafe-perm true` | https://learn.microsoft.com/azure/azure-functions/functions-run-local |
-| Node.js | `nvm install 22` or download from https://nodejs.org | https://nodejs.org |
-| Python | `sudo apt install python3.11` or download from https://python.org | https://python.org |
-| .NET SDK | `dotnet-install.sh --channel 8.0` | https://learn.microsoft.com/dotnet/core/install/ |
+Use the user's operating system when choosing fix commands. Do **not** give Linux-only installation commands to Windows or macOS users. If the operating system or package manager is unclear, show the OS-specific choices and ask the user to run the one that matches their machine.
+
+For language runtimes, prefer the latest Azure Functions **GA-supported** version for new installs. Do not recommend preview runtimes unless the user explicitly asks for previews.
+
+| Tool | Recommended version | Windows | macOS | Linux | Docs |
+|------|---------------------|---------|-------|-------|------|
+| Azure CLI | Latest stable, ≥ 2.60 | `winget install --exact --id Microsoft.AzureCLI` | `brew update && brew install azure-cli` | Use the distro-specific Microsoft Learn command for your package manager | https://learn.microsoft.com/cli/azure/install-azure-cli |
+| Azure Developer CLI | Latest stable | `winget install --exact --id Microsoft.Azd` | `brew install azure/azd/azd` | Use the Microsoft Learn instructions for your distro or install the signed `.deb`/`.rpm` package from the Azure Developer CLI release | https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd |
+| Core Tools | v4.x | Download and run the v4.x 64-bit MSI installer from Microsoft Learn | `brew tap azure/functions && brew install azure-functions-core-tools@4` | Use the Microsoft package repository for your distro, then install `azure-functions-core-tools-4` | https://learn.microsoft.com/azure/azure-functions/functions-run-local |
+| Node.js | Node.js 24 GA for new apps; Node.js 22 also supported | `winget install --exact --id OpenJS.NodeJS.LTS` or `fnm install 24` | `brew install node@24` or `fnm install 24` | Use your distro package manager or a version manager such as `fnm install 24` | https://learn.microsoft.com/azure/azure-functions/functions-versions |
+| Python | Python 3.13 GA for new apps; 3.10-3.13 supported | `winget install --exact --id Python.Python.3.13` | `brew install python@3.13` | Use your distro package manager or a version manager such as `pyenv install 3.13` | https://learn.microsoft.com/azure/azure-functions/functions-versions |
+| .NET SDK | .NET 8 LTS minimum; use the latest GA version supported by the target Functions model | `winget install --exact --id Microsoft.DotNet.SDK.8` | `brew install --cask dotnet-sdk` | Use the Microsoft Learn instructions for your distro | https://learn.microsoft.com/dotnet/core/install/ |
+
+Azure Functions runtime 4.x currently supports Node.js 24 and 22 for Node.js/TypeScript apps, and Python 3.10 through 3.13 for Python apps. Python 3.14 can appear in preview; keep Python 3.13 as the default recommendation until the user opts into preview support. Mention hosting caveats when relevant: newer language versions might not be available on Linux Consumption, so Flex Consumption is the safer default for new Linux-hosted apps.
 
 ## After Setup
 

--- a/evals/azure-functions-setup/eval.yaml
+++ b/evals/azure-functions-setup/eval.yaml
@@ -4,7 +4,7 @@ description: |
 
   Doubles as a CI environment sanity check: when the agent runs the
   prerequisite-version commands listed in the skill (az, azd, func,
-  node, python3, dotnet), every one of those tools must actually be
+  node, python/python3, dotnet), every one of those tools must actually be
   present on the runner. If any of them is missing the eval will
   surface it through the `prereq_*_ok` graders below.
 
@@ -139,6 +139,77 @@ stimuli:
         type: output-not-matches
         config:
           pattern: "(?i)(command not found|not installed|missing|❌)\\s*(:|—|-)?\\s*(azure cli|az\\b|azure developer cli|azd\\b|core tools|func\\b|node\\.?js|python|\\.net|dotnet)"
+
+      # Globals
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  # ─────────────────────────────────────────────────────────────────
+  # Response quality (tier: smoke) — cross-platform fix guidance
+  # The setup skill must not regress to Linux-only install commands or
+  # stale language versions when a prerequisite is missing.
+  # ─────────────────────────────────────────────────────────────────
+
+  - name: "Quality — cross-platform fix instructions"
+    prompt: |
+      Assume Azure Functions Core Tools, Node.js, and Python are missing
+      from my machine. I have not told you whether I use Windows, macOS,
+      or Linux. Provide the Fix Instructions part only: what's wrong,
+      how to fix it, and docs links. Make the install guidance universal
+      across Windows, macOS, and Linux.
+    tags:
+      type: integration
+      skill: azure-functions-setup
+      tier: smoke
+      cost: llm
+      area: response-quality
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-setup
+        - ../../templates/skills/azure-functions-common
+    constraints:
+      max_turns: 12
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-setup
+
+      - name: fix_mentions_windows
+        type: output-matches
+        config:
+          pattern: "(?i)Windows|winget|MSI"
+      - name: fix_mentions_macos
+        type: output-matches
+        config:
+          pattern: "(?i)macOS|Homebrew|\\bbrew\\b"
+      - name: fix_mentions_linux
+        type: output-matches
+        config:
+          pattern: "(?i)Linux|distro|package manager"
+      - name: fix_recommends_current_node
+        type: output-matches
+        config:
+          pattern: "(?i)Node\\.?js[^\\n]*(24|latest GA)|(?:24|latest GA)[^\\n]*Node\\.?js"
+      - name: fix_recommends_current_python
+        type: output-matches
+        config:
+          pattern: "(?i)Python[^\\n]*3\\.13|3\\.13[^\\n]*Python"
+      - name: fix_links_functions_versions
+        type: output-matches
+        config:
+          pattern: "https://learn\\.microsoft\\.com/.*/azure-functions/functions-versions"
+
+      - name: fix_avoids_stale_linux_only_commands
+        type: output-not-matches
+        config:
+          pattern: "(?i)(sudo apt install python3\\.11|nvm install 22|InstallAzureCLIDeb|unsafe-perm|dotnet-install\\.sh --channel 8\\.0)"
+      - name: fix_does_not_default_to_python_preview
+        type: output-not-matches
+        config:
+          pattern: "(?i)(recommend|install|default).{0,40}Python 3\\.14|Python 3\\.14.{0,40}(recommend|install|default)"
 
       # Globals
       - type: completed

--- a/templates/skills/azure-functions-setup/SKILL.md
+++ b/templates/skills/azure-functions-setup/SKILL.md
@@ -19,8 +19,9 @@ Run each check and report results:
 az --version        # Azure CLI ≥ 2.60
 azd version         # Azure Developer CLI, required for Azure Skills deployment workflows
 func --version      # Azure Functions Core Tools ≥ 4.x
-node --version      # Node.js ≥ 18 (if Node project)
-python3 --version   # Python ≥ 3.9 (if Python project)
+node --version      # Node.js 24 or 22 for new Node.js/TypeScript projects
+python --version    # Python 3.13 preferred; 3.10-3.13 supported for Python projects
+python3 --version   # Use this fallback when python is not on PATH
 dotnet --version    # .NET SDK ≥ 8.0 (if .NET project)
 ```
 
@@ -63,17 +64,23 @@ Azure Functions Environment Check
 
 For each failing check, provide:
 1. **What's wrong** — one-line description
-2. **How to fix** — exact install/fix command
+2. **How to fix** — exact install/fix command for the user's OS and shell
 3. **Docs link** — Microsoft Learn URL
 
-| Tool | Install Command | Docs |
-|------|----------------|------|
-| Azure CLI | `curl -sL https://aka.ms/InstallAzureCLIDeb \| sudo bash` | https://learn.microsoft.com/cli/azure/install-azure-cli |
-| Azure Developer CLI | See docs for OS-specific install | https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd |
-| Core Tools | `npm install -g azure-functions-core-tools@4 --unsafe-perm true` | https://learn.microsoft.com/azure/azure-functions/functions-run-local |
-| Node.js | `nvm install 22` or download from https://nodejs.org | https://nodejs.org |
-| Python | `sudo apt install python3.11` or download from https://python.org | https://python.org |
-| .NET SDK | `dotnet-install.sh --channel 8.0` | https://learn.microsoft.com/dotnet/core/install/ |
+Use the user's operating system when choosing fix commands. Do **not** give Linux-only installation commands to Windows or macOS users. If the operating system or package manager is unclear, show the OS-specific choices and ask the user to run the one that matches their machine.
+
+For language runtimes, prefer the latest Azure Functions **GA-supported** version for new installs. Do not recommend preview runtimes unless the user explicitly asks for previews.
+
+| Tool | Recommended version | Windows | macOS | Linux | Docs |
+|------|---------------------|---------|-------|-------|------|
+| Azure CLI | Latest stable, ≥ 2.60 | `winget install --exact --id Microsoft.AzureCLI` | `brew update && brew install azure-cli` | Use the distro-specific Microsoft Learn command for your package manager | https://learn.microsoft.com/cli/azure/install-azure-cli |
+| Azure Developer CLI | Latest stable | `winget install --exact --id Microsoft.Azd` | `brew install azure/azd/azd` | Use the Microsoft Learn instructions for your distro or install the signed `.deb`/`.rpm` package from the Azure Developer CLI release | https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd |
+| Core Tools | v4.x | Download and run the v4.x 64-bit MSI installer from Microsoft Learn | `brew tap azure/functions && brew install azure-functions-core-tools@4` | Use the Microsoft package repository for your distro, then install `azure-functions-core-tools-4` | https://learn.microsoft.com/azure/azure-functions/functions-run-local |
+| Node.js | Node.js 24 GA for new apps; Node.js 22 also supported | `winget install --exact --id OpenJS.NodeJS.LTS` or `fnm install 24` | `brew install node@24` or `fnm install 24` | Use your distro package manager or a version manager such as `fnm install 24` | https://learn.microsoft.com/azure/azure-functions/functions-versions |
+| Python | Python 3.13 GA for new apps; 3.10-3.13 supported | `winget install --exact --id Python.Python.3.13` | `brew install python@3.13` | Use your distro package manager or a version manager such as `pyenv install 3.13` | https://learn.microsoft.com/azure/azure-functions/functions-versions |
+| .NET SDK | .NET 8 LTS minimum; use the latest GA version supported by the target Functions model | `winget install --exact --id Microsoft.DotNet.SDK.8` | `brew install --cask dotnet-sdk` | Use the Microsoft Learn instructions for your distro | https://learn.microsoft.com/dotnet/core/install/ |
+
+Azure Functions runtime 4.x currently supports Node.js 24 and 22 for Node.js/TypeScript apps, and Python 3.10 through 3.13 for Python apps. Python 3.14 can appear in preview; keep Python 3.13 as the default recommendation until the user opts into preview support. Mention hosting caveats when relevant: newer language versions might not be available on Linux Consumption, so Flex Consumption is the safer default for new Linux-hosted apps.
 
 ## After Setup
 


### PR DESCRIPTION
## Summary
- Update azure-functions-setup fix instructions to provide Windows/macOS/Linux guidance instead of Linux-only commands.
- Recommend latest GA Azure Functions language runtimes for new installs: Node.js 24 and Python 3.13.
- Add setup eval coverage for cross-platform fix instructions and stale runtime regressions.

## Validation
- npm run validate:skills
- npm run build:plugin-payload
- npm run verify:plugin-payload
- npm run eval:lint
- node scripts/lint-skill-content.mjs
- npm run typecheck

Note: `npm run lint:security` still reports the existing npm publish audit finding in `azure-pipelines/templates/npm-publish-steps.yml`, unrelated to this change.