### PR TITLE
Fix GHCP MCP workspace config path

### DIFF
--- a/.github/skills/azure-functions-e2e-tests/references/commands.md
+++ b/.github/skills/azure-functions-e2e-tests/references/commands.md
@@ -52,7 +52,8 @@ The command IDs and their semantics are platform-independent. The exact shell sy
 | `.github/skills/azure-functions-agents/assets/**` | YES | infra + quickstart-sample |
 | `.github/skills/azure-functions-common/SKILL.md` | YES | — |
 | `.github/hooks/welcome-setup.json` | YES | — |
-| `.vscode/mcp.json` | YES | — |
+| `.mcp.json` | YES | Copilot CLI workspace MCP config |
+| `.vscode/mcp.json` | **NO** | Must NOT exist for GHCP CLI MCP activation |
 | `AGENTS.md` | YES | — |
 | `.github/copilot-instructions.md` | **NO** | Must NOT exist |
 | `.azure-functions-skills/state.local.json` | YES | — |
@@ -64,7 +65,8 @@ The command IDs and their semantics are platform-independent. The exact shell sy
 | `.github/copilot-instructions.md` | YES | Small routing block with managed markers |
 | `.github/agents/functions-copilot.agent.md` | YES | — |
 | `.github/hooks/welcome-setup.json` | YES | — |
-| `.vscode/mcp.json` | YES | — |
+| `.mcp.json` | YES | Copilot CLI workspace MCP config |
+| `.vscode/mcp.json` | **NO** | Must NOT exist for GHCP CLI MCP activation |
 | `.github/copilot/settings.json` | YES | Plugin reference |
 
 ### Claude — local mode (`install --local --agent claude`)
@@ -474,7 +476,7 @@ Apply these checks to every test case during workspace verification steps:
 - If routing file contains full skill instructions/steps, that is a FAIL
 
 ### Cross-file consistency
-- MCP server entries should match between `.vscode/mcp.json` / `.claude/settings.json` / `.codex/config.toml`
+- MCP server entries should match between `.mcp.json` / `.claude/settings.json` / `.codex/config.toml`
 - Hook commands should use cross-platform Node.js (`node -e`), not bash-only commands
 - All skill IDs in routing tables should correspond to actual SKILL.md files
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           echo "=== GHCP ==="
           ls -la dist/workspace/ghcp/.github/
-          ls -la dist/workspace/ghcp/.vscode/
+          test -f dist/workspace/ghcp/.mcp.json
+          test ! -e dist/workspace/ghcp/.vscode/mcp.json
           echo "=== Claude ==="
           ls -la dist/workspace/claude/.claude/
           ls -la dist/workspace/claude/.claude/skills/

--- a/docs/prd-docs/f14-build-system.md
+++ b/docs/prd-docs/f14-build-system.md
@@ -184,7 +184,7 @@ agentPaths:
       scopedInstructions: ".github/instructions/"  # *.instructions.md
       agentDefs: ".github/agents/"                  # *.agent.md
       prompts: ".github/prompts/"                    # *.prompt.md
-      mcp: ".vscode/mcp.json"
+      mcp: ".mcp.json"
     cursor:
       rules: ".cursor/rules/"                        # *.mdc
       mcp: ".cursor/mcp.json"
@@ -203,7 +203,7 @@ The build system also generates MCP config files per target (see F19):
 
 | Target | Output File | Format |
 |--------|------------|--------|
-| GHCP | `.vscode/mcp.json` | `{ "servers": { ... } }` |
+| GHCP | `.mcp.json` | `{ "mcpServers": { ... } }` |
 | Claude Code | `.claude/settings.json` | `{ "mcpServers": { ... } }` |
 | Cursor | `.cursor/mcp.json` | `{ "mcpServers": { ... } }` |
 
@@ -230,7 +230,7 @@ Step 3.5: Inject standard directives
 
 | Target | Output Format |
 |--------|--------------|
-| GHCP | `.md` skills, `.md` agents, `.js` hooks, `.github/` repo template, `.vscode/mcp.json` |
+| GHCP | `.md` skills, `.md` agents, `.js` hooks, `.github/` repo template, `.mcp.json` |
 | Claude Code | `.md` skills in `.claude/skills/`, `.json` agent manifest, `.claude/settings.json` MCP |
 | Cursor | `.md` skills in `.agents/skills/`, `.mdc` rules, `.cursor/mcp.json` |
 | Codex | `.md` skills in `.agents/skills/`, `AGENTS.md` instructions, post-task config |

--- a/docs/prd-docs/f15-distribution.md
+++ b/docs/prd-docs/f15-distribution.md
@@ -93,7 +93,7 @@ GitHub Copilot CLI:
 .github/agents/functions-copilot.agent.md
 .github/copilot-instructions.md        # thin routing only
 .github/hooks/welcome-setup.json       # opt-in setup mode only
-.vscode/mcp.json                       # VS Code MCP, opt-in
+.mcp.json                              # Copilot CLI workspace MCP, opt-in
 AGENTS.md                              # optional cross-agent fallback
 ```
 

--- a/docs/prd-docs/f19-mcp-integration.md
+++ b/docs/prd-docs/f19-mcp-integration.md
@@ -39,13 +39,14 @@ The Azure MCP Server includes Azure Functions tools for template discovery and p
 During `azure-functions-setup` (F3) workspace configuration, MCP settings are placed based on the detected agent:
 
 ```json
-// .vscode/mcp.json (GitHub Copilot)
+// .mcp.json (GitHub Copilot CLI)
 {
-  "servers": {
+  "mcpServers": {
     "azure": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@azure/mcp@latest", "server", "start"]
+      "args": ["-y", "@azure/mcp@latest", "server", "start"],
+      "tools": ["*"]
     }
   }
 }
@@ -105,7 +106,7 @@ The build system generates MCP config files per target:
 
 | Target | Output File | Format |
 |--------|------------|--------|
-| GHCP | `.vscode/mcp.json` | `{ "servers": { ... } }` |
+| GHCP | `.mcp.json` | `{ "mcpServers": { ... } }` |
 | Claude Code | `.claude/settings.json` | `{ "mcpServers": { ... } }` |
 | Cursor | `.cursor/mcp.json` | `{ "mcpServers": { ... } }` |
 | Codex | `codex-mcp.json` | Agent-specific format |
@@ -143,7 +144,7 @@ entry_conditions:
 
 | Target | Surfacing |
 |--------|-----------|
-| GHCP | Place MCP config in `.vscode/mcp.json`. Skill instructs MCP tool invocations |
+| GHCP | Place MCP config in `.mcp.json`. Skill instructs MCP tool invocations |
 | Claude Code | Place MCP config in `.claude/settings.json` |
 | Codex | Include MCP config in agent definition |
 | Repo Template | Include MCP config template in repo template |

--- a/docs/prd-docs/f3-azure-functions-setup.md
+++ b/docs/prd-docs/f3-azure-functions-setup.md
@@ -121,7 +121,7 @@ Files placed based on detected agent:
 | File | Target Agent | Content |
 |------|-------------|--------|
 | `.github/copilot-instructions.md` | GitHub Copilot | Functions-specific coding guidance |
-| `.vscode/mcp.json` | GitHub Copilot | Templates MCP server config (F19) |
+| `.mcp.json` | GitHub Copilot CLI | Templates MCP server config (F19) |
 | `.claude/settings.json` | Claude Code | MCP server + project settings |
 | `.cursor/rules/azure-functions.mdc` | Cursor | Functions rules |
 | `AGENTS.md` | Codex / generic | Agent-agnostic instructions |
@@ -141,7 +141,7 @@ agentPaths:
     github-copilot:
       instructions: ".github/copilot-instructions.md"
       agentDefs: ".github/agents/"
-      mcp: ".vscode/mcp.json"
+      mcp: ".mcp.json"
     cursor:
       rules: ".cursor/rules/"
       mcp: ".cursor/mcp.json"
@@ -165,7 +165,7 @@ Generated skill files and instruction files are customized to match the detected
 
 | Target | Surfacing |
 |--------|-----------|
-| GHCP | Skill runs checks via shell commands, configures `.github/` + `.vscode/mcp.json` |
+| GHCP | Skill runs checks via shell commands, configures `.github/` + `.mcp.json` |
 | Claude Code | Skill configures `.claude/` directory with skills, instructions, MCP |
 | Codex | Agent instruction with prerequisite verification + `AGENTS.md` generation |
 | Cursor | Skill configures `.cursor/rules/` and `.cursor/mcp.json` |

--- a/src/build/build-target.ts
+++ b/src/build/build-target.ts
@@ -310,7 +310,14 @@ function generatePluginMarketplace({ packageVersion, pluginSource }: PluginMarke
 }
 
 function generatePluginMcpJson(mcpServers: McpServer[]) {
-  return generateCopilotMcpJson(mcpServers);
+  const result: Record<string, { command: string; args: string[] }> = {};
+  for (const s of mcpServers) {
+    result[s.id] = {
+      command: s.command,
+      args: s.args,
+    };
+  }
+  return { mcpServers: result };
 }
 
 function generateClaudeSettings(mcpServers: McpServer[]) {

--- a/src/build/build-target.ts
+++ b/src/build/build-target.ts
@@ -125,14 +125,12 @@ function buildGhcp({ skills, mcpServers, agents }: BuildData, distDir: string): 
   const base = join(distDir, 'ghcp');
   mkdirSync(join(base, '.github', 'agents'), { recursive: true });
   mkdirSync(join(base, '.github', 'hooks'), { recursive: true });
-  mkdirSync(join(base, '.vscode'), { recursive: true });
 
   // No copilot-instructions.md — routing is handled by functions-copilot.agent.md
   // and skills are in .github/skills/<id>/SKILL.md
 
-  // mcp.json
-  const mcpJson = generateVscodeMcp(mcpServers);
-  writeFileSync(join(base, '.vscode', 'mcp.json'), JSON.stringify(mcpJson, null, 2));
+  // .mcp.json — Copilot CLI workspace MCP configuration
+  writeFileSync(join(base, '.mcp.json'), JSON.stringify(generateCopilotMcpJson(mcpServers), null, 2));
 
   // Agent definition
   writeFileSync(join(base, '.github', 'agents', 'functions-copilot.agent.md'), agents.copilot);
@@ -222,16 +220,17 @@ function generateRoutingBlock(agent: 'ghcp' | 'claude' | 'codex', skills: Skill[
   return template.replace('{{skills}}', skillList).trimEnd();
 }
 
-function generateVscodeMcp(mcpServers: McpServer[]) {
-  const servers: Record<string, { type: string; command: string; args: string[] }> = {};
+function generateCopilotMcpJson(mcpServers: McpServer[]) {
+  const servers: Record<string, { type: string; command: string; args: string[]; tools: string[] }> = {};
   for (const s of mcpServers) {
     servers[s.id] = {
       type: s.type || 'stdio',
       command: s.command,
       args: s.args,
+      tools: ['*'],
     };
   }
-  return { servers };
+  return { mcpServers: servers };
 }
 
 function generateGhcpSkillMd(skill: Skill): string {
@@ -311,14 +310,7 @@ function generatePluginMarketplace({ packageVersion, pluginSource }: PluginMarke
 }
 
 function generatePluginMcpJson(mcpServers: McpServer[]) {
-  const result: Record<string, { command: string; args: string[] }> = {};
-  for (const s of mcpServers) {
-    result[s.id] = {
-      command: s.command,
-      args: s.args,
-    };
-  }
-  return { mcpServers: result };
+  return generateCopilotMcpJson(mcpServers);
 }
 
 function generateClaudeSettings(mcpServers: McpServer[]) {

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -149,7 +149,7 @@ function isPluginOnlyArtifact(agent: CliAgentName, relativePath: string): boolea
   const [topLevel, secondLevel] = relativePath.split(/[\\/]/);
 
   if (agent === 'ghcp') {
-    return ['plugin.json', 'skills', 'agents', 'hooks.json', '.mcp.json'].includes(topLevel);
+    return ['plugin.json', 'skills', 'agents', 'hooks.json'].includes(topLevel);
   }
 
   if (agent === 'codex') {

--- a/src/setup/local-update.ts
+++ b/src/setup/local-update.ts
@@ -259,7 +259,8 @@ function isRoutingFile(relativePath: string): boolean {
 
 function isSettingsFile(relativePath: string): boolean {
   const normalized = relativePath.replaceAll('\\', '/');
-  return normalized === '.vscode/mcp.json' ||
+  return normalized === '.mcp.json' ||
+    normalized === '.vscode/mcp.json' ||
     normalized === '.claude/settings.json' ||
     normalized === '.codex/config.toml' ||
     normalized === '.github/copilot/settings.json' ||
@@ -269,7 +270,7 @@ function isSettingsFile(relativePath: string): boolean {
 function isPluginOnlyArtifact(agent: CliAgentName, relativePath: string): boolean {
   const [topLevel, secondLevel] = relativePath.split(/[\\/]/);
   if (agent === 'ghcp') {
-    return ['plugin.json', 'skills', 'agents', 'hooks.json', '.mcp.json'].includes(topLevel);
+    return ['plugin.json', 'skills', 'agents', 'hooks.json'].includes(topLevel);
   }
   if (agent === 'codex') {
     if (['.codex-plugin', 'skills', '.mcp.json'].includes(topLevel)) return true;

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -93,7 +93,7 @@ function activationFiles(agent: CliAgentName, mode: WorkspaceMode, options: Work
     files.push({ path: '.github/copilot-instructions.md', content: routingBlock(agent), merge: true });
     if (options.includeAgent) files.push({ path: '.github/agents/functions-copilot.agent.md', content: ghcpAgentDefinition() });
     if (mode === 'plugin-reference') files.push({ path: '.github/copilot/settings.json', content: JSON.stringify(ghcpPluginSettings(), null, 2) });
-    if (options.includeMcp) files.push({ path: '.vscode/mcp.json', content: JSON.stringify(ghcpMcpSettings(), null, 2) });
+    if (options.includeMcp) files.push({ path: '.mcp.json', content: JSON.stringify(ghcpMcpSettings(), null, 2) });
     if (options.includeHooks) files.push({ path: '.github/hooks/welcome-setup.json', content: JSON.stringify(crossPlatformHooks(), null, 2) });
   }
 
@@ -212,15 +212,16 @@ function mcpServers(): McpServer[] {
 }
 
 function ghcpMcpSettings() {
-  const servers: Record<string, { type: string; command: string; args: string[] }> = {};
+  const servers: Record<string, { type: string; command: string; args: string[]; tools: string[] }> = {};
   for (const server of mcpServers()) {
     servers[server.id] = {
       type: server.type || 'stdio',
       command: server.command,
       args: server.args,
+      tools: ['*'],
     };
   }
-  return { servers };
+  return { mcpServers: servers };
 }
 
 function claudeMcpSettings() {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -146,18 +146,20 @@ describe('buildTarget — ghcp', () => {
     expect(existsSync(instrPath)).toBe(false);
   });
 
-  it('generates mcp.json with servers', () => {
+  it('generates root .mcp.json with mcpServers for Copilot CLI', () => {
     const skills = loadSkills(join(TEMPLATES_DIR, 'skills'));
     const mcpServers = loadMcpServers(join(TEMPLATES_DIR, 'mcp', 'servers.yaml'));
     const agents = loadAgents(join(TEMPLATES_DIR, 'agents'));
     const hooks = loadHooks(join(TEMPLATES_DIR, 'hooks'));
     buildTarget('ghcp', { skills, mcpServers, agents, hooks }, DIST_DIR);
 
-    const mcpPath = join(DIST_DIR, 'ghcp', '.vscode', 'mcp.json');
+    const mcpPath = join(DIST_DIR, 'ghcp', '.mcp.json');
     expect(existsSync(mcpPath)).toBe(true);
+    expect(existsSync(join(DIST_DIR, 'ghcp', '.vscode', 'mcp.json'))).toBe(false);
     const mcp = JSON.parse(readFileSync(mcpPath, 'utf-8'));
-    expect(mcp.servers).toBeTruthy();
-    expect(mcp.servers['azure']).toBeTruthy();
+    expect(mcp.mcpServers).toBeTruthy();
+    expect(mcp.mcpServers['azure']).toBeTruthy();
+    expect(mcp.mcpServers['azure'].tools).toEqual(['*']);
   });
 
   it('generates agent definition', () => {
@@ -271,7 +273,8 @@ describe('buildTarget — ghcp', () => {
     expect(existsSync(join(DIST_DIR, 'ghcp', 'plugin.json'))).toBe(false);
     expect(existsSync(join(DIST_DIR, 'ghcp', 'skills'))).toBe(false);
     expect(existsSync(join(DIST_DIR, 'ghcp', 'agents'))).toBe(false);
-    expect(existsSync(join(DIST_DIR, 'ghcp', '.mcp.json'))).toBe(false);
+    expect(existsSync(join(DIST_DIR, 'ghcp', '.mcp.json'))).toBe(true);
+    expect(existsSync(join(DIST_DIR, 'ghcp', '.vscode', 'mcp.json'))).toBe(false);
     expect(existsSync(join(DIST_DIR, 'ghcp', 'hooks.json'))).toBe(false);
   });
 
@@ -592,7 +595,8 @@ describe('setup module', () => {
 
     // GHCP: agent definition + mcp + AGENTS.md (no copilot-instructions.md)
     expect(existsSync(join(DIST_DIR, '.github', 'agents', 'functions-copilot.agent.md'))).toBe(true);
-    expect(existsSync(join(DIST_DIR, '.vscode', 'mcp.json'))).toBe(true);
+    expect(existsSync(join(DIST_DIR, '.mcp.json'))).toBe(true);
+    expect(existsSync(join(DIST_DIR, '.vscode', 'mcp.json'))).toBe(false);
     expect(existsSync(join(DIST_DIR, 'AGENTS.md'))).toBe(true);
   });
 
@@ -606,7 +610,7 @@ describe('setup module', () => {
     expect(existsSync(join(DIST_DIR, 'agents'))).toBe(false);
     expect(existsSync(join(DIST_DIR, 'plugin.json'))).toBe(false);
     expect(existsSync(join(DIST_DIR, 'hooks.json'))).toBe(false);
-    expect(existsSync(join(DIST_DIR, '.mcp.json'))).toBe(false);
+    expect(existsSync(join(DIST_DIR, '.mcp.json'))).toBe(true);
   });
 
   it('applySetup handles codex target', async () => {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -531,6 +531,11 @@ describe('buildPluginPayload', () => {
     expect(existsSync(join(payloadDir, '.mcp.json'))).toBe(true);
     expect(existsSync(join(payloadDir, 'hooks.json'))).toBe(true);
     expect(existsSync(join(payloadDir, 'agents', 'functions-copilot.agent.md'))).toBe(true);
+    const mcpConfig = JSON.parse(readFileSync(join(payloadDir, '.mcp.json'), 'utf-8'));
+    expect(mcpConfig.mcpServers.azure).toEqual({
+      command: 'npx',
+      args: ['-y', '@azure/mcp@latest', 'server', 'start'],
+    });
 
     const manifest = JSON.parse(readFileSync(join(payloadDir, '.plugin', 'plugin.json'), 'utf-8'));
     expect(manifest.skills).toBe('./skills/');

--- a/tests/e2e/update-local.e2e.test.ts
+++ b/tests/e2e/update-local.e2e.test.ts
@@ -37,7 +37,7 @@ function runCli(args: string[], options: { cwd?: string } = {}): string {
 
 describe('E2E: local update flow', () => {
   describe.each([
-    { agent: 'ghcp', routingFile: null, settingsFile: '.vscode/mcp.json', skillsDir: '.github/skills' },
+    { agent: 'ghcp', routingFile: null, settingsFile: '.mcp.json', skillsDir: '.github/skills' },
     { agent: 'claude', routingFile: 'CLAUDE.md', settingsFile: '.claude/settings.json', skillsDir: '.claude/skills' },
     { agent: 'codex', routingFile: 'AGENTS.md', settingsFile: '.codex/config.toml', skillsDir: '.agents/skills' },
   ] as const)('$agent', ({ agent, routingFile, settingsFile, skillsDir }) => {

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -79,7 +79,8 @@ function assertAgentFiles(root: string, expectedAgentFiles: string[]): void {
 function assertWorkspaceLayout(root: string, target: BuildTargetName, expectedSkillIds: string[], expectedAgentFiles: string[]): void {
   if (target === 'ghcp') {
     // No copilot-instructions.md (routing handled by agent definition)
-    expect(existsSync(join(root, '.vscode', 'mcp.json'))).toBe(true);
+    expect(existsSync(join(root, '.mcp.json'))).toBe(true);
+    expect(existsSync(join(root, '.vscode', 'mcp.json'))).toBe(false);
     expect(existsSync(join(root, '.github', 'hooks', 'welcome-setup.json'))).toBe(true);
     assertAgentFiles(join(root, '.github', 'agents'), expectedAgentFiles);
     assertSkillDirectories(join(root, '.github', 'skills'), expectedSkillIds);
@@ -255,7 +256,8 @@ describe('CLI command integration', () => {
       '--yes',
     ]);
 
-    expect(existsSync(join(projectDir, '.vscode', 'mcp.json'))).toBe(true);
+    expect(existsSync(join(projectDir, '.mcp.json'))).toBe(true);
+    expect(existsSync(join(projectDir, '.vscode', 'mcp.json'))).toBe(false);
     expect(existsSync(join(projectDir, '.github', 'hooks', 'welcome-setup.json'))).toBe(true);
     expect(existsSync(join(projectDir, '.claude', 'settings.json'))).toBe(true);
     expect(existsSync(join(projectDir, '.codex', 'config.toml'))).toBe(true);
@@ -282,7 +284,7 @@ describe('CLI command integration', () => {
     expect(output).toContain('Workspace:');
     expect(output).toContain('.github/copilot-instructions.md');
     expect(output).toContain('.github/agents/functions-copilot.agent.md');
-    expect(output).toContain('.vscode/mcp.json');
+    expect(output).toContain('.mcp.json');
     expect(output).toContain('.github/hooks/welcome-setup.json');
     expect(existsSync(join(projectDir, '.github', 'copilot-instructions.md'))).toBe(false);
   });
@@ -660,7 +662,7 @@ describe('CLI command integration', () => {
     // Verify initial install laid down workspace files (no copilot-instructions.md for GHCP)
     const agentDefPath = join(projectDir, '.github', 'agents', 'functions-copilot.agent.md');
     expect(existsSync(agentDefPath)).toBe(true);
-    const mcpPath = join(projectDir, '.vscode', 'mcp.json');
+    const mcpPath = join(projectDir, '.mcp.json');
     expect(existsSync(mcpPath)).toBe(true);
 
     // Step 2: User customizes the MCP file
@@ -675,7 +677,7 @@ describe('CLI command integration', () => {
     const afterUpdate = readFileSync(mcpPath, 'utf-8');
     expect(afterUpdate).toContain('my custom note');
     // New version saved aside
-    const asidePath = join(projectDir, '.vscode', 'mcp.azure-functions-skills-new.json');
+    const asidePath = join(projectDir, '.mcp.azure-functions-skills-new.json');
     expect(existsSync(asidePath)).toBe(true);
     // Skills should be refreshed (overwrite strategy)
     const skillsDir = join(projectDir, '.github', 'skills');

--- a/tests/local-update.test.ts
+++ b/tests/local-update.test.ts
@@ -37,11 +37,10 @@ function setupLocalWorkspace(dir: string, agent: 'ghcp' | 'claude' | 'codex'): v
       '',
       'More custom user content.',
     ].join('\n'));
-    mkdirSync(join(dir, '.vscode'), { recursive: true });
-    writeFileSync(join(dir, '.vscode', 'mcp.json'), JSON.stringify({
-      servers: {
+    writeFileSync(join(dir, '.mcp.json'), JSON.stringify({
+      mcpServers: {
         'my-custom-server': { type: 'stdio', command: 'my-tool', args: [] },
-        'azure-functions': { type: 'stdio', command: 'npx', args: ['@azure/mcp@old'] },
+        'azure-functions': { type: 'stdio', command: 'npx', args: ['@azure/mcp@old'], tools: ['*'] },
       },
     }, null, 2));
     mkdirSync(join(dir, '.github', 'hooks'), { recursive: true });
@@ -210,18 +209,18 @@ describe('applyLocalUpdate', () => {
   });
 
   describe('MCP settings use save-aside', () => {
-    it('saves aside .vscode/mcp.json preserving existing file', async () => {
+    it('saves aside .mcp.json preserving existing file', async () => {
       const dir = makeTempDir();
       setupLocalWorkspace(dir, 'ghcp');
 
       await applyLocalUpdate(dir, { agents: ['ghcp'] });
 
       // Original file preserved with user's custom server
-      const original = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
-      expect(original.servers['my-custom-server']).toBeDefined();
+      const original = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+      expect(original.mcpServers['my-custom-server']).toBeDefined();
 
       // New file saved aside
-      const asidePath = join(dir, '.vscode', 'mcp.azure-functions-skills-new.json');
+      const asidePath = join(dir, '.mcp.azure-functions-skills-new.json');
       expect(existsSync(asidePath)).toBe(true);
     });
 
@@ -276,11 +275,11 @@ describe('applyLocalUpdate', () => {
 
       await applyLocalUpdate(dir, { agents: ['ghcp'], force: true });
 
-      const mcp = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
+      const mcp = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
       // User's custom server is gone (overwritten)
-      expect(mcp.servers?.['my-custom-server']).toBeUndefined();
+      expect(mcp.mcpServers?.['my-custom-server']).toBeUndefined();
       // No save-aside file created
-      expect(existsSync(join(dir, '.vscode', 'mcp.azure-functions-skills-new.json'))).toBe(false);
+      expect(existsSync(join(dir, '.mcp.azure-functions-skills-new.json'))).toBe(false);
     });
   });
 
@@ -359,11 +358,11 @@ describe('applyLocalUpdate', () => {
       expect(result.savedAside).toHaveLength(0);
       // The files that would have been save-aside are now in overwritten
       expect(result.overwritten.length).toBeGreaterThan(0);
-      // mcp.json should be overwritten (user's custom server gone)
-      const mcp = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
-      expect(mcp.servers?.['my-custom-server']).toBeUndefined();
+      // .mcp.json should be overwritten (user's custom server gone)
+      const mcp = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+      expect(mcp.mcpServers?.['my-custom-server']).toBeUndefined();
       // No save-aside file
-      expect(existsSync(join(dir, '.vscode', 'mcp.azure-functions-skills-new.json'))).toBe(false);
+      expect(existsSync(join(dir, '.mcp.azure-functions-skills-new.json'))).toBe(false);
     });
 
     it('saves aside file when prompter returns skip', async () => {
@@ -376,8 +375,8 @@ describe('applyLocalUpdate', () => {
       // Save-aside files created
       expect(result.savedAside.length).toBeGreaterThan(0);
       // User's custom MCP server preserved
-      const mcp = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
-      expect(mcp.servers['my-custom-server']).toBeDefined();
+      const mcp = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+      expect(mcp.mcpServers['my-custom-server']).toBeDefined();
     });
 
     it('does not call prompter when not provided (non-interactive)', async () => {
@@ -419,7 +418,7 @@ describe('saveAsidePath', () => {
     expect(saveAsidePath('CLAUDE.md')).toBe('CLAUDE.azure-functions-skills-new.md');
     expect(saveAsidePath('settings.json')).toBe('settings.azure-functions-skills-new.json');
     expect(saveAsidePath('config.toml')).toBe('config.azure-functions-skills-new.toml');
-    expect(saveAsidePath(join('.vscode', 'mcp.json'))).toBe(join('.vscode', 'mcp.azure-functions-skills-new.json'));
+    expect(saveAsidePath('.mcp.json')).toBe('.mcp.azure-functions-skills-new.json');
   });
 
   it('handles files without extension', () => {

--- a/tests/workspace-apply.test.ts
+++ b/tests/workspace-apply.test.ts
@@ -177,7 +177,8 @@ describe('applyWorkspace', () => {
       includeHooks: true,
     });
 
-    expect(existsSync(join(dir, '.vscode', 'mcp.json'))).toBe(true);
+    expect(existsSync(join(dir, '.mcp.json'))).toBe(true);
+    expect(existsSync(join(dir, '.vscode', 'mcp.json'))).toBe(false);
     expect(existsSync(join(dir, '.github', 'hooks', 'welcome-setup.json'))).toBe(true);
     expect(existsSync(join(dir, '.claude', 'settings.json'))).toBe(true);
     expect(existsSync(join(dir, '.codex', 'config.toml'))).toBe(true);


### PR DESCRIPTION
## Summary

- Write GHCP/Copilot CLI workspace MCP config to root `.mcp.json` instead of `.vscode/mcp.json`
- Switch GHCP MCP schema from `{ "servers": ... }` to Copilot CLI-compatible `{ "mcpServers": ... }` with `tools: ["*"]`
- Update local update behavior, tests, and PRD docs for the new GHCP MCP path

Closes #163

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run verify:plugin-payload`
- E2E: `workspace apply --agent ghcp --include-mcp` in an isolated workspace, then `copilot -C <workspace> mcp list --json` confirms Azure MCP loads with `source: "workspace"`