### PR TITLE
fix: preserve chat startup context with passthrough

### DIFF
--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -63,6 +63,7 @@ Options:
   --agent <name>     Agent: github-copilot, claude-code, codex
   --prompt <text>    Custom prompt (overrides startup template)
   --dir <path>       Working directory (default: current directory)
+  --dry-run          Print planned launch without starting the agent or updating state
   --check-prerequisites  Check external prerequisites without installing them
   --skip-prerequisites   Skip external prerequisite checks
   -- <args...>       Pass remaining arguments through to the selected agent CLI
@@ -230,6 +231,7 @@ function printHelp() {
     --prompt <text>    Custom prompt (overrides startup template)
     --dir <path>       Working directory (default: current directory)
     --as-plugin        Ensure plugin is registered before launching agent
+    --dry-run          Print planned launch without starting the agent or updating state
     --check-prerequisites  Check external prerequisites without installing them
     --skip-prerequisites   Skip external prerequisite checks
     -- <args...>       Pass remaining arguments through to the selected agent CLI
@@ -257,6 +259,38 @@ function printCommandHelp(topic) {
     process.exit(1);
   }
   console.log(text);
+}
+
+function printChatDryRun(result, setupSkillPending) {
+  const startupPromptIncluded = chatPromptIncludedInArgs(result);
+  console.log('Planned chat launch:');
+  console.log(`  Agent: ${result.agent}`);
+  console.log(`  Working directory: ${result.cwd}`);
+  console.log(`  Command: ${result.command}`);
+  console.log(`  Arguments: ${formatChatArgs(result.args, result.prompt)}`);
+  console.log(`  Startup prompt: ${startupPromptIncluded ? 'included' : 'not included'}`);
+  console.log(`  Setup instruction: ${setupSkillPending && startupPromptIncluded ? 'included' : 'not included'}`);
+  if (startupPromptIncluded) console.log(`  Prompt preview: ${previewPrompt(result.prompt)}`);
+}
+
+function chatPromptIncludedInArgs(result) {
+  return Boolean(result.prompt && result.args.includes(result.prompt));
+}
+
+function formatChatArgs(args, prompt) {
+  return args
+    .map(arg => (prompt && arg === prompt ? '<startup prompt>' : formatShellArg(arg)))
+    .join(' ');
+}
+
+function formatShellArg(arg) {
+  if (/^[A-Za-z0-9_@%+=:,./\\-]+$/.test(arg)) return arg;
+  return JSON.stringify(arg);
+}
+
+function previewPrompt(prompt) {
+  const normalized = prompt.replace(/\s+/g, ' ').trim();
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
 }
 
 /** Extract the value following a flag from args, e.g. getFlag('--dir') → '/path'. */
@@ -755,6 +789,7 @@ if (command === 'install' || command === 'update') {
   let prompt = null;
   let dir = process.cwd();
   let asPlugin = false;
+  let dryRun = false;
   let prerequisites = 'auto';
   const passthroughArgs = [];
 
@@ -763,6 +798,7 @@ if (command === 'install' || command === 'update') {
     else if (args[i] === '--prompt' && args[i + 1]) prompt = args[++i];
     else if (args[i] === '--dir' && args[i + 1]) dir = args[++i];
     else if (args[i] === '--as-plugin') asPlugin = true;
+    else if (args[i] === '--dry-run') dryRun = true;
     else if (args[i] === '--check-prerequisites') prerequisites = 'check-only';
     else if (args[i] === '--skip-prerequisites') prerequisites = 'skip';
     else if (args[i] === '--') {
@@ -774,7 +810,7 @@ if (command === 'install' || command === 'update') {
   }
 
   // If --as-plugin, ensure plugin is registered first
-  if (asPlugin) {
+  if (asPlugin && !dryRun) {
     const { installPlugin, getPluginDir } = await import('../lib/setup/plugin-install.js');
     const { existsSync } = await import('node:fs');
 
@@ -820,19 +856,21 @@ if (command === 'install' || command === 'update') {
     }
   }
 
-  console.log(`\n🚀 Launching ${agent} with Azure Functions context...\n`);
+  if (!dryRun) console.log(`\n🚀 Launching ${agent} with Azure Functions context...\n`);
 
   const options = { agent, dir };
   if (prompt) options.prompt = prompt;
   if (passthroughArgs.length > 0) options.passthroughArgs = passthroughArgs;
   options.prerequisites = prerequisites;
-  const setupSkillPending = state && state.setupSkill.status !== 'completed';
+  options.dryRun = dryRun;
+  const setupSkillPending = Boolean(state && state.setupSkill.status !== 'completed');
   if (setupSkillPending) {
-    markSetupPrompted(dir, agent);
     options.setupSkillPending = true;
     options.setupCompleteCommand = `azure-functions-skills state setup-complete --dir "${dir}" --agent ${agent}`;
   }
-  await chat(options);
+  const result = await chat(options);
+  if (dryRun) printChatDryRun(result, setupSkillPending);
+  else if (setupSkillPending && chatPromptIncludedInArgs(result)) markSetupPrompted(dir, agent);
 } else if (command === 'workspace') {
   const action = args[1];
   if ((action === 'apply' || action === 'update') && (args.includes('--help') || args.includes('-h'))) {

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -80,6 +80,7 @@ Options:
   --workspace        Apply workspace plugin-reference activation (default)
   --no-workspace     Skip workspace activation
   --dry-run          Print planned changes without writing files
+  --force            Overwrite customer-owned workspace activation files
   --yes              Approve workspace activation changes to existing instruction files
 `,
   'plugin update': `Usage: azure-functions-skills plugin update [options]
@@ -94,6 +95,7 @@ Options:
   --workspace        Apply workspace plugin-reference activation (default)
   --no-workspace     Skip workspace activation
   --dry-run          Print planned changes without writing files
+  --force            Overwrite customer-owned workspace activation files
   --yes              Approve workspace activation changes to existing instruction files
 `,
   'workspace apply': `Usage: azure-functions-skills workspace apply [options]
@@ -106,6 +108,7 @@ Options:
   --mode <name>      minimal, copy, plugin-reference (default: copy)
   --merge-strategy <name> managed-block, include-file, fail-if-exists, append
   --dry-run          Print planned changes without writing files
+  --force            Overwrite customer-owned workspace activation files
   --yes              Approve modifying existing instruction files without prompting
   --include-agent    Add the GHCP functions-copilot workspace agent definition
   --include-mcp      Add workspace MCP configuration files
@@ -121,6 +124,7 @@ Options:
   --mode <name>      minimal, copy, plugin-reference (default: copy)
   --merge-strategy <name> managed-block, include-file, fail-if-exists, append
   --dry-run          Print planned changes without writing files
+  --force            Overwrite customer-owned workspace activation files
   --yes              Approve modifying existing instruction files without prompting
   --include-agent    Add the GHCP functions-copilot workspace agent definition
   --include-mcp      Add workspace MCP configuration files
@@ -210,6 +214,7 @@ function printHelp() {
     --merge-strategy <name> managed-block, include-file, fail-if-exists, append
     --update           Replace existing Azure Functions managed blocks
     --dry-run          Print planned changes without writing files
+    --force            Overwrite customer-owned workspace activation files
     --yes              Approve modifying existing instruction files without prompting
     --include-agent    Add the GHCP functions-copilot workspace agent definition
     --include-mcp      Add workspace MCP configuration files
@@ -271,6 +276,33 @@ function printChatDryRun(result, setupSkillPending) {
   console.log(`  Startup prompt: ${startupPromptIncluded ? 'included' : 'not included'}`);
   console.log(`  Setup instruction: ${setupSkillPending && startupPromptIncluded ? 'included' : 'not included'}`);
   if (startupPromptIncluded) console.log(`  Prompt preview: ${previewPrompt(result.prompt)}`);
+}
+
+function printWorkspaceResultDetails(result, indent = '  ') {
+  if (result.overwritten.length > 0) {
+    console.log(`${indent}Overwrite:`);
+    for (const file of result.overwritten) console.log(`${indent}  - ${file}`);
+  }
+  if (result.managedBlockUpdated.length > 0) {
+    console.log(`${indent}Managed update:`);
+    for (const file of result.managedBlockUpdated) console.log(`${indent}  - ${file}`);
+  }
+  if (result.savedAside.length > 0) {
+    console.log(`${indent}Save aside (review & merge manually):`);
+    for (const entry of result.savedAside) console.log(`${indent}  - ${entry.original} → ${entry.aside}`);
+  }
+  if (result.overwritten.length === 0 && result.managedBlockUpdated.length === 0 && result.savedAside.length === 0) {
+    for (const file of result.plannedFiles) console.log(`${indent}- ${file}`);
+  }
+}
+
+function printSavedAsideWarning(savedAside) {
+  if (savedAside.length === 0) return;
+  console.log('\n⚠️  Some files were saved aside for manual review:');
+  for (const entry of savedAside) {
+    console.log(`   ${entry.original} → ${entry.aside}`);
+  }
+  console.log('   Review these files and merge changes as needed.');
 }
 
 function chatPromptIncludedInArgs(result) {
@@ -627,7 +659,9 @@ if (command === 'install' || command === 'update') {
   } else {
     const { runPluginOperation } = await import('../lib/setup/plugin-install.js');
     const { applyWorkspace } = await import('../lib/setup/workspace.js');
+    const { createInteractivePrompter } = await import('../lib/setup/local-update.js');
     const action = command;
+    const prompter = isInteractive() && !force && !yes && !dryRun ? createInteractivePrompter() : undefined;
     const pluginResult = await runPluginOperation({
       action,
       agents: detectedAgents,
@@ -645,6 +679,8 @@ if (command === 'install' || command === 'update') {
       update: action === 'update',
       dryRun,
       yes,
+      force,
+      prompter,
       includeMcp,
       includeHooks,
       includeAgent: true,
@@ -658,7 +694,7 @@ if (command === 'install' || command === 'update') {
         for (const pluginCommand of step.commands || []) console.log(`        $ ${pluginCommand}`);
       }
       console.log('  Workspace:');
-      for (const file of workspaceResult.plannedFiles) console.log(`    - ${file}`);
+      printWorkspaceResultDetails(workspaceResult, '    ');
     } else {
       const state = recordInstallState(dir, {
         action,
@@ -673,6 +709,7 @@ if (command === 'install' || command === 'update') {
       const gitignoreResult = await updateStateGitignore({ dir, yes, ensureStateIgnored, stateIgnoreEntry: STATE_IGNORE_ENTRY });
       const gitRepoResult = await ensureGitRepo({ dir, yes, agents: detectedAgents, action });
       printInstallSummary({ action, agents: detectedAgents, dir, filesWritten: workspaceResult.filesWritten, state, gitignoreResult, gitRepoResult });
+      printSavedAsideWarning(workspaceResult.savedAside);
     }
   }
 } else if (command === 'setup') {
@@ -884,6 +921,7 @@ if (command === 'install' || command === 'update') {
   }
 
   const { applyWorkspace } = await import('../lib/setup/workspace.js');
+  const { createInteractivePrompter } = await import('../lib/setup/local-update.js');
   const agents = [];
   let dir = process.cwd();
   let mode = 'copy';
@@ -891,6 +929,7 @@ if (command === 'install' || command === 'update') {
   let dryRun = false;
   let update = action === 'update';
   let yes = false;
+  let force = false;
   let includeMcp = false;
   let includeHooks = false;
   let includeAgent = false;
@@ -903,6 +942,7 @@ if (command === 'install' || command === 'update') {
     else if (args[i] === '--dry-run') dryRun = true;
     else if (args[i] === '--update') update = true;
     else if (args[i] === '--yes') yes = true;
+    else if (args[i] === '--force') force = true;
     else if (args[i] === '--include-mcp') includeMcp = true;
     else if (args[i] === '--include-hooks') includeHooks = true;
     else if (args[i] === '--include-agent') includeAgent = true;
@@ -910,6 +950,7 @@ if (command === 'install' || command === 'update') {
 
   let result;
   try {
+    const prompter = isInteractive() && !force && !yes && !dryRun ? createInteractivePrompter() : undefined;
     result = await applyWorkspace(dir, {
       agents: agents.length > 0 ? agents : undefined,
       mode,
@@ -917,6 +958,8 @@ if (command === 'install' || command === 'update') {
       update,
       dryRun,
       yes,
+      force,
+      prompter,
       includeMcp,
       includeHooks,
       includeAgent,
@@ -928,12 +971,13 @@ if (command === 'install' || command === 'update') {
 
   if (dryRun) {
     console.log('Planned workspace changes:');
-    for (const file of result.plannedFiles) console.log(`  - ${file}`);
+    printWorkspaceResultDetails(result, '  ');
   } else {
     console.log(`Workspace ${action} complete.`);
     console.log(`  Agents configured: ${result.agents.join(', ')}`);
     console.log(`  Mode: ${result.mode}`);
     console.log(`  Files written: ${result.filesWritten}`);
+    printSavedAsideWarning(result.savedAside);
   }
 } else if (command === 'plugin') {
   const action = args[1];
@@ -949,6 +993,7 @@ if (command === 'install' || command === 'update') {
 
   const { detectAgents } = await import('../lib/setup/index.js');
   const { runPluginOperation } = await import('../lib/setup/plugin-install.js');
+  const { createInteractivePrompter } = await import('../lib/setup/local-update.js');
   const agents = [];
   let dir = process.cwd();
   let scope = 'workspace';
@@ -957,6 +1002,7 @@ if (command === 'install' || command === 'update') {
   let workspace = true;
   let dryRun = false;
   let yes = false;
+  let force = false;
 
   for (let i = 2; i < args.length; i++) {
     if (args[i] === '--agent' && args[i + 1]) agents.push(args[++i]);
@@ -968,11 +1014,13 @@ if (command === 'install' || command === 'update') {
     else if (args[i] === '--no-workspace') workspace = false;
     else if (args[i] === '--dry-run') dryRun = true;
     else if (args[i] === '--yes') yes = true;
+    else if (args[i] === '--force') force = true;
   }
 
   const detectedAgents = agents.length > 0 ? agents : await detectAgents();
   let result;
   try {
+    const prompter = isInteractive() && !force && !yes && !dryRun ? createInteractivePrompter() : undefined;
     result = await runPluginOperation({
       action,
       agents: detectedAgents,
@@ -983,6 +1031,8 @@ if (command === 'install' || command === 'update') {
       version,
       workspace,
       yes,
+      force,
+      prompter,
     });
   } catch (err) {
     console.error(err.message);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -100,6 +100,8 @@ npx @azure/functions-skills chat --agent github-copilot --dir ./my-app
 | `--agent <name>` | state | `github-copilot`, `claude-code`, `codex`. |
 | `--prompt <text>` | startup template | Custom prompt. |
 | `--dir <path>` | `cwd` | Working directory. |
+| `--as-plugin` | off | Ensure the native plugin is registered before launching the agent. |
+| `--dry-run` | off | Print the planned agent launch without starting the agent or updating state. |
 | `--check-prerequisites` | off | Check external prerequisites and exit. |
 | `--skip-prerequisites` | off | Skip prerequisite checks. |
 | `-- <args...>` | — | Pass-through to the underlying agent CLI. |

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -172,7 +172,7 @@ export async function buildStartupPrompt(dir: string, options: StartupPromptOpti
  * @param {string} [options.agent] - Agent ID (github-copilot, claude-code, codex)
  * @param {string} [options.prompt] - Custom prompt (overrides startup template)
  * @param {string} [options.dir] - Working directory
- * @returns {Promise<{childProcess: object, agent: string, prompt: string}>}
+ * @returns {Promise<{childProcess: object | null, agent: string, prompt: string}>}
  */
 export async function chat(options: ChatOptions = {}): Promise<ChatResult> {
   const dir = options.dir || process.cwd();
@@ -183,14 +183,25 @@ export async function chat(options: ChatOptions = {}): Promise<ChatResult> {
     throw new Error(`Unknown agent: ${agentId}. Available: ${Object.keys(LAUNCHERS).join(', ')}`);
   }
 
-  // Skip auto-generated startup prompt when passthrough args are present and
-  // no explicit --prompt was given — the user is controlling the agent CLI directly
-  const hasPassthrough = options.passthroughArgs && options.passthroughArgs.length > 0;
-  const basePrompt = options.prompt || (hasPassthrough ? undefined : await buildStartupPrompt(dir));
+  const basePrompt = options.prompt || await buildStartupPrompt(dir);
   const startupPrompt = basePrompt
     ? (options.setupSkillPending ? `${setupInstruction(options.setupCompleteCommand)} ${basePrompt}` : basePrompt)
     : undefined;
   const args = launcher.buildArgs({ startupPrompt, passthroughArgs: options.passthroughArgs });
+  const prompt = startupPrompt || '';
+
+  if (options.dryRun) {
+    return {
+      dryRun: true,
+      childProcess: null,
+      agent: agentId,
+      prompt,
+      command: launcher.command,
+      args,
+      cwd: dir,
+    };
+  }
+
   const resolvedLauncher = resolveLauncherCommand(launcher.command);
 
   const child = spawn(resolvedLauncher.command, [...resolvedLauncher.argsPrefix, ...args], {
@@ -209,7 +220,15 @@ export async function chat(options: ChatOptions = {}): Promise<ChatResult> {
     });
 
     child.on('spawn', () => {
-      resolve({ childProcess: child, agent: agentId, prompt: startupPrompt || '' });
+      resolve({
+        dryRun: false,
+        childProcess: child,
+        agent: agentId,
+        prompt,
+        command: launcher.command,
+        args,
+        cwd: dir,
+      });
     });
   });
 }

--- a/src/setup/local-update.ts
+++ b/src/setup/local-update.ts
@@ -14,20 +14,13 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { buildTarget } from '../build/build-target.js';
 import { loadAgents, loadHooks, loadMcpServers, loadSkills } from '../build/loader.js';
-import type { BuildData, CliAgentName } from '../types.js';
+import type { BuildData, CliAgentName, FilePrompter, FilePromptResult } from '../types.js';
+export type { FilePrompter, FilePromptResult } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', '..', 'templates');
 
 const BLOCK_PATTERN = /<!-- azure-functions-skills:start[^\n]* -->[\s\S]*?<!-- azure-functions-skills:end -->/;
-
-export type FilePromptResult = 'overwrite' | 'skip';
-
-/**
- * A function that prompts the user for an action on a shared file.
- * Receives the relative path and new content; returns the chosen action.
- */
-export type FilePrompter = (relativePath: string, newContent: string, existingContent: string) => Promise<FilePromptResult>;
 
 export interface LocalUpdateOptions {
   agents: CliAgentName[];

--- a/src/setup/local-update.ts
+++ b/src/setup/local-update.ts
@@ -4,7 +4,7 @@
  * Unlike `applySetup()` which overwrites everything via cpSync, this module:
  * - Overwrites managed content (skills, agent definitions, hooks)
  * - Uses managed-block replacement for routing files (preserves user customizations)
- * - Saves aside settings files for user to merge manually
+ * - Deep-merges JSON settings files and saves aside non-JSON settings files for manual merge
  * - Supports --force to overwrite everything
  */
 
@@ -39,7 +39,7 @@ export interface LocalUpdateResult {
   dryRun: boolean;
 }
 
-type FileAction = 'overwrite' | 'managed-block' | 'save-aside';
+type FileAction = 'overwrite' | 'managed-block' | 'save-aside' | 'deep-merge-json';
 
 interface GeneratedFile {
   /** Relative path within the workspace (e.g., '.github/copilot-instructions.md') */
@@ -220,6 +220,7 @@ function resolveAction(relativePath: string, targetDir: string, force: boolean):
   if (isSettingsFile(relativePath)) {
     const existing = join(targetDir, relativePath);
     if (!existsSync(existing)) return 'overwrite';
+    if (canDeepMergeJson(existing)) return 'deep-merge-json';
     return 'save-aside';
   }
 
@@ -314,6 +315,15 @@ async function applyFile(file: GeneratedFile, _agentDir: string, targetDir: stri
       break;
     }
 
+    case 'deep-merge-json': {
+      if (!dryRun) {
+        const updated = deepMergeJsonFile(destPath, newContent);
+        writeFileSync(destPath, updated);
+      }
+      result.managedBlockUpdated.push(file.relativePath);
+      break;
+    }
+
     case 'save-aside': {
       const asideRelative = resolveUniqueAsidePath(targetDir, file.relativePath);
       if (!dryRun) {
@@ -325,6 +335,38 @@ async function applyFile(file: GeneratedFile, _agentDir: string, targetDir: stri
       break;
     }
   }
+}
+
+function canDeepMergeJson(filePath: string): boolean {
+  if (!filePath.endsWith('.json')) return false;
+  try {
+    JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function deepMergeJsonFile(filePath: string, generatedContent: string): string {
+  const existing = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+  const generated = JSON.parse(generatedContent) as Record<string, unknown>;
+  return `${JSON.stringify(deepMerge(existing, generated), null, 2)}\n`;
+}
+
+function deepMerge(existing: Record<string, unknown>, generated: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...existing };
+  for (const [key, value] of Object.entries(generated)) {
+    if (isRecord(result[key]) && isRecord(value)) {
+      result[key] = deepMerge(result[key], value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -9,7 +9,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
-import type { BuildTargetName } from '../types.js';
+import type { BuildTargetName, FilePrompter } from '../types.js';
 import type { CommandRunner } from './prerequisites/types.js';
 import { applyWorkspace } from './workspace.js';
 
@@ -46,6 +46,8 @@ export interface PluginOperationOptions {
   runner?: CommandRunner;
   platform?: NodeJS.Platform;
   yes?: boolean;
+  force?: boolean;
+  prompter?: FilePrompter;
   passthroughArgs?: string[];
 }
 
@@ -272,6 +274,8 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
       mergeStrategy: 'managed-block',
       update: options.action === 'update',
       yes: options.yes,
+      force: options.force,
+      prompter: options.prompter,
       includeAgent: true,
     });
     result.filesWritten += workspaceResult.filesWritten;

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadMcpServers, loadSkills } from '../build/loader.js';
 import { applySetup, detectAgents } from './index.js';
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', '..', 'templates');
 const BLOCK_START = '<!-- azure-functions-skills:start';
 const BLOCK_END = '<!-- azure-functions-skills:end -->';
+const BLOCK_PATTERN = /<!-- azure-functions-skills:start[^\n]* -->[\s\S]*?<!-- azure-functions-skills:end -->/;
 
 type PlannedFile = {
   path: string;
@@ -16,12 +17,13 @@ type PlannedFile = {
   merge?: boolean;
 };
 
+type WorkspaceFileAction = 'overwrite' | 'managed-block' | 'save-aside' | 'deep-merge-json' | 'include-file' | 'append-block';
+
 export async function applyWorkspace(targetDir: string, options: WorkspaceApplyOptions = {}): Promise<WorkspaceApplyResult> {
   const agents = options.agents || await detectAgents();
   const mode = options.mode || 'copy';
   const mergeStrategy = options.mergeStrategy || 'managed-block';
   const dryRun = options.dryRun === true;
-  const approved = options.yes === true;
 
   if (mode === 'copy') {
     if (dryRun) {
@@ -31,6 +33,9 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
         filesWritten: 0,
         plannedFiles: agents.flatMap(agent => plannedCopyFiles(agent)),
         dryRun,
+        overwritten: [],
+        managedBlockUpdated: [],
+        savedAside: [],
       };
     }
     const setupResult = await applySetup(targetDir, { agents, prerequisites: 'skip' });
@@ -40,45 +45,29 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
       filesWritten: setupResult.filesWritten,
       plannedFiles: [],
       dryRun,
+      overwritten: [],
+      managedBlockUpdated: [],
+      savedAside: [],
     };
   }
 
-  const plannedFiles = agents.flatMap(agent => activationFiles(agent, mode, options));
-  if (dryRun) {
-    return {
-      agents,
-      mode,
-      filesWritten: 0,
-      plannedFiles: plannedFiles.flatMap(file => plannedWorkspacePaths(file, mergeStrategy)),
-      dryRun,
-    };
-  }
-
-  let filesWritten = 0;
-  for (const file of plannedFiles) {
-    const fullPath = join(targetDir, file.path);
-    const content = file.merge
-      ? mergeInstructionFile(fullPath, file.content, mergeStrategy, options.update === true, approved)
-      : mergeJsonLikeFile(fullPath, file.content);
-    mkdirSync(dirname(fullPath), { recursive: true });
-    writeFileSync(fullPath, content);
-    filesWritten++;
-
-    if (file.merge && mergeStrategy === 'include-file') {
-      const includeFullPath = join(targetDir, includeInstructionPath(file.path));
-      mkdirSync(dirname(includeFullPath), { recursive: true });
-      writeFileSync(includeFullPath, ensureTrailingNewline(file.content));
-      filesWritten++;
-    }
-  }
-
-  return {
+  const plannedFiles = coalescePlannedFiles(agents.flatMap(agent => activationFiles(agent, mode, options)));
+  const result: WorkspaceApplyResult = {
     agents,
     mode,
-    filesWritten,
-    plannedFiles: plannedFiles.map(file => file.path),
+    filesWritten: 0,
+    plannedFiles: plannedFiles.flatMap(file => plannedWorkspacePaths(file, mergeStrategy)),
     dryRun,
+    overwritten: [],
+    managedBlockUpdated: [],
+    savedAside: [],
   };
+
+  for (const file of plannedFiles) {
+    await applyPlannedFile(targetDir, file, mergeStrategy, options, result);
+  }
+
+  return result;
 }
 
 function plannedCopyFiles(agent: CliAgentName): string[] {
@@ -118,47 +107,184 @@ function plannedWorkspacePaths(file: PlannedFile, strategy: MergeStrategy): stri
   return [file.path];
 }
 
-function mergeInstructionFile(filePath: string, generatedContent: string, strategy: MergeStrategy, update: boolean, approved: boolean): string {
-  const block = managedBlock(generatedContent);
-  if (!existsSync(filePath)) return `${block}\n`;
+async function applyPlannedFile(
+  targetDir: string,
+  file: PlannedFile,
+  mergeStrategy: MergeStrategy,
+  options: WorkspaceApplyOptions,
+  result: WorkspaceApplyResult,
+): Promise<void> {
+  const fullPath = join(targetDir, file.path);
+  let action = resolveWorkspaceAction(fullPath, file, mergeStrategy, options.force === true);
 
-  const existing = readFileSync(filePath, 'utf-8');
-  const blockPattern = /<!-- azure-functions-skills:start[^\n]* -->[\s\S]*?<!-- azure-functions-skills:end -->/;
-  if (blockPattern.test(existing)) {
-    if (!update) return existing;
-    return ensureTrailingNewline(existing.replace(blockPattern, block));
+  if (action === 'save-aside' && options.prompter && existsSync(fullPath)) {
+    const choice = await options.prompter(file.path, file.content, readFileSync(fullPath, 'utf-8'));
+    if (choice === 'overwrite') action = 'overwrite';
   }
 
-  if (strategy === 'fail-if-exists') {
-    throw new Error(`Refusing to modify existing customer-owned file: ${filePath}`);
+  switch (action) {
+    case 'overwrite':
+      if (!options.dryRun) writeGeneratedFile(fullPath, file.content);
+      result.overwritten.push(file.path);
+      if (!options.dryRun) result.filesWritten++;
+      return;
+    case 'managed-block':
+      if (!options.dryRun) writeGeneratedFile(fullPath, mergeInstructionFile(fullPath, file.content));
+      result.managedBlockUpdated.push(file.path);
+      if (!options.dryRun) result.filesWritten++;
+      return;
+    case 'deep-merge-json':
+      if (!options.dryRun) writeGeneratedFile(fullPath, deepMergeJsonFile(fullPath, file.content));
+      result.managedBlockUpdated.push(file.path);
+      if (!options.dryRun) result.filesWritten++;
+      return;
+    case 'include-file':
+      await applyIncludeFileStrategy(targetDir, fullPath, file, options, result);
+      return;
+    case 'append-block':
+      if (!options.dryRun) writeGeneratedFile(fullPath, appendManagedBlock(fullPath, file.content));
+      result.managedBlockUpdated.push(file.path);
+      if (!options.dryRun) result.filesWritten++;
+      return;
+    case 'save-aside': {
+      const asideRelative = resolveUniqueAsidePath(targetDir, file.path);
+      if (!options.dryRun) writeGeneratedFile(join(targetDir, asideRelative), file.content);
+      result.savedAside.push({ original: file.path, aside: asideRelative });
+      if (!options.dryRun) result.filesWritten++;
+      return;
+    }
   }
-
-  if (!approved) {
-    throw new Error(`Refusing to modify existing customer-owned file without approval: ${filePath}. Re-run with --yes or use --merge-strategy fail-if-exists.`);
-  }
-
-  if (strategy === 'append' || strategy === 'managed-block') {
-    return `${existing.trimEnd()}\n\n${block}\n`;
-  }
-
-  if (strategy === 'include-file') {
-    const includePath = includeInstructionPath(filePath);
-    const includeLine = `See ${includePath} for Azure Functions routing.`;
-    return existing.includes(includeLine) ? ensureTrailingNewline(existing) : `${existing.trimEnd()}\n\n${includeLine}\n`;
-  }
-
-  return `${existing.trimEnd()}\n\n${block}\n`;
 }
 
-function mergeJsonLikeFile(filePath: string, generatedContent: string): string {
-  if (!existsSync(filePath)) return `${generatedContent}\n`;
-  try {
-    const existing = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
-    const generated = JSON.parse(generatedContent) as Record<string, unknown>;
-    return `${JSON.stringify(deepMerge(existing, generated), null, 2)}\n`;
-  } catch {
-    return `${generatedContent}\n`;
+function resolveWorkspaceAction(filePath: string, file: PlannedFile, strategy: MergeStrategy, force: boolean): WorkspaceFileAction {
+  if (force) return 'overwrite';
+  if (!existsSync(filePath)) return 'overwrite';
+
+  if (file.merge) {
+    const existing = readFileSync(filePath, 'utf-8');
+    if (BLOCK_PATTERN.test(existing)) return 'managed-block';
+    if (strategy === 'include-file') return 'include-file';
+    if (strategy === 'append') return 'append-block';
+    if (strategy === 'fail-if-exists') {
+      throw new Error(`Refusing to modify existing customer-owned file: ${filePath}`);
+    }
+    return 'save-aside';
   }
+
+  if (canDeepMergeJson(filePath, file.content)) return 'deep-merge-json';
+  if (isSettingsFile(file.path)) return 'save-aside';
+  return 'overwrite';
+}
+
+function mergeInstructionFile(filePath: string, generatedContent: string): string {
+  const block = managedBlock(generatedContent);
+  const existing = readFileSync(filePath, 'utf-8');
+  const blockPattern = /<!-- azure-functions-skills:start[^\n]* -->[\s\S]*?<!-- azure-functions-skills:end -->/;
+  return ensureTrailingNewline(existing.replace(blockPattern, block));
+}
+
+function appendManagedBlock(filePath: string, generatedContent: string): string {
+  const existing = readFileSync(filePath, 'utf-8');
+  return `${existing.trimEnd()}\n\n${managedBlock(generatedContent)}\n`;
+}
+
+async function applyIncludeFileStrategy(targetDir: string, fullPath: string, file: PlannedFile, options: WorkspaceApplyOptions, result: WorkspaceApplyResult): Promise<void> {
+  const includePath = includeInstructionPath(file.path);
+  const includeLine = `See ${includePath} for Azure Functions routing.`;
+  if (!options.dryRun) {
+    const existing = readFileSync(fullPath, 'utf-8');
+    const next = existing.includes(includeLine) ? ensureTrailingNewline(existing) : `${existing.trimEnd()}\n\n${includeLine}\n`;
+    writeGeneratedFile(fullPath, next);
+    writeGeneratedFile(join(targetDir, includePath), file.content);
+  }
+  result.managedBlockUpdated.push(file.path);
+  result.overwritten.push(includePath);
+  if (!options.dryRun) result.filesWritten += 2;
+}
+
+function deepMergeJsonFile(filePath: string, generatedContent: string): string {
+  const existing = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+  const generated = JSON.parse(generatedContent) as Record<string, unknown>;
+  return `${JSON.stringify(deepMerge(existing, generated), null, 2)}\n`;
+}
+
+function canDeepMergeJson(filePath: string, generatedContent: string): boolean {
+  if (!filePath.endsWith('.json')) return false;
+  try {
+    JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    JSON.parse(generatedContent) as Record<string, unknown>;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writeGeneratedFile(filePath: string, content: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, ensureTrailingNewline(content));
+}
+
+function coalescePlannedFiles(files: PlannedFile[]): PlannedFile[] {
+  const coalesced: PlannedFile[] = [];
+  for (const file of files) {
+    const existing = coalesced.find(candidate => candidate.path === file.path);
+    if (!existing) {
+      coalesced.push({ ...file });
+      continue;
+    }
+    existing.content = mergeGeneratedContent(existing.content, file.content);
+    existing.merge = existing.merge || file.merge;
+  }
+  return coalesced;
+}
+
+function mergeGeneratedContent(left: string, right: string): string {
+  try {
+    const leftJson = JSON.parse(left) as Record<string, unknown>;
+    const rightJson = JSON.parse(right) as Record<string, unknown>;
+    return JSON.stringify(deepMerge(leftJson, rightJson), null, 2);
+  } catch {
+    return right;
+  }
+}
+
+function resolveUniqueAsidePath(targetDir: string, originalRelativePath: string): string {
+  let aside = saveAsidePath(originalRelativePath);
+  let counter = 2;
+  while (existsSync(join(targetDir, aside))) {
+    aside = saveAsidePathWithSuffix(originalRelativePath, counter);
+    counter++;
+  }
+  return aside;
+}
+
+function saveAsidePath(filePath: string): string {
+  const dir = dirname(filePath);
+  const ext = extname(filePath);
+  const base = basename(filePath, ext);
+  const aside = ext
+    ? `${base}.azure-functions-skills-new${ext}`
+    : `${base}.azure-functions-skills-new`;
+  return dir === '.' ? aside : join(dir, aside);
+}
+
+function saveAsidePathWithSuffix(filePath: string, suffix: number): string {
+  const dir = dirname(filePath);
+  const ext = extname(filePath);
+  const base = basename(filePath, ext);
+  const aside = ext
+    ? `${base}.azure-functions-skills-new-${suffix}${ext}`
+    : `${base}.azure-functions-skills-new-${suffix}`;
+  return dir === '.' ? aside : join(dir, aside);
+}
+
+function isSettingsFile(relativePath: string): boolean {
+  const normalized = relativePath.replaceAll('\\', '/');
+  return normalized === '.vscode/mcp.json' ||
+    normalized === '.claude/settings.json' ||
+    normalized === '.codex/config.toml' ||
+    normalized === '.github/copilot/settings.json' ||
+    normalized === '.agents/plugins/marketplace.json';
 }
 
 function deepMerge(existing: Record<string, unknown>, generated: Record<string, unknown>): Record<string, unknown> {

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, dirname, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadMcpServers, loadSkills } from '../build/loader.js';
+import { loadAgents, loadMcpServers, loadSkills } from '../build/loader.js';
 import { applySetup, detectAgents } from './index.js';
 import type { CliAgentName, McpServer, MergeStrategy, WorkspaceApplyOptions, WorkspaceApplyResult, WorkspaceMode } from '../types.js';
 
@@ -71,7 +71,7 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
 }
 
 function plannedCopyFiles(agent: CliAgentName): string[] {
-  if (agent === 'ghcp') return ['.github/copilot-instructions.md', '.github/skills/<skill-id>/SKILL.md'];
+  if (agent === 'ghcp') return ['AGENTS.md', '.github/agents/functions-copilot.agent.md', '.github/skills/<skill-id>/SKILL.md'];
   if (agent === 'claude') return ['CLAUDE.md', '.claude/skills/<skill-id>/SKILL.md'];
   return ['AGENTS.md', '.agents/skills/<skill-id>/SKILL.md'];
 }
@@ -79,7 +79,7 @@ function plannedCopyFiles(agent: CliAgentName): string[] {
 function activationFiles(agent: CliAgentName, mode: WorkspaceMode, options: WorkspaceApplyOptions): PlannedFile[] {
   const files: PlannedFile[] = [];
   if (agent === 'ghcp') {
-    files.push({ path: '.github/copilot-instructions.md', content: routingBlock(agent), merge: true });
+    files.push({ path: 'AGENTS.md', content: agentsMdDefinition(), merge: true });
     if (options.includeAgent) files.push({ path: '.github/agents/functions-copilot.agent.md', content: ghcpAgentDefinition() });
     if (mode === 'plugin-reference') files.push({ path: '.github/copilot/settings.json', content: JSON.stringify(ghcpPluginSettings(), null, 2) });
     if (options.includeMcp) files.push({ path: '.mcp.json', content: JSON.stringify(ghcpMcpSettings(), null, 2) });
@@ -323,6 +323,10 @@ function routingBlock(agent: CliAgentName): string {
 
 function ghcpAgentDefinition(): string {
   return readFileSync(join(TEMPLATES_DIR, 'agents', 'functions-copilot.agent.md'), 'utf-8').trimEnd();
+}
+
+function agentsMdDefinition(): string {
+  return loadAgents(join(TEMPLATES_DIR, 'agents')).agentsMd.trimEnd();
 }
 
 function skillRoutingList(): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,14 +101,31 @@ export interface ChatOptions {
   prompt?: string;
   dir?: string;
   passthroughArgs?: string[];
+  dryRun?: boolean;
   prerequisites?: PrerequisiteMode;
   prerequisiteRunner?: CommandRunner;
   setupSkillPending?: boolean;
   setupCompleteCommand?: string;
 }
 
-export interface ChatResult {
+export interface ChatLaunchResult {
+  dryRun: false;
   childProcess: ChildProcess;
   agent: LauncherId;
   prompt: string;
+  command: string;
+  args: string[];
+  cwd: string;
 }
+
+export interface ChatDryRunResult {
+  dryRun: true;
+  childProcess: null;
+  agent: LauncherId;
+  prompt: string;
+  command: string;
+  args: string[];
+  cwd: string;
+}
+
+export type ChatResult = ChatLaunchResult | ChatDryRunResult;

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,10 @@ export interface SetupResult {
   prerequisites?: PrerequisiteResult[];
 }
 
+export type FilePromptResult = 'overwrite' | 'skip';
+
+export type FilePrompter = (relativePath: string, newContent: string, existingContent: string) => Promise<FilePromptResult>;
+
 export interface WorkspaceApplyOptions {
   agents?: CliAgentName[];
   mode?: WorkspaceMode;
@@ -66,6 +70,8 @@ export interface WorkspaceApplyOptions {
   update?: boolean;
   dryRun?: boolean;
   yes?: boolean;
+  force?: boolean;
+  prompter?: FilePrompter;
   includeMcp?: boolean;
   includeHooks?: boolean;
   includeAgent?: boolean;
@@ -77,6 +83,9 @@ export interface WorkspaceApplyResult {
   filesWritten: number;
   plannedFiles: string[];
   dryRun: boolean;
+  overwritten: string[];
+  managedBlockUpdated: string[];
+  savedAside: Array<{ original: string; aside: string }>;
 }
 
 export interface LauncherContext {

--- a/tests/chat-passthrough.test.ts
+++ b/tests/chat-passthrough.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import type { SpawnOptions } from 'node:child_process';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+type SpawnCall = {
+  command: string;
+  args: string[];
+  options: SpawnOptions;
+};
+
+type FakeChildProcess = {
+  on: (event: string, callback: () => void) => FakeChildProcess;
+};
+
+const TEMP_DIRS: string[] = [];
+
+afterEach(() => {
+  vi.doUnmock('node:child_process');
+  vi.resetModules();
+});
+
+afterAll(() => {
+  for (const dir of TEMP_DIRS) {
+    removeDir(dir);
+  }
+});
+
+describe('chat passthrough startup context', () => {
+  it('keeps generated setup/startup prompt while forwarding passthrough args', async () => {
+    const spawnCalls: SpawnCall[] = [];
+    installChildProcessMock(spawnCalls);
+    const dir = createTempDir('af-skills-chat-passthrough-');
+    TEMP_DIRS.push(dir);
+
+    const { chat } = await import('../src/chat/index.js');
+    const originalPath = process.env.PATH;
+    const originalWindowsPath = process.env.Path;
+    process.env.PATH = '';
+    process.env.Path = '';
+
+    try {
+      const result = await chat({
+        agent: 'github-copilot',
+        dir,
+        passthroughArgs: ['--yolo'],
+        setupSkillPending: true,
+        setupCompleteCommand: 'azure-functions-skills state setup-complete --dir . --agent github-copilot',
+      });
+
+      expect(result.prompt).toContain('First run azure-functions-setup');
+      expect(result.prompt).toContain('Azure Functions');
+      expect(spawnCalls).toHaveLength(1);
+
+      const call = spawnCalls[0];
+      expect(call.command).toBe('copilot');
+      expect(call.args).toContain('--experimental');
+      expect(call.args).toContain('--agent');
+      expect(call.args).toContain('functions-copilot');
+      expect(call.args).toContain('--yolo');
+
+      const promptIndex = call.args.indexOf('-i');
+      expect(promptIndex).toBeGreaterThanOrEqual(0);
+      expect(call.args[promptIndex + 1]).toContain('First run azure-functions-setup');
+      expect(call.args[promptIndex + 1]).toContain('Azure Functions');
+    } finally {
+      restoreEnv('PATH', originalPath);
+      restoreEnv('Path', originalWindowsPath);
+    }
+  });
+
+  it('returns the generated launch plan without spawning when dry-run is set', async () => {
+    const spawnCalls: SpawnCall[] = [];
+    installChildProcessMock(spawnCalls);
+    const dir = createTempDir('af-skills-chat-dry-run-');
+    TEMP_DIRS.push(dir);
+
+    const { chat } = await import('../src/chat/index.js');
+    const result = await chat({
+      agent: 'github-copilot',
+      dir,
+      passthroughArgs: ['--yolo'],
+      setupSkillPending: true,
+      setupCompleteCommand: 'azure-functions-skills state setup-complete --dir . --agent github-copilot',
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.childProcess).toBeNull();
+    expect(result.command).toBe('copilot');
+    expect(result.args).toContain('--yolo');
+    expect(result.prompt).toContain('First run azure-functions-setup');
+    expect(result.prompt).toContain('Azure Functions');
+    expect(spawnCalls).toEqual([]);
+  });
+
+  it('reports generated prompt as not included when the launcher omits it for an explicit prompt arg', async () => {
+    const spawnCalls: SpawnCall[] = [];
+    installChildProcessMock(spawnCalls);
+    const dir = createTempDir('af-skills-chat-dry-run-explicit-prompt-');
+    TEMP_DIRS.push(dir);
+
+    const { chat } = await import('../src/chat/index.js');
+    const result = await chat({
+      agent: 'github-copilot',
+      dir,
+      passthroughArgs: ['-p', 'headless prompt'],
+      setupSkillPending: true,
+      setupCompleteCommand: 'azure-functions-skills state setup-complete --dir . --agent github-copilot',
+      dryRun: true,
+    });
+
+    expect(result.prompt).toContain('First run azure-functions-setup');
+    expect(result.args).toContain('-p');
+    expect(result.args).toContain('headless prompt');
+    expect(result.args).not.toContain(result.prompt);
+    expect(spawnCalls).toEqual([]);
+  });
+});
+
+function installChildProcessMock(spawnCalls: SpawnCall[]): void {
+  const child: FakeChildProcess = {
+    on(event, callback) {
+      if (event === 'spawn') queueMicrotask(callback);
+      return child;
+    },
+  };
+
+  vi.doMock('node:child_process', () => ({
+    execSync: vi.fn(),
+    spawn: vi.fn((command: string, args: string[], options: SpawnOptions) => {
+      spawnCalls.push({ command, args: [...args], options });
+      return child;
+    }),
+  }));
+}
+
+function restoreEnv(name: 'PATH' | 'Path', value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -222,7 +222,7 @@ describe('CLI command integration', () => {
     }
   });
 
-  it('workspace apply --yes appends routing to an existing Claude instructions file', () => {
+  it('workspace apply --yes saves aside routing for an existing Claude instructions file', () => {
     const projectDir = makeTempDir('af-skills-e2e-workspace-yes-');
     writeFileSync(join(projectDir, 'CLAUDE.md'), '# Existing Claude rules\n');
 
@@ -237,7 +237,8 @@ describe('CLI command integration', () => {
 
     const content = readFileSync(join(projectDir, 'CLAUDE.md'), 'utf-8');
     expect(content).toContain('# Existing Claude rules');
-    expect(content).toContain('<!-- azure-functions-skills:start');
+    expect(content).not.toContain('<!-- azure-functions-skills:start');
+    expect(existsSync(join(projectDir, 'CLAUDE.azure-functions-skills-new.md'))).toBe(true);
   });
 
   it('workspace apply can opt into MCP and hooks from the CLI', () => {
@@ -827,6 +828,60 @@ describe('CLI command integration', () => {
 
     // Output describes planned actions
     expect(output).toContain('Planned local update');
+  });
+
+  it('update after plugin install saves aside customer-owned routing files', { timeout: 15_000 }, () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-plugin-update-save-aside-');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+    const env = {
+      PATH: pathValue,
+      Path: pathValue,
+      ...(pathext ? { PATHEXT: pathext } : {}),
+    };
+
+    runCli(['install', '--agent', 'claude', '--dir', projectDir, '--yes'], { env });
+    const claudePath = join(projectDir, 'CLAUDE.md');
+    writeFileSync(claudePath, '# My Custom Claude Rules\nNo managed block here.\n');
+
+    const output = runCliOutput(['update', '--agent', 'claude', '--dir', projectDir, '--yes'], { env });
+
+    const updatedContent = readFileSync(claudePath, 'utf-8');
+    expect(updatedContent).toContain('No managed block here.');
+    expect(updatedContent).not.toContain('azure-functions-skills:start');
+    const asidePath = join(projectDir, 'CLAUDE.azure-functions-skills-new.md');
+    expect(existsSync(asidePath)).toBe(true);
+    expect(readFileSync(asidePath, 'utf-8')).toContain('Azure Functions Skills');
+    expect(output).toContain('saved aside');
+    expect(output).toContain('CLAUDE.azure-functions-skills-new.md');
+  });
+
+  it('update --force after plugin install overwrites customer-owned routing files', { timeout: 15_000 }, () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-plugin-update-force-');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+    const env = {
+      PATH: pathValue,
+      Path: pathValue,
+      ...(pathext ? { PATHEXT: pathext } : {}),
+    };
+
+    runCli(['install', '--agent', 'claude', '--dir', projectDir, '--yes'], { env });
+    const claudePath = join(projectDir, 'CLAUDE.md');
+    writeFileSync(claudePath, '# My Custom Claude Rules\nNo managed block here.\n');
+
+    runCli(['update', '--agent', 'claude', '--dir', projectDir, '--yes', '--force'], { env });
+
+    const updatedContent = readFileSync(claudePath, 'utf-8');
+    expect(updatedContent).not.toContain('No managed block here.');
+    expect(updatedContent).toContain('Azure Functions Skills');
+    expect(existsSync(join(projectDir, 'CLAUDE.azure-functions-skills-new.md'))).toBe(false);
   });
 
   it('install rejects mixed mode: local then plugin', { timeout: 15_000 }, () => {

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -781,12 +781,11 @@ describe('CLI command integration', () => {
     // Step 3: Run update (should auto-detect local mode from state)
     runCli(['update', '--agent', 'ghcp', '--dir', projectDir, '--yes']);
 
-    // Verify: MCP file preserved (save-aside strategy)
+    // Verify: MCP file preserved and live settings deep-merged
     const afterUpdate = readFileSync(mcpPath, 'utf-8');
     expect(afterUpdate).toContain('my custom note');
-    // New version saved aside
     const asidePath = join(projectDir, '.mcp.azure-functions-skills-new.json');
-    expect(existsSync(asidePath)).toBe(true);
+    expect(existsSync(asidePath)).toBe(false);
     // Skills should be refreshed (overwrite strategy)
     const skillsDir = join(projectDir, '.github', 'skills');
     expect(existsSync(skillsDir)).toBe(true);

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -197,7 +197,7 @@ describe('CLI command integration', () => {
 
   it('workspace apply --dry-run prints planned plugin-reference changes without writing files for each target', () => {
     const expectations: Array<{ target: BuildTargetName; files: string[] }> = [
-      { target: 'ghcp', files: ['.github/copilot-instructions.md', '.github/copilot/settings.json'] },
+      { target: 'ghcp', files: ['AGENTS.md', '.github/copilot/settings.json'] },
       { target: 'claude', files: ['CLAUDE.md', '.claude/settings.json'] },
       { target: 'codex', files: ['AGENTS.md', '.agents/plugins/marketplace.json'] },
     ];
@@ -283,9 +283,10 @@ describe('CLI command integration', () => {
     expect(output).toContain('Plugin:');
     expect(output).toContain('copilot plugin marketplace add Azure/azure-functions-skills');
     expect(output).toContain('Workspace:');
-    expect(output).toContain('.github/copilot-instructions.md');
+    expect(output).toContain('AGENTS.md');
     expect(output).toContain('.github/agents/functions-copilot.agent.md');
     expect(output).toContain('.mcp.json');
+    expect(output).not.toContain('.github/copilot-instructions.md');
     expect(output).toContain('.github/hooks/welcome-setup.json');
     expect(existsSync(join(projectDir, '.github', 'copilot-instructions.md'))).toBe(false);
   });

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -601,6 +601,112 @@ describe('CLI command integration', () => {
     expect(readFileSync(argsFile, 'utf-8').trim()).toBe('--help hello');
   });
 
+  it('chat --dry-run prints the launch plan without launching or marking setup prompted', () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-chat-dry-run-');
+    const argsFile = join(projectDir, 'agent-args.txt');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+    const env = {
+      PATH: pathValue,
+      Path: pathValue,
+      AF_SKILLS_FAKE_ARGS_FILE: argsFile,
+      ...(pathext ? { PATHEXT: pathext } : {}),
+    };
+
+    runCli(['install', '--agent', 'ghcp', '--dir', projectDir, '--yes'], { env });
+    writeFileSync(argsFile, '');
+
+    const output = runCliOutput(['chat', '--dir', projectDir, '--skip-prerequisites', '--dry-run', '--', '--yolo'], { env });
+
+    expect(output).toContain('Planned chat launch:');
+    expect(output).toContain('Agent: github-copilot');
+    expect(output).toContain('Command: copilot');
+    expect(output).toContain('--agent functions-copilot');
+    expect(output).toContain('--yolo');
+    expect(output).toContain('Startup prompt: included');
+    expect(output).toContain('Setup instruction: included');
+    expect(readFileSync(argsFile, 'utf-8')).toBe('');
+
+    const state = JSON.parse(readFileSync(join(projectDir, '.azure-functions-skills', 'state.local.json'), 'utf-8')) as {
+      setupSkill: { status: string };
+    };
+    expect(state.setupSkill.status).toBe('not-run');
+  });
+
+  it('chat --dry-run reports generated setup context as not included when an explicit agent prompt prevents it', () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-chat-dry-run-explicit-prompt-');
+    const argsFile = join(projectDir, 'agent-args.txt');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+    const env = {
+      PATH: pathValue,
+      Path: pathValue,
+      AF_SKILLS_FAKE_ARGS_FILE: argsFile,
+      ...(pathext ? { PATHEXT: pathext } : {}),
+    };
+
+    runCli(['install', '--agent', 'ghcp', '--dir', projectDir, '--yes'], { env });
+    writeFileSync(argsFile, '');
+
+    const output = runCliOutput([
+      'chat',
+      '--dir', projectDir,
+      '--skip-prerequisites',
+      '--dry-run',
+      '--',
+      '-p', 'headless prompt',
+    ], { env });
+
+    expect(output).toContain('Planned chat launch:');
+    expect(output).toContain('-p "headless prompt"');
+    expect(output).toContain('Startup prompt: not included');
+    expect(output).toContain('Setup instruction: not included');
+    expect(output).not.toContain('<startup prompt>');
+    expect(readFileSync(argsFile, 'utf-8')).toBe('');
+
+    const state = JSON.parse(readFileSync(join(projectDir, '.azure-functions-skills', 'state.local.json'), 'utf-8')) as {
+      setupSkill: { status: string };
+    };
+    expect(state.setupSkill.status).toBe('not-run');
+  });
+
+  it('chat does not mark setup prompted when an explicit agent prompt prevents generated setup context', () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-chat-explicit-agent-prompt-');
+    const argsFile = join(projectDir, 'agent-args.txt');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+    const env = {
+      PATH: pathValue,
+      Path: pathValue,
+      AF_SKILLS_FAKE_ARGS_FILE: argsFile,
+      ...(pathext ? { PATHEXT: pathext } : {}),
+    };
+
+    runCli(['install', '--agent', 'ghcp', '--dir', projectDir, '--yes'], { env });
+    writeFileSync(argsFile, '');
+
+    runCli(['chat', '--dir', projectDir, '--skip-prerequisites', '--', '-p', 'headless prompt'], { env });
+
+    const firstArgs = readFileSync(argsFile, 'utf-8');
+    expect(firstArgs).toContain('-p');
+    expect(firstArgs).toContain('headless prompt');
+    expect(firstArgs).not.toContain('First run azure-functions-setup');
+
+    const state = JSON.parse(readFileSync(join(projectDir, '.azure-functions-skills', 'state.local.json'), 'utf-8')) as {
+      setupSkill: { status: string };
+    };
+    expect(state.setupSkill.status).toBe('not-run');
+  });
+
   it('chat uses state to select the installed agent and prompts setup only until setup-complete', () => {
     const fakeBinDir = createFakeAgentCliDirectory();
     const projectDir = makeTempDir('af-skills-e2e-chat-state-');

--- a/tests/local-update.test.ts
+++ b/tests/local-update.test.ts
@@ -208,35 +208,37 @@ describe('applyLocalUpdate', () => {
     });
   });
 
-  describe('MCP settings use save-aside', () => {
-    it('saves aside .mcp.json preserving existing file', async () => {
+  describe('settings update strategies', () => {
+    it('deep-merges .mcp.json preserving existing custom servers', async () => {
       const dir = makeTempDir();
       setupLocalWorkspace(dir, 'ghcp');
 
-      await applyLocalUpdate(dir, { agents: ['ghcp'] });
+      const result = await applyLocalUpdate(dir, { agents: ['ghcp'] });
 
-      // Original file preserved with user's custom server
-      const original = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
-      expect(original.mcpServers['my-custom-server']).toBeDefined();
+      const merged = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+      expect(merged.mcpServers['my-custom-server']).toBeDefined();
+      expect(merged.mcpServers['azure-functions']).toBeDefined();
 
-      // New file saved aside
       const asidePath = join(dir, '.mcp.azure-functions-skills-new.json');
-      expect(existsSync(asidePath)).toBe(true);
+      expect(existsSync(asidePath)).toBe(false);
+      expect(result.managedBlockUpdated).toContain('.mcp.json');
+      expect(result.savedAside).toHaveLength(0);
     });
 
-    it('saves aside .claude/settings.json preserving existing file', async () => {
+    it('deep-merges .claude/settings.json preserving existing custom servers', async () => {
       const dir = makeTempDir();
       setupLocalWorkspace(dir, 'claude');
 
-      await applyLocalUpdate(dir, { agents: ['claude'] });
+      const result = await applyLocalUpdate(dir, { agents: ['claude'] });
 
-      // Original file preserved
-      const original = JSON.parse(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8'));
-      expect(original.mcpServers['my-custom-server']).toBeDefined();
+      const merged = JSON.parse(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8'));
+      expect(merged.mcpServers['my-custom-server']).toBeDefined();
+      expect(merged.mcpServers['azure-functions']).toBeDefined();
 
-      // New file saved aside
       const asidePath = join(dir, '.claude', 'settings.azure-functions-skills-new.json');
-      expect(existsSync(asidePath)).toBe(true);
+      expect(existsSync(asidePath)).toBe(false);
+      expect(result.managedBlockUpdated).toContain(join('.claude', 'settings.json'));
+      expect(result.savedAside).toHaveLength(0);
     });
 
     it('saves aside .codex/config.toml preserving existing file', async () => {
@@ -310,8 +312,9 @@ describe('applyLocalUpdate', () => {
 
       expect(result.overwritten.length).toBeGreaterThan(0);
       // copilot-instructions.md is no longer generated for GHCP,
-      // so no managed-block updates happen
-      expect(result.savedAside.length).toBeGreaterThan(0);
+      // so only JSON settings are merged.
+      expect(result.managedBlockUpdated).toContain('.mcp.json');
+      expect(result.savedAside).toHaveLength(0);
     });
   });
 
@@ -333,10 +336,10 @@ describe('applyLocalUpdate', () => {
   describe('interactive prompts', () => {
     it('calls prompter for save-aside files when interactive', async () => {
       const dir = makeTempDir();
-      setupLocalWorkspace(dir, 'ghcp');
+      setupLocalWorkspace(dir, 'codex');
 
       const prompter: FilePrompter = vi.fn().mockResolvedValue('skip');
-      await applyLocalUpdate(dir, { agents: ['ghcp'], prompter });
+      await applyLocalUpdate(dir, { agents: ['codex'], prompter });
 
       // prompter should be called for each save-aside candidate
       expect(prompter).toHaveBeenCalled();
@@ -349,42 +352,42 @@ describe('applyLocalUpdate', () => {
 
     it('overwrites file when prompter returns overwrite', async () => {
       const dir = makeTempDir();
-      setupLocalWorkspace(dir, 'ghcp');
+      setupLocalWorkspace(dir, 'codex');
 
       const prompter: FilePrompter = vi.fn().mockResolvedValue('overwrite');
-      const result = await applyLocalUpdate(dir, { agents: ['ghcp'], prompter });
+      const result = await applyLocalUpdate(dir, { agents: ['codex'], prompter });
 
       // No save-aside files — all overwritten
       expect(result.savedAside).toHaveLength(0);
       // The files that would have been save-aside are now in overwritten
       expect(result.overwritten.length).toBeGreaterThan(0);
-      // .mcp.json should be overwritten (user's custom server gone)
-      const mcp = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
-      expect(mcp.mcpServers?.['my-custom-server']).toBeUndefined();
+      // .codex/config.toml should be overwritten (user's custom config gone)
+      const config = readFileSync(join(dir, '.codex', 'config.toml'), 'utf-8');
+      expect(config).not.toContain('# Custom Codex config');
       // No save-aside file
-      expect(existsSync(join(dir, '.mcp.azure-functions-skills-new.json'))).toBe(false);
+      expect(existsSync(join(dir, '.codex', 'config.azure-functions-skills-new.toml'))).toBe(false);
     });
 
     it('saves aside file when prompter returns skip', async () => {
       const dir = makeTempDir();
-      setupLocalWorkspace(dir, 'ghcp');
+      setupLocalWorkspace(dir, 'codex');
 
       const prompter: FilePrompter = vi.fn().mockResolvedValue('skip');
-      const result = await applyLocalUpdate(dir, { agents: ['ghcp'], prompter });
+      const result = await applyLocalUpdate(dir, { agents: ['codex'], prompter });
 
       // Save-aside files created
       expect(result.savedAside.length).toBeGreaterThan(0);
-      // User's custom MCP server preserved
-      const mcp = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
-      expect(mcp.mcpServers['my-custom-server']).toBeDefined();
+      // User's custom Codex config preserved
+      const config = readFileSync(join(dir, '.codex', 'config.toml'), 'utf-8');
+      expect(config).toContain('# Custom Codex config');
     });
 
     it('does not call prompter when not provided (non-interactive)', async () => {
       const dir = makeTempDir();
-      setupLocalWorkspace(dir, 'ghcp');
+      setupLocalWorkspace(dir, 'codex');
 
       // No prompter — should default to save-aside
-      const result = await applyLocalUpdate(dir, { agents: ['ghcp'] });
+      const result = await applyLocalUpdate(dir, { agents: ['codex'] });
 
       expect(result.savedAside.length).toBeGreaterThan(0);
     });
@@ -401,10 +404,10 @@ describe('applyLocalUpdate', () => {
 
     it('does not call prompter when --yes is set', async () => {
       const dir = makeTempDir();
-      setupLocalWorkspace(dir, 'ghcp');
+      setupLocalWorkspace(dir, 'codex');
 
       const prompter: FilePrompter = vi.fn().mockResolvedValue('overwrite');
-      const result = await applyLocalUpdate(dir, { agents: ['ghcp'], yes: true, prompter });
+      const result = await applyLocalUpdate(dir, { agents: ['codex'], yes: true, prompter });
 
       expect(prompter).not.toHaveBeenCalled();
       // --yes defaults to save-aside for shared files

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -204,7 +204,7 @@ describe('planPluginOperation', () => {
         { command: 'codex', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
         { command: 'codex', args: ['plugin', 'add', 'azure-functions-skills@azure-functions-skills'] },
       ]);
-      expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(true);
+      expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(false);
       expect(existsSync(join(dir, '.github', 'agents', 'functions-copilot.agent.md'))).toBe(true);
       expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(true);
       expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
@@ -234,7 +234,7 @@ describe('planPluginOperation', () => {
         { command: 'codex', args: ['plugin', 'marketplace', 'add', 'Azure/azure-functions-skills'] },
         { command: 'codex', args: ['plugin', 'add', 'azure-functions-skills@azure-functions-skills'] },
       ]);
-      expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(true);
+      expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(false);
       expect(existsSync(join(dir, '.github', 'agents', 'functions-copilot.agent.md'))).toBe(true);
       expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
       expect(result.filesWritten).toBeGreaterThan(0);

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -319,8 +319,9 @@ describe('planPluginOperation', () => {
     });
 
     const command = plan.steps[0].commands?.[0] || '';
+    const normalizedRoot = process.cwd().replaceAll('\\', '/');
     expect(command.replaceAll('\\', '/')).toContain('claude plugin marketplace add');
-    expect(command.replaceAll('\\', '/')).toContain('/azure-functions-skills --scope local');
+    expect(command.replaceAll('\\', '/')).toContain(`${normalizedRoot} --scope local`);
     expect(plan.steps[0].commands?.[1]).toBe('claude plugin install azure-functions-skills@azure-functions-skills --scope local');
   });
 

--- a/tests/workspace-apply.test.ts
+++ b/tests/workspace-apply.test.ts
@@ -126,11 +126,11 @@ describe('applyWorkspace', () => {
       mergeStrategy: 'managed-block',
     });
 
-    expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(true);
+    expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(false);
+    expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
     expect(existsSync(join(dir, '.github', 'copilot', 'settings.json'))).toBe(true);
     expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(true);
     expect(existsSync(join(dir, '.claude', 'settings.json'))).toBe(true);
-    expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
     expect(existsSync(join(dir, '.agents', 'plugins', 'marketplace.json'))).toBe(true);
 
     expect(existsSync(join(dir, '.github', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(false);
@@ -152,8 +152,13 @@ describe('applyWorkspace', () => {
     const agentPath = join(dir, '.github', 'agents', 'functions-copilot.agent.md');
     expect(existsSync(agentPath)).toBe(true);
     expect(readFileSync(agentPath, 'utf-8')).toContain('name: functions-copilot');
+    expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
+    expect(readFileSync(join(dir, 'AGENTS.md'), 'utf-8')).toContain('Azure Functions Development Standards');
+    expect(existsSync(join(dir, '.github', 'copilot-instructions.md'))).toBe(false);
     expect(existsSync(join(dir, '.github', 'skills', 'azure-functions-setup', 'SKILL.md'))).toBe(false);
     expect(result.plannedFiles).toContain('.github/agents/functions-copilot.agent.md');
+    expect(result.plannedFiles).toContain('AGENTS.md');
+    expect(result.plannedFiles).not.toContain('.github/copilot-instructions.md');
   });
 
   it('dry-run reports planned changes without writing files', async () => {

--- a/tests/workspace-apply.test.ts
+++ b/tests/workspace-apply.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadSkills } from '../src/build/loader.js';
@@ -23,21 +23,24 @@ afterEach(() => {
 });
 
 describe('applyWorkspace', () => {
-  it('refuses to append to existing Claude instructions without approval', async () => {
+  it('saves aside generated routing without modifying existing Claude instructions when not approved', async () => {
     const dir = makeTempDir();
     const claudePath = join(dir, 'CLAUDE.md');
     writeFileSync(claudePath, ['# Project Rules', '', 'Keep this file careful.'].join('\n'));
 
-    await expect(applyWorkspace(dir, {
+    const result = await applyWorkspace(dir, {
       agents: ['claude'],
       mode: 'plugin-reference',
       mergeStrategy: 'managed-block',
-    })).rejects.toThrow(/Refusing to modify existing customer-owned file/);
+    });
 
     expect(readFileSync(claudePath, 'utf-8')).not.toContain('azure-functions-skills:start');
+    expect(readFileSync(claudePath, 'utf-8')).toContain('Keep this file careful.');
+    expect(existsSync(join(dir, 'CLAUDE.azure-functions-skills-new.md'))).toBe(true);
+    expect(result.savedAside).toHaveLength(1);
   });
 
-  it('appends a managed block to existing Claude instructions when approved', async () => {
+  it('saves aside generated routing when existing Claude instructions are customer-owned', async () => {
     const dir = makeTempDir();
     const claudePath = join(dir, 'CLAUDE.md');
     writeFileSync(claudePath, ['# Project Rules', '', 'Keep this file careful.'].join('\n'));
@@ -51,8 +54,12 @@ describe('applyWorkspace', () => {
 
     const content = readFileSync(claudePath, 'utf-8');
     expect(content).toContain('Keep this file careful.');
-    expect(content).toContain('<!-- azure-functions-skills:start');
+    expect(content).not.toContain('<!-- azure-functions-skills:start');
+    const asidePath = join(dir, 'CLAUDE.azure-functions-skills-new.md');
+    expect(existsSync(asidePath)).toBe(true);
+    expect(readFileSync(asidePath, 'utf-8')).toContain('Azure Functions Skills');
     expect(result.filesWritten).toBeGreaterThan(0);
+    expect(result.savedAside).toEqual([{ original: 'CLAUDE.md', aside: 'CLAUDE.azure-functions-skills-new.md' }]);
   });
 
   it('preserves customer content while replacing the managed block', async () => {
@@ -187,6 +194,98 @@ describe('applyWorkspace', () => {
     const codexHooks = readFileSync(join(dir, '.codex', 'hooks.json'), 'utf-8');
     expect(codexHooks).toContain('node -e');
     expect(codexHooks).not.toContain('bash -c');
+  });
+
+  it('deep-merges JSON settings so plugin activation stays live', async () => {
+    const dir = makeTempDir();
+    const settingsPath = join(dir, '.github', 'copilot', 'settings.json');
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({ existingSetting: true }, null, 2));
+
+    const result = await applyWorkspace(dir, {
+      agents: ['ghcp'],
+      mode: 'plugin-reference',
+      includeMcp: true,
+      includeHooks: true,
+      includeAgent: true,
+    });
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      existingSetting?: boolean;
+      enabledPlugins?: Record<string, boolean>;
+      extraKnownMarketplaces?: Record<string, unknown>;
+    };
+    expect(settings.existingSetting).toBe(true);
+    expect(settings.enabledPlugins?.['azure-functions-skills@azure-functions-skills']).toBe(true);
+    expect(settings.extraKnownMarketplaces?.['azure-functions-skills']).toBeTruthy();
+    expect(result.savedAside).toHaveLength(0);
+  });
+
+  it('coalesces Claude plugin and MCP settings before applying conflict policy', async () => {
+    const dir = makeTempDir();
+    const settingsPath = join(dir, '.claude', 'settings.json');
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({ existingSetting: true }, null, 2));
+
+    await applyWorkspace(dir, {
+      agents: ['claude'],
+      mode: 'plugin-reference',
+      includeMcp: true,
+    });
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      existingSetting?: boolean;
+      enabledPlugins?: Record<string, boolean>;
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(settings.existingSetting).toBe(true);
+    expect(settings.enabledPlugins?.['azure-functions-skills@azure-functions-skills']).toBe(true);
+    expect(Object.keys(settings.mcpServers || {}).length).toBeGreaterThan(0);
+  });
+
+  it('saves aside non-JSON settings unless force is set', async () => {
+    const dir = makeTempDir();
+    const configPath = join(dir, '.codex', 'config.toml');
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, 'custom = true\n');
+
+    const result = await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      includeMcp: true,
+      yes: true,
+    });
+
+    expect(readFileSync(configPath, 'utf-8')).toBe('custom = true\n');
+    const asidePath = join(dir, '.codex', 'config.azure-functions-skills-new.toml');
+    expect(existsSync(asidePath)).toBe(true);
+    expect(readFileSync(asidePath, 'utf-8')).toContain('Azure Functions MCP Servers');
+    expect(result.savedAside).toEqual([{ original: '.codex/config.toml', aside: join('.codex', 'config.azure-functions-skills-new.toml') }]);
+  });
+
+  it('force overwrites customer-owned routing and non-JSON settings', async () => {
+    const dir = makeTempDir();
+    const agentsPath = join(dir, 'AGENTS.md');
+    const configPath = join(dir, '.codex', 'config.toml');
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(agentsPath, 'CUSTOM AGENTS\n');
+    writeFileSync(configPath, 'custom = true\n');
+
+    const result = await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      includeMcp: true,
+      force: true,
+      yes: true,
+    });
+
+    expect(readFileSync(agentsPath, 'utf-8')).not.toContain('CUSTOM AGENTS');
+    expect(readFileSync(agentsPath, 'utf-8')).toContain('For Azure Functions work');
+    expect(readFileSync(configPath, 'utf-8')).not.toContain('custom = true');
+    expect(readFileSync(configPath, 'utf-8')).toContain('Azure Functions MCP Servers');
+    expect(result.savedAside).toHaveLength(0);
+    expect(result.overwritten).toContain('AGENTS.md');
+    expect(result.overwritten).toContain('.codex/config.toml');
   });
 
   it('include-file strategy creates an include target and avoids duplicate include lines', async () => {


### PR DESCRIPTION
## Summary
- rebased onto latest `main`, including GHCP MCP workspace config path change to root `.mcp.json`
- keep generated Azure Functions startup/setup context when chat forwards passthrough args
- add `chat --dry-run` to preview resolved agent launch without spawning or mutating setup state
- align plugin workspace activation updates with local update conflict handling: customer-owned routing/TOML files save aside by default, `--force` overwrites, JSON settings remain live via deep merge
- align local updates for JSON settings (`.mcp.json`, `.claude/settings.json`) with plugin mode by deep-merging instead of save-aside
- align GHCP plugin activation with local GHCP layout: use `AGENTS.md` + `.github/agents/functions-copilot.agent.md`, and stop generating `.github/copilot-instructions.md`
- document the new chat dry-run flag and cover passthrough/dry-run/workspace update edge cases

## Validation
- npm run compile
- npm run lint
- npm run typecheck
- npm test
- isolated workspace E2E: `chat --dry-run -- --yolo`
- isolated workspace E2E: GHCP plugin install creates `AGENTS.md`, `.github/agents/functions-copilot.agent.md`, root `.mcp.json`, `.github/copilot/settings.json`; does not create `.github/copilot-instructions.md`, `.vscode/mcp.json`, or local skill bodies
- isolated workspace E2E: local and plugin GHCP `install -> update --yes` both preserve custom `.mcp.json` entries, deep-merge live `mcpServers`, and do not create `.mcp.azure-functions-skills-new.json`
- isolated workspace E2E per agent: `install --agent ghcp|claude|codex` → customize routing → `update --agent ... --yes` preserves custom routing and creates `*.azure-functions-skills-new.*`
- isolated workspace E2E per agent: `install --agent ghcp|claude|codex` → customize routing → `update --agent ... --yes --force` overwrites custom routing without save-aside