### PR TITLE
Preserve plugin workspace artifacts on update

### DIFF
--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -94,6 +94,7 @@ Options:
   --no-workspace     Skip workspace activation
   --dry-run          Print planned changes without writing files
   --yes              Approve workspace activation changes to existing instruction files
+  --force            Overwrite workspace activation files instead of saving aside
 `,
   'workspace apply': `Usage: azure-functions-skills workspace apply [options]
 
@@ -614,6 +615,7 @@ if (command === 'install' || command === 'update') {
       includeMcp,
       includeHooks,
       includeAgent: true,
+      force,
     });
 
     if (dryRun) {
@@ -919,6 +921,7 @@ if (command === 'install' || command === 'update') {
   let workspace = true;
   let dryRun = false;
   let yes = false;
+  let force = false;
 
   for (let i = 2; i < args.length; i++) {
     if (args[i] === '--agent' && args[i + 1]) agents.push(args[++i]);
@@ -930,6 +933,7 @@ if (command === 'install' || command === 'update') {
     else if (args[i] === '--no-workspace') workspace = false;
     else if (args[i] === '--dry-run') dryRun = true;
     else if (args[i] === '--yes') yes = true;
+    else if (args[i] === '--force') force = true;
   }
 
   const detectedAgents = agents.length > 0 ? agents : await detectAgents();
@@ -945,6 +949,7 @@ if (command === 'install' || command === 'update') {
       version,
       workspace,
       yes,
+      force,
     });
   } catch (err) {
     console.error(err.message);

--- a/src/setup/local-update.ts
+++ b/src/setup/local-update.ts
@@ -9,12 +9,15 @@
  */
 
 import { existsSync, cpSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import { basename, dirname, extname, join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { buildTarget } from '../build/build-target.js';
 import { loadAgents, loadHooks, loadMcpServers, loadSkills } from '../build/loader.js';
 import type { BuildData, CliAgentName } from '../types.js';
+import { resolveUniqueAsidePath } from './save-aside.js';
+
+export { saveAsidePath } from './save-aside.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', '..', 'templates');
@@ -97,20 +100,6 @@ export async function applyLocalUpdate(targetDir: string, options: LocalUpdateOp
   }
 
   return result;
-}
-
-/**
- * Generate the save-aside path for a file, preserving the original extension.
- * Example: `CLAUDE.md` → `CLAUDE.azure-functions-skills-new.md`
- */
-export function saveAsidePath(filePath: string): string {
-  const dir = dirname(filePath);
-  const ext = extname(filePath);
-  const base = basename(filePath, ext);
-  const aside = ext
-    ? `${base}.azure-functions-skills-new${ext}`
-    : `${base}.azure-functions-skills-new`;
-  return dir === '.' ? aside : join(dir, aside);
 }
 
 /**
@@ -346,32 +335,4 @@ function buildManagedBlock(generatedContent: string): string {
 
   // Otherwise wrap the content in a managed block
   return `<!-- azure-functions-skills:start version=0.12.1 -->\n${generatedContent.trimEnd()}\n<!-- azure-functions-skills:end -->`;
-}
-
-/**
- * Find a unique save-aside path, appending numeric suffixes if needed.
- */
-function resolveUniqueAsidePath(targetDir: string, relativePath: string): string {
-  const candidate = saveAsidePath(relativePath);
-  if (!existsSync(join(targetDir, candidate))) return candidate;
-
-  const dir = dirname(candidate);
-  // Remove the .azure-functions-skills-new part to get base + original ext
-  const originalExt = extname(relativePath);
-  const originalBase = basename(relativePath, originalExt);
-
-  for (let i = 1; i < 100; i++) {
-    const numbered = originalExt
-      ? `${originalBase}.azure-functions-skills-new.${i}${originalExt}`
-      : `${originalBase}.azure-functions-skills-new.${i}`;
-    const numberedPath = dir === '.' ? numbered : join(dir, numbered);
-    if (!existsSync(join(targetDir, numberedPath))) return numberedPath;
-  }
-
-  // Fallback with timestamp
-  const ts = Date.now();
-  const fallback = originalExt
-    ? `${originalBase}.azure-functions-skills-new.${ts}${originalExt}`
-    : `${originalBase}.azure-functions-skills-new.${ts}`;
-  return dir === '.' ? fallback : join(dir, fallback);
 }

--- a/src/setup/plugin-install.ts
+++ b/src/setup/plugin-install.ts
@@ -46,6 +46,7 @@ export interface PluginOperationOptions {
   runner?: CommandRunner;
   platform?: NodeJS.Platform;
   yes?: boolean;
+  force?: boolean;
   passthroughArgs?: string[];
 }
 
@@ -272,6 +273,7 @@ export async function runPluginOperation(options: PluginOperationOptions): Promi
       mergeStrategy: 'managed-block',
       update: options.action === 'update',
       yes: options.yes,
+      force: options.force,
       includeAgent: true,
     });
     result.filesWritten += workspaceResult.filesWritten;

--- a/src/setup/save-aside.ts
+++ b/src/setup/save-aside.ts
@@ -1,0 +1,42 @@
+import { basename, dirname, extname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+/**
+ * Generate the save-aside path for a file, preserving the original extension.
+ * Example: `CLAUDE.md` -> `CLAUDE.azure-functions-skills-new.md`
+ */
+export function saveAsidePath(filePath: string): string {
+  const dir = dirname(filePath);
+  const ext = extname(filePath);
+  const base = basename(filePath, ext);
+  const aside = ext
+    ? `${base}.azure-functions-skills-new${ext}`
+    : `${base}.azure-functions-skills-new`;
+  return dir === '.' ? aside : join(dir, aside);
+}
+
+/**
+ * Find a unique save-aside path, appending numeric suffixes if needed.
+ */
+export function resolveUniqueAsidePath(targetDir: string, relativePath: string): string {
+  const candidate = saveAsidePath(relativePath);
+  if (!existsSync(join(targetDir, candidate))) return candidate;
+
+  const dir = dirname(candidate);
+  const originalExt = extname(relativePath);
+  const originalBase = basename(relativePath, originalExt);
+
+  for (let i = 1; i < 100; i++) {
+    const numbered = originalExt
+      ? `${originalBase}.azure-functions-skills-new.${i}${originalExt}`
+      : `${originalBase}.azure-functions-skills-new.${i}`;
+    const numberedPath = dir === '.' ? numbered : join(dir, numbered);
+    if (!existsSync(join(targetDir, numberedPath))) return numberedPath;
+  }
+
+  const ts = Date.now();
+  const fallback = originalExt
+    ? `${originalBase}.azure-functions-skills-new.${ts}${originalExt}`
+    : `${originalBase}.azure-functions-skills-new.${ts}`;
+  return dir === '.' ? fallback : join(dir, fallback);
+}

--- a/src/setup/workspace.ts
+++ b/src/setup/workspace.ts
@@ -3,17 +3,24 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadMcpServers, loadSkills } from '../build/loader.js';
 import { applySetup, detectAgents } from './index.js';
+import { resolveUniqueAsidePath } from './save-aside.js';
 import type { CliAgentName, McpServer, MergeStrategy, WorkspaceApplyOptions, WorkspaceApplyResult, WorkspaceMode } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', '..', 'templates');
 const BLOCK_START = '<!-- azure-functions-skills:start';
 const BLOCK_END = '<!-- azure-functions-skills:end -->';
+const BLOCK_PATTERN = /<!-- azure-functions-skills:start[^\n]* -->[\s\S]*?<!-- azure-functions-skills:end -->/;
 
 type PlannedFile = {
   path: string;
   content: string;
   merge?: boolean;
+};
+
+type PlannedWrite = {
+  path: string;
+  content: string;
 };
 
 export async function applyWorkspace(targetDir: string, options: WorkspaceApplyOptions = {}): Promise<WorkspaceApplyResult> {
@@ -22,6 +29,7 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
   const mergeStrategy = options.mergeStrategy || 'managed-block';
   const dryRun = options.dryRun === true;
   const approved = options.yes === true;
+  const force = options.force === true;
 
   if (mode === 'copy') {
     if (dryRun) {
@@ -44,27 +52,34 @@ export async function applyWorkspace(targetDir: string, options: WorkspaceApplyO
   }
 
   const plannedFiles = agents.flatMap(agent => activationFiles(agent, mode, options));
+  const combinedFiles = combinePlannedFiles(plannedFiles);
   if (dryRun) {
     return {
       agents,
       mode,
       filesWritten: 0,
-      plannedFiles: plannedFiles.flatMap(file => plannedWorkspacePaths(file, mergeStrategy)),
+      plannedFiles: plannedDryRunPaths(targetDir, combinedFiles, mergeStrategy, options.update === true, force),
       dryRun,
     };
   }
 
-  let filesWritten = 0;
-  for (const file of plannedFiles) {
-    const fullPath = join(targetDir, file.path);
-    const content = file.merge
-      ? mergeInstructionFile(fullPath, file.content, mergeStrategy, options.update === true, approved)
-      : mergeJsonLikeFile(fullPath, file.content);
-    mkdirSync(dirname(fullPath), { recursive: true });
-    writeFileSync(fullPath, content);
-    filesWritten++;
+  const existingAtStart = new Set(
+    combinedFiles
+      .map(file => file.path)
+      .filter(path => existsSync(join(targetDir, path))),
+  );
 
-    if (file.merge && mergeStrategy === 'include-file') {
+  let filesWritten = 0;
+  for (const file of combinedFiles) {
+    const writes = plannedWritesForFile(targetDir, file, mergeStrategy, options.update === true, approved, force, existingAtStart);
+    for (const write of writes) {
+      const fullPath = join(targetDir, write.path);
+      mkdirSync(dirname(fullPath), { recursive: true });
+      writeFileSync(fullPath, write.content);
+      filesWritten++;
+    }
+
+    if (file.merge && mergeStrategy === 'include-file' && writes.some(write => write.path === file.path)) {
       const includeFullPath = join(targetDir, includeInstructionPath(file.path));
       mkdirSync(dirname(includeFullPath), { recursive: true });
       writeFileSync(includeFullPath, ensureTrailingNewline(file.content));
@@ -118,15 +133,93 @@ function plannedWorkspacePaths(file: PlannedFile, strategy: MergeStrategy): stri
   return [file.path];
 }
 
-function mergeInstructionFile(filePath: string, generatedContent: string, strategy: MergeStrategy, update: boolean, approved: boolean): string {
+function plannedDryRunPaths(targetDir: string, files: PlannedFile[], strategy: MergeStrategy, update: boolean, force: boolean): string[] {
+  return files.flatMap(file => {
+    if (force || !update) return plannedWorkspacePaths(file, strategy);
+
+    if (file.merge) {
+      const fullPath = join(targetDir, file.path);
+      if (!existsSync(fullPath)) return plannedWorkspacePaths(file, strategy);
+      const existing = readFileSync(fullPath, 'utf-8');
+      if (BLOCK_PATTERN.test(existing)) return plannedWorkspacePaths(file, strategy);
+      return [resolveUniqueAsidePath(targetDir, file.path)];
+    }
+
+    if (existsSync(join(targetDir, file.path)) && isSettingsFile(file.path)) {
+      return [resolveUniqueAsidePath(targetDir, file.path)];
+    }
+
+    return [file.path];
+  });
+}
+
+function combinePlannedFiles(files: PlannedFile[]): PlannedFile[] {
+  const combined = new Map<string, PlannedFile>();
+  const result: PlannedFile[] = [];
+
+  for (const file of files) {
+    const existing = combined.get(file.path);
+    if (!existing || existing.merge || file.merge) {
+      combined.set(file.path, file);
+      result.push(file);
+      continue;
+    }
+
+    existing.content = mergeGeneratedContent(existing.content, file.content);
+  }
+
+  return result;
+}
+
+function mergeGeneratedContent(existingContent: string, nextContent: string): string {
+  try {
+    const existing = JSON.parse(existingContent) as Record<string, unknown>;
+    const next = JSON.parse(nextContent) as Record<string, unknown>;
+    return JSON.stringify(deepMerge(existing, next), null, 2);
+  } catch {
+    return nextContent;
+  }
+}
+
+function plannedWritesForFile(
+  targetDir: string,
+  file: PlannedFile,
+  strategy: MergeStrategy,
+  update: boolean,
+  approved: boolean,
+  force: boolean,
+  existingAtStart: Set<string>,
+): PlannedWrite[] {
+  if (file.merge) {
+    return instructionFileWrites(targetDir, file.path, file.content, strategy, update, approved, force);
+  }
+
+  if (force) {
+    return [{ path: file.path, content: ensureTrailingNewline(file.content) }];
+  }
+
+  if (update && existingAtStart.has(file.path) && isSettingsFile(file.path)) {
+    return [{ path: resolveUniqueAsidePath(targetDir, file.path), content: ensureTrailingNewline(file.content) }];
+  }
+
+  const fullPath = join(targetDir, file.path);
+  return [{ path: file.path, content: mergeJsonLikeFile(fullPath, file.content) }];
+}
+
+function instructionFileWrites(targetDir: string, relativePath: string, generatedContent: string, strategy: MergeStrategy, update: boolean, approved: boolean, force: boolean): PlannedWrite[] {
+  const filePath = join(targetDir, relativePath);
   const block = managedBlock(generatedContent);
-  if (!existsSync(filePath)) return `${block}\n`;
+  if (force) return [{ path: relativePath, content: `${block}\n` }];
+  if (!existsSync(filePath)) return [{ path: relativePath, content: `${block}\n` }];
 
   const existing = readFileSync(filePath, 'utf-8');
-  const blockPattern = /<!-- azure-functions-skills:start[^\n]* -->[\s\S]*?<!-- azure-functions-skills:end -->/;
-  if (blockPattern.test(existing)) {
-    if (!update) return existing;
-    return ensureTrailingNewline(existing.replace(blockPattern, block));
+  if (BLOCK_PATTERN.test(existing)) {
+    if (!update) return [{ path: relativePath, content: existing }];
+    return [{ path: relativePath, content: ensureTrailingNewline(existing.replace(BLOCK_PATTERN, block)) }];
+  }
+
+  if (update) {
+    return [{ path: resolveUniqueAsidePath(targetDir, relativePath), content: `${block}\n` }];
   }
 
   if (strategy === 'fail-if-exists') {
@@ -138,16 +231,19 @@ function mergeInstructionFile(filePath: string, generatedContent: string, strate
   }
 
   if (strategy === 'append' || strategy === 'managed-block') {
-    return `${existing.trimEnd()}\n\n${block}\n`;
+    return [{ path: relativePath, content: `${existing.trimEnd()}\n\n${block}\n` }];
   }
 
   if (strategy === 'include-file') {
     const includePath = includeInstructionPath(filePath);
     const includeLine = `See ${includePath} for Azure Functions routing.`;
-    return existing.includes(includeLine) ? ensureTrailingNewline(existing) : `${existing.trimEnd()}\n\n${includeLine}\n`;
+    return [{
+      path: relativePath,
+      content: existing.includes(includeLine) ? ensureTrailingNewline(existing) : `${existing.trimEnd()}\n\n${includeLine}\n`,
+    }];
   }
 
-  return `${existing.trimEnd()}\n\n${block}\n`;
+  return [{ path: relativePath, content: `${existing.trimEnd()}\n\n${block}\n` }];
 }
 
 function mergeJsonLikeFile(filePath: string, generatedContent: string): string {
@@ -175,6 +271,16 @@ function deepMerge(existing: Record<string, unknown>, generated: Record<string, 
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSettingsFile(relativePath: string): boolean {
+  const normalized = relativePath.replaceAll('\\', '/');
+  return normalized === '.mcp.json' ||
+    normalized === '.vscode/mcp.json' ||
+    normalized === '.claude/settings.json' ||
+    normalized === '.codex/config.toml' ||
+    normalized === '.github/copilot/settings.json' ||
+    normalized === '.agents/plugins/marketplace.json';
 }
 
 function managedBlock(content: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface WorkspaceApplyOptions {
   update?: boolean;
   dryRun?: boolean;
   yes?: boolean;
+  force?: boolean;
   includeMcp?: boolean;
   includeHooks?: boolean;
   includeAgent?: boolean;

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -723,6 +723,45 @@ describe('CLI command integration', () => {
     expect(output).toContain('Planned local update');
   });
 
+  it('update after plugin install auto-detects plugin mode and preserves workspace settings', { timeout: 30_000 }, () => {
+    const fakeBinDir = createFakeAgentCliDirectory();
+    const projectDir = makeTempDir('af-skills-e2e-plugin-update-preserve-');
+    const pathValue = `${fakeBinDir}${delimiter}${process.env.PATH || ''}`;
+    const pathext = process.platform === 'win32'
+      ? `.CMD;.EXE;.BAT;.COM;${process.env.PATHEXT || ''}`
+      : process.env.PATHEXT;
+    const env = {
+      PATH: pathValue,
+      Path: pathValue,
+      ...(pathext ? { PATHEXT: pathext } : {}),
+    };
+
+    runCli(['install', '--agent', 'codex', '--dir', projectDir, '--yes'], { env });
+
+    const configPath = join(projectDir, '.codex', 'config.toml');
+    const customConfig = [
+      '# Custom Codex MCP config',
+      '',
+      '[mcp_servers.custom]',
+      'command = "custom-tool"',
+      '',
+    ].join('\n');
+    writeFileSync(configPath, customConfig);
+
+    runCli(['update', '--agent', 'codex', '--dir', projectDir, '--yes'], { env });
+
+    expect(readFileSync(configPath, 'utf-8')).toBe(customConfig);
+    const asidePath = join(projectDir, '.codex', 'config.azure-functions-skills-new.toml');
+    expect(existsSync(asidePath)).toBe(true);
+    expect(readFileSync(asidePath, 'utf-8')).toContain('[mcp_servers.');
+
+    runCli(['update', '--agent', 'codex', '--dir', projectDir, '--yes', '--force'], { env });
+
+    const forcedUpdate = readFileSync(configPath, 'utf-8');
+    expect(forcedUpdate).not.toBe(customConfig);
+    expect(forcedUpdate).toContain('[mcp_servers.');
+  });
+
   it('install rejects mixed mode: local then plugin', { timeout: 15_000 }, () => {
     const fakeBinDir = createFakeAgentCliDirectory();
     const projectDir = makeTempDir('af-skills-e2e-mixed-mode-');

--- a/tests/workspace-apply.test.ts
+++ b/tests/workspace-apply.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadSkills } from '../src/build/loader.js';
@@ -87,6 +87,93 @@ describe('applyWorkspace', () => {
     expect(content).toContain('For Azure Functions work, prefer the Azure Functions Skills plugin');
     expect(content).not.toContain('old generated content');
     expect(result.filesWritten).toBeGreaterThan(0);
+  });
+
+  it('plugin-reference update saves customer-owned routing aside instead of appending', async () => {
+    const dir = makeTempDir();
+    const agentsPath = join(dir, 'AGENTS.md');
+    const customContent = ['# Project Agents', '', 'Keep this file custom.'].join('\n');
+    writeFileSync(agentsPath, customContent);
+
+    await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      mergeStrategy: 'managed-block',
+      update: true,
+      yes: true,
+    });
+
+    expect(readFileSync(agentsPath, 'utf-8')).toBe(customContent);
+    const asidePath = join(dir, 'AGENTS.azure-functions-skills-new.md');
+    expect(existsSync(asidePath)).toBe(true);
+    expect(readFileSync(asidePath, 'utf-8')).toContain('Azure Functions Skills');
+  });
+
+  it('plugin-reference update saves existing settings aside instead of overwriting', async () => {
+    const dir = makeTempDir();
+    const configPath = join(dir, '.codex', 'config.toml');
+    mkdirSync(dirname(configPath), { recursive: true });
+    const customConfig = [
+      '# Custom Codex MCP config',
+      '',
+      '[mcp_servers.custom]',
+      'command = "custom-tool"',
+      '',
+    ].join('\n');
+    writeFileSync(configPath, customConfig);
+
+    await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      update: true,
+      includeMcp: true,
+      yes: true,
+    });
+
+    expect(readFileSync(configPath, 'utf-8')).toBe(customConfig);
+    const asidePath = join(dir, '.codex', 'config.azure-functions-skills-new.toml');
+    expect(existsSync(asidePath)).toBe(true);
+    expect(readFileSync(asidePath, 'utf-8')).toContain('[mcp_servers.');
+  });
+
+  it('plugin-reference update dry-run reports save-aside targets for existing settings', async () => {
+    const dir = makeTempDir();
+    const configPath = join(dir, '.codex', 'config.toml');
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '[mcp_servers.custom]\ncommand = "custom-tool"\n');
+
+    const result = await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      update: true,
+      includeMcp: true,
+      dryRun: true,
+    });
+
+    expect(result.filesWritten).toBe(0);
+    expect(result.plannedFiles).toContain(join('.codex', 'config.azure-functions-skills-new.toml'));
+    expect(result.plannedFiles).not.toContain(join('.codex', 'config.toml'));
+    expect(readFileSync(configPath, 'utf-8')).toContain('custom-tool');
+  });
+
+  it('plugin-reference update force overwrites existing settings', async () => {
+    const dir = makeTempDir();
+    const configPath = join(dir, '.codex', 'config.toml');
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '[mcp_servers.custom]\ncommand = "custom-tool"\n');
+
+    await applyWorkspace(dir, {
+      agents: ['codex'],
+      mode: 'plugin-reference',
+      update: true,
+      includeMcp: true,
+      force: true,
+    });
+
+    const updated = readFileSync(configPath, 'utf-8');
+    expect(updated).not.toContain('custom-tool');
+    expect(updated).toContain('[mcp_servers.');
+    expect(existsSync(join(dir, '.codex', 'config.azure-functions-skills-new.toml'))).toBe(false);
   });
 
   it('generates routing guidance from current skill templates', async () => {


### PR DESCRIPTION
## Summary
- make plugin-mode `update` preserve existing workspace activation artifacts using save-aside behavior aligned with local update
- share save-aside path generation between local update and workspace activation
- support `--force` for plugin update workspace activation and make dry-run report save-aside targets

## Tests
- `npm run lint`
- `npm run compile`
- `npm run typecheck`
- `npm test`
- `node bin\\azure-functions-skills.js update --agent codex --dir <temp-workspace> --dry-run --source local --yes`

Stacked on #164 (`fix/ghcp-mcp-json`) to avoid mixing with the existing GHCP MCP path PR.