### PR TITLE
chore: prepare v0.0.5-preview release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Azure Functions coding agent skills and MCP guidance",
-    "version": "0.0.3-preview"
+    "version": "0.0.5-preview"
   },
   "plugins": [
     {
       "name": "azure-functions-skills",
       "source": "./.github/plugins/azure-functions-skills",
       "description": "Azure Functions skills for setup, create, and deploy workflows",
-      "version": "0.0.3-preview",
+      "version": "0.0.5-preview",
       "category": "Development",
       "tags": [
         "azure-functions",

--- a/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.5-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/"
 }

--- a/.github/plugins/azure-functions-skills/.codex-plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.5-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.github/plugins/azure-functions-skills/.plugin/plugin.json
+++ b/.github/plugins/azure-functions-skills/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.5-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.github/plugins/azure-functions-skills/plugin.json
+++ b/.github/plugins/azure-functions-skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.5-preview",
   "description": "Azure Functions skills for setup, create, and deploy workflows",
   "skills": "./skills/",
   "interface": {

--- a/.plugin/marketplace.json
+++ b/.plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Azure Functions coding agent skills and MCP guidance",
-    "version": "0.0.3-preview"
+    "version": "0.0.5-preview"
   },
   "plugins": [
     {
       "name": "azure-functions-skills",
       "source": "./.github/plugins/azure-functions-skills",
       "description": "Azure Functions skills for setup, create, and deploy workflows",
-      "version": "0.0.3-preview",
+      "version": "0.0.5-preview",
       "category": "Development",
       "tags": [
         "azure-functions",

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,8 +101,8 @@ node bin/azure-functions-skills.js chat --agent codex --dir ../tmp-functions-app
 Use the local release helper from a clean `main` branch that matches `origin/main`:
 
 ```bash
-npm run release:local -- 0.0.3-preview --dry-run
-npm run release:local -- 0.0.3-preview --yes
+npm run release:local -- 0.0.5-preview --dry-run
+npm run release:local -- 0.0.5-preview --yes
 ```
 
 The helper:
@@ -122,9 +122,9 @@ The tag push triggers two independent downstream processes:
 Useful release options:
 
 ```bash
-npm run release:local -- 0.0.3-preview --dry-run
-npm run release:local -- 0.0.3-preview --yes --skip-check
-npm run release:local -- 0.0.3-preview --yes --no-push-main
+npm run release:local -- 0.0.5-preview --dry-run
+npm run release:local -- 0.0.5-preview --yes --skip-check
+npm run release:local -- 0.0.5-preview --yes --no-push-main
 ```
 
 Before tagging, confirm that:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.5-preview",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/functions-skills",
-      "version": "0.0.3-preview",
+      "version": "0.0.5-preview",
       "license": "MIT",
       "bin": {
         "azure-functions-skills": "bin/azure-functions-skills.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/functions-skills",
-  "version": "0.0.3-preview",
+  "version": "0.0.5-preview",
   "description": "AI assistant plugins for Azure Functions — one-command setup for GitHub Copilot, Claude Code, and Codex",
   "type": "module",
   "bin": {

--- a/scripts/release-local.mjs
+++ b/scripts/release-local.mjs
@@ -34,8 +34,8 @@ Usage:
   npm run release:local -- <version> [options]
 
 Examples:
-  npm run release:local -- 0.0.3-preview --yes
-  npm run release:local -- 0.0.3-preview --dry-run
+  npm run release:local -- 0.0.5-preview --yes
+  npm run release:local -- 0.0.5-preview --dry-run
 
 What it does:
   1. Verifies main is clean and matches origin/main.
@@ -86,7 +86,7 @@ function parseArgs(argv) {
 }
 
 function normalizeVersion(input) {
-  if (!input) throw new Error('Version is required. Example: npm run release:local -- 0.0.3-preview --yes');
+  if (!input) throw new Error('Version is required. Example: npm run release:local -- 0.0.5-preview --yes');
   const version = input.replace(/^v/, '');
   if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
     throw new Error(`Invalid version: ${input}`);


### PR DESCRIPTION
## Summary
- bump package version to 0.0.5-preview
- regenerate plugin payload and marketplace manifests
- refresh release helper docs/examples to the new preview version

## Validation
- npm run lint
- npm run typecheck
- npm run validate:skills
- npm run verify:plugin-payload
- npm test
- npm run build

Note: npm run lint:security still reports the existing audit warning about npm publish references in azure-pipelines/templates/npm-publish-steps.yml.