### PR TITLE
Suppress fake doctor SQL credential fixture

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "placeholder": "Driver={ODBC Driver 18 for SQL Server};Server=tcp:myserver.database.windows.net,1433;Database=mydb;Uid=adminuser;Pwd=SuperSecret123!;Encrypt=yes;TrustServerCertificate=no;",
+      "_justification": "False positive: non-live SQL connection string fixture used by doctor tests to verify secret detection behavior."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add .config/CredScanSuppressions.json for the fake SQL connection string in tests/fixtures/doctor-bad-apps/python-deep-secrets-sql-injection/function_app.py.
- The Azure DevOps mirror run reported SEC101/037 SqlLegacyCredentials at commit 4663ea05, line 17, columns 135-150.
- The value uses placeholder host/database/user/password values and is intentionally present as a doctor test fixture.

## Validation
- Parsed .config/CredScanSuppressions.json with Node JSON.parse.