### PR TITLE
Support library local install

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,38 @@ The first time, the agent greets you with a welcome message, shows the available
 
 > **More options?** See [CLI Reference](docs/cli-reference.md) for every command, flag, and headless example.
 
+## Local installs and VS Code extension integration
+
+`install --local` copies skill bodies, agent definitions, hooks, and MCP settings from the assets bundled in the installed `@azure/functions-skills` npm package. It does not fetch templates from GitHub or use a source ref. When a newer npm package is available, the CLI prints an update command so users can refresh the bundled assets before reinstalling or updating.
+
+VS Code extensions can call the same local install flow from TypeScript:
+
+```ts
+import { installLocalSkills } from '@azure/functions-skills/setup';
+
+const result = await installLocalSkills({
+  targetDir: workspaceFolder.uri.fsPath,
+  agents: ['ghcp'],
+  yes: true,
+  prerequisites: 'skip',
+});
+```
+
+Common options:
+
+| Option | Description |
+| --- | --- |
+| `targetDir` | Required workspace root where local skills should be installed. |
+| `agents` | Optional agents: `ghcp`, `claude`, `codex`. Defaults to GHCP-compatible setup when omitted. |
+| `dryRun` | Return planned local files without writing. |
+| `yes` | Approve safe noninteractive changes such as local state `.gitignore` updates. |
+| `prerequisites` | `auto`, `check-only`, or `skip`, matching the CLI prerequisite behavior. |
+| `checkForUpdates` | Set `false` to skip npm package freshness guidance. |
+| `runner` | Optional command runner for tests or extension-host controlled npm checks. |
+| `initializeGitForGhcp` | Set `false` to skip GHCP git initialization. |
+
+The result includes installed agents, files written, local state, git setup status, `.gitignore` status, and `packageUpdate` guidance that extensions can surface in their own UI.
+
 ## Skills
 
 For contributor guidance on the product boundary between Azure Skills and Azure Functions Skills, see [Azure Skills and Azure Functions Skills Boundary](docs/azure-skills-boundary.md).

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -27,7 +27,7 @@ Options:
   --agent <name>     Agent: ghcp, claude, codex (repeatable)
   --all              Install all supported agents explicitly
   --dir <path>       Target directory (default: current directory)
-  --local            Full workspace-local setup, equivalent to setup
+  --local            Full workspace-local setup from bundled npm package assets
   --dry-run          Print planned install without writing files
   --yes              Approve safe file updates such as managed blocks and state .gitignore entry
   --source <name>    marketplace, github, or local (default: marketplace)
@@ -45,7 +45,7 @@ Options:
   --agent <name>     Agent: ghcp, claude, codex (repeatable)
   --all              Update all supported agents explicitly
   --dir <path>       Target directory (default: current directory)
-  --local            Force local update mode (auto-detected from state if omitted)
+  --local            Force local update mode using bundled npm package assets
   --force            Overwrite all files including user-customized files
   --dry-run          Print planned update without writing files
   --yes              Approve safe file updates such as managed blocks and state .gitignore entry
@@ -198,7 +198,7 @@ function printHelp() {
   Options (install/update):
     --agent <name>     Specify agent: ghcp, claude, codex (repeatable)
     --dir <path>       Target directory (default: current directory)
-    --local            Full workspace-local setup, equivalent to setup
+    --local            Full workspace-local setup from bundled npm package assets
     --dry-run          Print planned install without writing files
     --yes              Approve modifying existing instruction files without prompting
     --source <name>    marketplace, github, or local (default: marketplace)
@@ -483,6 +483,11 @@ function printInstallSummary({ action, agents, dir, filesWritten, state, gitigno
   console.log(`  Next: azure-functions-skills chat --dir "${dir}"`);
 }
 
+function printPackageUpdateGuidance(packageUpdate) {
+  if (!packageUpdate || packageUpdate.status !== 'update-available') return;
+  console.log(`  Package update: ${packageUpdate.message}`);
+}
+
 if (command === '--version' || command === '-V') {
   const { readFileSync } = await import('node:fs');
   const { join: joinPath, dirname } = await import('node:path');
@@ -591,7 +596,9 @@ if (command === 'install' || command === 'update') {
     if (command === 'update') {
       // Use file-type-aware local update strategy
       const { applyLocalUpdate, createInteractivePrompter } = await import('../lib/setup/local-update.js');
+      const { checkPackageUpdate } = await import('../lib/setup/package-update.js');
       const prompter = isInteractive() && !force && !yes && !dryRun ? createInteractivePrompter() : undefined;
+      const packageUpdate = await checkPackageUpdate();
       const result = await applyLocalUpdate(dir, {
         agents: detectedAgents,
         force,
@@ -601,6 +608,7 @@ if (command === 'install' || command === 'update') {
       });
       if (dryRun) {
         console.log(`Planned local update:`);
+        console.log('  Local assets: bundled with @azure/functions-skills');
         if (result.overwritten.length > 0) {
           console.log('  Overwrite:');
           for (const f of result.overwritten) console.log(`    - ${f}`);
@@ -613,6 +621,7 @@ if (command === 'install' || command === 'update') {
           console.log('  Save aside (review & merge manually):');
           for (const entry of result.savedAside) console.log(`    - ${entry.original} → ${entry.aside}`);
         }
+        printPackageUpdateGuidance(packageUpdate);
       } else {
         const state = recordInstallState(dir, {
           action: command,
@@ -626,6 +635,8 @@ if (command === 'install' || command === 'update') {
         });
         const gitignoreResult = await updateStateGitignore({ dir, yes, ensureStateIgnored, stateIgnoreEntry: STATE_IGNORE_ENTRY });
         printInstallSummary({ action: command, agents: detectedAgents, dir, filesWritten: result.overwritten.length + result.managedBlockUpdated.length + result.savedAside.length, state, gitignoreResult });
+        console.log('  Local assets: bundled with @azure/functions-skills');
+        printPackageUpdateGuidance(packageUpdate);
         if (result.savedAside.length > 0) {
           console.log('\n⚠️  Some files were saved aside for manual review:');
           for (const entry of result.savedAside) {
@@ -635,25 +646,34 @@ if (command === 'install' || command === 'update') {
         }
       }
     } else {
-      // install --local: use original applySetup()
+      const { installLocalSkills } = await import('../lib/setup/index.js');
+      const result = await installLocalSkills({
+        targetDir: dir,
+        agents: detectedAgents,
+        dryRun,
+        yes,
+        prerequisites,
+        scope,
+        approveStateGitignore: isInteractive() ? () => askYesNo(`Add ${STATE_IGNORE_ENTRY} to .gitignore so local state is not committed?`) : undefined,
+        approveGitInit: isInteractive() ? () => askYesNo('Initialize git repository? GitHub Copilot requires a git repo to discover agent definitions.') : undefined,
+      });
       if (dryRun) {
         console.log(`Planned local install:`);
-        for (const agent of detectedAgents) console.log(`  - ${agent}: workspace setup files`);
+        console.log('  Local assets: bundled with @azure/functions-skills');
+        for (const planned of result.plannedFiles) console.log(`  - ${planned}`);
+        printPackageUpdateGuidance(result.packageUpdate);
       } else {
-        const result = await applySetup(dir, { agents: detectedAgents, prerequisites });
-        const state = recordInstallState(dir, {
+        printInstallSummary({
           action: command,
           agents: detectedAgents,
-          mode: 'local',
-          source: 'local',
-          scope,
-          includeMcp: true,
-          includeHooks: true,
-          includeAgent: detectedAgents.includes('ghcp'),
+          dir,
+          filesWritten: result.filesWritten,
+          state: result.state,
+          gitignoreResult: result.gitignoreResult,
+          gitRepoResult: result.gitRepoResult,
         });
-        const gitignoreResult = await updateStateGitignore({ dir, yes, ensureStateIgnored, stateIgnoreEntry: STATE_IGNORE_ENTRY });
-        const gitRepoResult = await ensureGitRepo({ dir, yes, agents: detectedAgents, action: command });
-        printInstallSummary({ action: command, agents: detectedAgents, dir, filesWritten: result.filesWritten, state, gitignoreResult, gitRepoResult });
+        console.log('  Local assets: bundled with @azure/functions-skills');
+        printPackageUpdateGuidance(result.packageUpdate);
       }
     }
   } else {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -40,7 +40,7 @@ Options:
 | `--agent <name>` | (interactive prompt) | Repeatable. `ghcp`, `claude`, `codex`. CI must specify. |
 | `--all` | off | Install all supported agents. |
 | `--dir <path>` | `cwd` | Target directory. |
-| `--local` | off | Full workspace-local setup (skill bodies copied). Compatibility flow when the host has no plugin support. |
+| `--local` | off | Full workspace-local setup from bundled npm package assets. Compatibility flow when the host has no plugin support. |
 | `--dry-run` | off | Print planned actions without writing. |
 | `--yes` | off | Approve modifying existing instruction files and adding state to `.gitignore`. |
 | `--source <name>` | `marketplace` | `marketplace`, `github`, or `local`. |
@@ -51,6 +51,8 @@ Options:
 | `-- <args...>` | — | Pass-through to host plugin install (single agent only). |
 
 State: `install` writes `.azure-functions-skills/state.local.json` so future `chat`/`update` runs can use the same agent selection. With `--yes`, only this state file is appended to `.gitignore`; the directory itself is not ignored because workspace activation files may be useful to commit.
+
+Local installs use only the `templates/` assets bundled in the installed `@azure/functions-skills` npm package. They do not fetch templates from GitHub or accept a source ref. If a newer npm package is available, local install/update prints an actionable update command such as `npm install -g @azure/functions-skills@latest`.
 
 ---
 
@@ -63,7 +65,7 @@ npx @azure/functions-skills update
 npx @azure/functions-skills update --agent ghcp
 ```
 
-Same flags as `install`.
+Same flags as `install`. For workspaces installed with `install --local`, `update` auto-detects local mode from state and refreshes files from the currently installed npm package's bundled assets.
 
 ---
 
@@ -83,6 +85,36 @@ npx @azure/functions-skills setup --agent ghcp --dir ./my-app
 | `--as-plugin` | off | Register as native plugin instead of copying files. |
 | `--check-prerequisites` | off | Check external prerequisites without installing them. |
 | `--skip-prerequisites` | off | Skip prerequisite checks entirely. |
+
+---
+
+## Library API for local installs
+
+VS Code extensions can run the CLI `install --local` flow without spawning the CLI:
+
+```ts
+import { installLocalSkills } from '@azure/functions-skills/setup';
+
+const result = await installLocalSkills({
+  targetDir: workspaceFolder.uri.fsPath,
+  agents: ['ghcp'],
+  yes: true,
+  prerequisites: 'skip',
+});
+```
+
+| Option | Required | Description |
+| --- | --- | --- |
+| `targetDir` | yes | Workspace root where package-bundled local assets should be installed. |
+| `agents` | no | `ghcp`, `claude`, `codex`. Defaults to GHCP-compatible setup when omitted. |
+| `dryRun` | no | Return planned local files without writing. |
+| `yes` | no | Approve safe noninteractive changes such as state `.gitignore` updates and GHCP git initialization. |
+| `prerequisites` | no | `auto`, `check-only`, or `skip`, matching CLI behavior. |
+| `checkForUpdates` | no | Set `false` to skip npm package freshness guidance. |
+| `runner` | no | Injectable command runner for tests or extension-host controlled npm checks. |
+| `initializeGitForGhcp` | no | Set `false` to skip GHCP git initialization. |
+
+The result includes `agents`, `filesWritten`, `state`, `gitignoreResult`, `gitRepoResult`, and `packageUpdate` so an extension can present its own notifications.
 
 ---
 

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -187,3 +187,17 @@ function copyRecursive(src: string, dest: string, shouldCopy: (relativePath: str
   }
   return count;
 }
+
+export {
+  installLocalSkills,
+  type GitRepoResult,
+  type GitRepoResultStatus,
+  type LocalInstallOptions,
+  type LocalInstallResult,
+} from './local-install.js';
+export {
+  checkPackageUpdate,
+  type PackageUpdateInfo,
+  type PackageUpdateOptions,
+  type PackageUpdateStatus,
+} from './package-update.js';

--- a/src/setup/local-install.ts
+++ b/src/setup/local-install.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process';
+import { normalize, resolve } from 'node:path';
+import {
+  ensureStateIgnored,
+  recordInstallState,
+  type AzureFunctionsSkillsState,
+  type GitignoreResult,
+} from './state.js';
+import { checkPackageUpdate, type PackageUpdateInfo } from './package-update.js';
+import type { CliAgentName, SetupResult } from '../types.js';
+import type { CommandRunner, PrerequisiteMode } from './prerequisites/types.js';
+
+export type GitRepoResultStatus = 'skipped' | 'detected' | 'initialized' | 'not-initialized' | 'git-unavailable';
+
+export interface GitRepoResult {
+  readonly status: GitRepoResultStatus;
+}
+
+export interface LocalInstallOptions {
+  readonly targetDir: string;
+  readonly agents?: CliAgentName[];
+  readonly dryRun?: boolean;
+  readonly yes?: boolean;
+  readonly prerequisites?: PrerequisiteMode;
+  readonly scope?: string;
+  readonly runner?: CommandRunner;
+  readonly checkForUpdates?: boolean;
+  readonly initializeGitForGhcp?: boolean;
+  readonly approveStateGitignore?: () => Promise<boolean>;
+  readonly approveGitInit?: () => Promise<boolean>;
+}
+
+export interface LocalInstallResult {
+  readonly agents: CliAgentName[];
+  readonly filesWritten: number;
+  readonly plannedFiles: string[];
+  readonly dryRun: boolean;
+  readonly state: AzureFunctionsSkillsState | null;
+  readonly gitignoreResult: GitignoreResult;
+  readonly gitRepoResult: GitRepoResult;
+  readonly packageUpdate: PackageUpdateInfo;
+  readonly setup: SetupResult | null;
+}
+
+export async function installLocalSkills(options: LocalInstallOptions): Promise<LocalInstallResult> {
+  const agents: CliAgentName[] = options.agents || ['ghcp'];
+  const dryRun = options.dryRun === true;
+  const packageUpdate = await checkPackageUpdate({
+    enabled: options.checkForUpdates !== false,
+    runner: options.runner,
+  });
+
+  if (dryRun) {
+    return {
+      agents,
+      filesWritten: 0,
+      plannedFiles: agents.map(agent => `${agent}: workspace setup files from bundled npm package assets`),
+      dryRun,
+      state: null,
+      gitignoreResult: { status: 'needs-approval', path: '', entry: '.azure-functions-skills/state.local.json' },
+      gitRepoResult: { status: 'skipped' },
+      packageUpdate,
+      setup: null,
+    };
+  }
+
+  const { applySetup } = await import('./index.js');
+  const setup = await applySetup(options.targetDir, {
+    agents,
+    prerequisites: options.prerequisites || 'auto',
+    prerequisiteRunner: options.runner,
+  });
+  const state = recordInstallState(options.targetDir, {
+    action: 'install',
+    agents,
+    mode: 'local',
+    source: 'local',
+    scope: options.scope || 'workspace',
+    includeMcp: true,
+    includeHooks: true,
+    includeAgent: agents.includes('ghcp'),
+  });
+  const gitignoreResult = await updateStateGitignore(options);
+  const gitRepoResult = await ensureGhcpGitRepo(options, agents);
+
+  return {
+    agents,
+    filesWritten: setup.filesWritten,
+    plannedFiles: [],
+    dryRun,
+    state,
+    gitignoreResult,
+    gitRepoResult,
+    packageUpdate,
+    setup,
+  };
+}
+
+async function updateStateGitignore(options: LocalInstallOptions): Promise<GitignoreResult> {
+  let result = ensureStateIgnored(options.targetDir, { yes: options.yes });
+  if (result.status === 'needs-approval' && options.approveStateGitignore && await options.approveStateGitignore()) {
+    result = ensureStateIgnored(options.targetDir, { yes: true });
+  }
+  return result;
+}
+
+async function ensureGhcpGitRepo(options: LocalInstallOptions, agents: CliAgentName[]): Promise<GitRepoResult> {
+  if (options.initializeGitForGhcp === false || !agents.includes('ghcp')) {
+    return { status: 'skipped' };
+  }
+
+  try {
+    const toplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: options.targetDir,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    }).trim();
+    if (normalize(resolve(options.targetDir)).toLowerCase() === normalize(resolve(toplevel)).toLowerCase()) {
+      return { status: 'detected' };
+    }
+  } catch (_err) {
+    // Continue to optional initialization below.
+  }
+
+  if (options.yes || (options.approveGitInit && await options.approveGitInit())) {
+    try {
+      execFileSync('git', ['init'], { cwd: options.targetDir, stdio: 'pipe' });
+      return { status: 'initialized' };
+    } catch (_err) {
+      return { status: 'git-unavailable' };
+    }
+  }
+
+  return { status: 'not-initialized' };
+}

--- a/src/setup/package-update.ts
+++ b/src/setup/package-update.ts
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import type { CommandRunner } from './prerequisites/types.js';
+
+export type PackageUpdateStatus = 'current' | 'update-available' | 'check-failed' | 'disabled';
+
+export interface PackageUpdateInfo {
+  readonly status: PackageUpdateStatus;
+  readonly packageName: string;
+  readonly currentVersion: string;
+  readonly latestVersion?: string;
+  readonly command?: string;
+  readonly message: string;
+}
+
+export interface PackageUpdateOptions {
+  readonly packageName?: string;
+  readonly currentVersion?: string;
+  readonly runner?: CommandRunner;
+  readonly enabled?: boolean;
+}
+
+interface ParsedVersion {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly prerelease: string | null;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(__dirname, '..', '..');
+const DEFAULT_PACKAGE_NAME = '@azure/functions-skills';
+
+export async function checkPackageUpdate(options: PackageUpdateOptions = {}): Promise<PackageUpdateInfo> {
+  const packageName = options.packageName || DEFAULT_PACKAGE_NAME;
+  const currentVersion = options.currentVersion || readCurrentPackageVersion();
+  if (options.enabled === false || process.env.AZURE_FUNCTIONS_SKILLS_SKIP_UPDATE_CHECK === '1') {
+    return {
+      status: 'disabled',
+      packageName,
+      currentVersion,
+      message: `Skipped npm update check for ${packageName}.`,
+    };
+  }
+
+  const runner = options.runner || defaultRunner;
+  const result = await runner('npm', ['view', packageName, 'version', '--json']);
+  if (result.exitCode !== 0) {
+    return {
+      status: 'check-failed',
+      packageName,
+      currentVersion,
+      message: `Could not check npm for ${packageName} updates: ${result.stderr || result.stdout || 'npm view failed'}`,
+    };
+  }
+
+  const latestVersion = parseNpmVersionOutput(result.stdout);
+  if (!latestVersion) {
+    return {
+      status: 'check-failed',
+      packageName,
+      currentVersion,
+      message: `Could not check npm for ${packageName} updates: npm returned an empty version.`,
+    };
+  }
+
+  if (isVersionGreater(latestVersion, currentVersion)) {
+    const command = `npm install -g ${packageName}@latest`;
+    return {
+      status: 'update-available',
+      packageName,
+      currentVersion,
+      latestVersion,
+      command,
+      message: `${packageName} ${latestVersion} is available. Update package-bundled skills with: ${command}`,
+    };
+  }
+
+  return {
+    status: 'current',
+    packageName,
+    currentVersion,
+    latestVersion,
+    message: `${packageName} ${currentVersion} is up to date.`,
+  };
+}
+
+function parseNpmVersionOutput(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return typeof parsed === 'string' && parsed.trim() ? parsed.trim() : null;
+  } catch (_err) {
+    return trimmed.replace(/^"|"$/g, '');
+  }
+}
+
+function isVersionGreater(candidate: string, baseline: string): boolean {
+  const candidateVersion = parseVersion(candidate);
+  const baselineVersion = parseVersion(baseline);
+  if (!candidateVersion || !baselineVersion) return candidate !== baseline;
+
+  for (const key of ['major', 'minor', 'patch'] as const) {
+    if (candidateVersion[key] > baselineVersion[key]) return true;
+    if (candidateVersion[key] < baselineVersion[key]) return false;
+  }
+
+  if (candidateVersion.prerelease === baselineVersion.prerelease) return false;
+  if (candidateVersion.prerelease === null) return true;
+  if (baselineVersion.prerelease === null) return false;
+  return candidateVersion.prerelease.localeCompare(baselineVersion.prerelease) > 0;
+}
+
+function parseVersion(value: string): ParsedVersion | null {
+  const match = value.trim().match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([^+]+))?(?:\+.+)?$/);
+  if (!match) return null;
+  return {
+    major: Number.parseInt(match[1] || '0', 10),
+    minor: Number.parseInt(match[2] || '0', 10),
+    patch: Number.parseInt(match[3] || '0', 10),
+    prerelease: match[4] || null,
+  };
+}
+
+function readCurrentPackageVersion(): string {
+  try {
+    const packageJson = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf-8')) as { version?: string };
+    return packageJson.version || '0.0.0';
+  } catch (_err) {
+    return '0.0.0';
+  }
+}
+
+async function defaultRunner(command: string, args: string[]) {
+  const isWin = process.platform === 'win32';
+  const execCommand = isWin ? 'cmd.exe' : command;
+  const execArgs = isWin ? ['/d', '/s', '/c', command, ...args] : args;
+  try {
+    const stdout = execFileSync(execCommand, execArgs, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (error) {
+    const err = error as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
+    return {
+      exitCode: err.status ?? 1,
+      stdout: bufferToString(err.stdout),
+      stderr: bufferToString(err.stderr) || err.message || '',
+    };
+  }
+}
+
+function bufferToString(value: Buffer | string | undefined): string {
+  if (!value) return '';
+  return typeof value === 'string' ? value : value.toString('utf-8');
+}

--- a/tests/integration-commands.test.ts
+++ b/tests/integration-commands.test.ts
@@ -129,7 +129,7 @@ function runCli(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv
 }
 
 function runCliOutput(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): string {
-  const env = { ...process.env, ...options.env };
+  const env = { ...process.env, AZURE_FUNCTIONS_SKILLS_SKIP_UPDATE_CHECK: '1', ...options.env };
   return execFileSync(process.execPath, [CLI_PATH, ...args], {
     cwd: options.cwd || ROOT_DIR,
     env,
@@ -154,6 +154,19 @@ function createFakeAgentCliDirectory(): string {
       writeFileSync(join(fakeBinDir, `${launcher.command}.ps1`), 'exit 0\r\n', { mode: 0o755 });
     }
   }
+  return fakeBinDir;
+}
+
+function createFakeNpmDirectory(latestVersion: string): string {
+  const fakeBinDir = makeTempDir('af-skills-e2e-npm-');
+  const commandPath = join(fakeBinDir, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+  writeFileSync(
+    commandPath,
+    process.platform === 'win32'
+      ? `@echo off\r\nif "%1"=="view" echo ${latestVersion}\r\nexit /b 0\r\n`
+      : `#!/usr/bin/env sh\nif [ "$1" = "view" ]; then printf "%s\\n" "${latestVersion}"; fi\nexit 0\n`,
+    { mode: 0o755 },
+  );
   return fakeBinDir;
 }
 
@@ -336,6 +349,33 @@ describe('CLI command integration', () => {
     runCli(['install', '--local', '--agent', 'ghcp', '--dir', projectDir, '--skip-prerequisites']);
 
     assertWorkspaceLayout(projectDir, 'ghcp', expectedSkillIds, expectedAgentFiles);
+  });
+
+  it('install --local reports bundled assets and npm update guidance when the package is stale', () => {
+    const fakeNpmDir = createFakeNpmDirectory('9.9.9');
+    const projectDir = makeTempDir('af-skills-e2e-install-local-update-guidance-');
+    const pathValue = `${fakeNpmDir}${delimiter}${process.env.PATH || ''}`;
+
+    const output = runCliOutput([
+      'install',
+      '--local',
+      '--agent', 'claude',
+      '--dir', projectDir,
+      '--yes',
+      '--skip-prerequisites',
+    ], {
+      env: {
+        PATH: pathValue,
+        Path: pathValue,
+        AZURE_FUNCTIONS_SKILLS_SKIP_UPDATE_CHECK: '0',
+      },
+    });
+
+    expect(output).toContain('Local assets: bundled with @azure/functions-skills');
+    expect(output).toContain('@azure/functions-skills 9.9.9 is available');
+    expect(output).toContain('npm install -g @azure/functions-skills@latest');
+    expect(output).not.toContain('source-ref');
+    expect(output).not.toContain('Fetching templates from GitHub');
   });
 
   it('install passes host CLI arguments through for a single agent dry-run', () => {
@@ -829,6 +869,26 @@ describe('CLI command integration', () => {
 
     // Output describes planned actions
     expect(output).toContain('Planned local update');
+  });
+
+  it('local update reports bundled assets and npm update guidance when the package is stale', { timeout: 15_000 }, () => {
+    const fakeNpmDir = createFakeNpmDirectory('9.9.9');
+    const projectDir = makeTempDir('af-skills-e2e-local-update-guidance-');
+    const pathValue = `${fakeNpmDir}${delimiter}${process.env.PATH || ''}`;
+    const env = {
+      PATH: pathValue,
+      Path: pathValue,
+      AZURE_FUNCTIONS_SKILLS_SKIP_UPDATE_CHECK: '0',
+    };
+
+    runCli(['install', '--local', '--agent', 'codex', '--dir', projectDir, '--yes', '--skip-prerequisites'], { env });
+    const output = runCliOutput(['update', '--agent', 'codex', '--dir', projectDir, '--yes'], { env });
+
+    expect(output).toContain('Local assets: bundled with @azure/functions-skills');
+    expect(output).toContain('@azure/functions-skills 9.9.9 is available');
+    expect(output).toContain('npm install -g @azure/functions-skills@latest');
+    expect(output).not.toContain('source-ref');
+    expect(output).not.toContain('Fetching templates from GitHub');
   });
 
   it('update after plugin install saves aside customer-owned routing files', { timeout: 15_000 }, () => {

--- a/tests/local-install.test.ts
+++ b/tests/local-install.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { installLocalSkills } from '../src/setup/index.js';
+import type { CommandRunner } from '../src/setup/prerequisites/types.js';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+const TEMP_DIRS: string[] = [];
+
+function makeTempDir(): string {
+  const dir = createTempDir('af-skills-local-install-');
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+function stalePackageRunner(): CommandRunner {
+  return async command => {
+    if (command === 'npm') {
+      return { exitCode: 0, stdout: '9.9.9\n', stderr: '' };
+    }
+    return { exitCode: 0, stdout: 'ok\n', stderr: '' };
+  };
+}
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0)) removeDir(dir);
+});
+
+describe('installLocalSkills', () => {
+  it('installs bundled local assets and records local state like CLI install --local', async () => {
+    const dir = makeTempDir();
+
+    const result = await installLocalSkills({
+      targetDir: dir,
+      agents: ['ghcp'],
+      yes: true,
+      prerequisites: 'skip',
+      checkForUpdates: false,
+    });
+
+    expect(result.filesWritten).toBeGreaterThan(0);
+    expect(existsSync(join(dir, '.github', 'skills'))).toBe(true);
+    expect(existsSync(join(dir, '.github', 'agents', 'functions-copilot.agent.md'))).toBe(true);
+    expect(result.state?.install.mode).toBe('local');
+    expect(result.state?.install.source).toBe('local');
+    expect(result.gitignoreResult.status).toBe('updated');
+  });
+
+  it('supports dry-run without writing workspace files or state', async () => {
+    const dir = makeTempDir();
+
+    const result = await installLocalSkills({
+      targetDir: dir,
+      agents: ['claude'],
+      dryRun: true,
+      checkForUpdates: false,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.plannedFiles).toContain('claude: workspace setup files from bundled npm package assets');
+    expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(false);
+    expect(existsSync(join(dir, '.azure-functions-skills', 'state.local.json'))).toBe(false);
+  });
+
+  it('returns structured npm update guidance for VS Code integrations', async () => {
+    const dir = makeTempDir();
+
+    const result = await installLocalSkills({
+      targetDir: dir,
+      agents: ['codex'],
+      yes: true,
+      prerequisites: 'skip',
+      runner: stalePackageRunner(),
+    });
+
+    expect(result.packageUpdate.status).toBe('update-available');
+    expect(result.packageUpdate.command).toBe('npm install -g @azure/functions-skills@latest');
+    const state = JSON.parse(readFileSync(join(dir, '.azure-functions-skills', 'state.local.json'), 'utf-8')) as {
+      install: { mode: string; source: string };
+    };
+    expect(state.install).toEqual(expect.objectContaining({ mode: 'local', source: 'local' }));
+  });
+});

--- a/tests/package-update.test.ts
+++ b/tests/package-update.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { checkPackageUpdate } from '../src/setup/package-update.js';
+import type { CommandRunner } from '../src/setup/prerequisites/types.js';
+
+function runnerWith(stdout: string, exitCode = 0, stderr = ''): CommandRunner {
+  return async () => ({ exitCode, stdout, stderr });
+}
+
+describe('checkPackageUpdate', () => {
+  it('returns current when the installed package is up to date', async () => {
+    const result = await checkPackageUpdate({
+      currentVersion: '1.2.3',
+      runner: runnerWith('"1.2.3"\n'),
+    });
+
+    expect(result.status).toBe('current');
+    expect(result.currentVersion).toBe('1.2.3');
+    expect(result.latestVersion).toBe('1.2.3');
+  });
+
+  it('returns actionable npm guidance when a newer package exists', async () => {
+    const result = await checkPackageUpdate({
+      currentVersion: '1.2.3',
+      runner: runnerWith('1.3.0\n'),
+    });
+
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('1.3.0');
+    expect(result.message).toContain('@azure/functions-skills 1.3.0 is available');
+    expect(result.command).toBe('npm install -g @azure/functions-skills@latest');
+  });
+
+  it('treats preview versions as comparable package versions', async () => {
+    const result = await checkPackageUpdate({
+      currentVersion: '0.0.5-preview',
+      runner: runnerWith('"0.0.6-preview"\n'),
+    });
+
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('0.0.6-preview');
+  });
+
+  it('returns a non-blocking check-failed result when npm metadata lookup fails', async () => {
+    const result = await checkPackageUpdate({
+      currentVersion: '1.2.3',
+      runner: runnerWith('', 1, 'registry unavailable'),
+    });
+
+    expect(result.status).toBe('check-failed');
+    expect(result.message).toContain('Could not check npm for @azure/functions-skills updates');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a library-facing `installLocalSkills()` API for VS Code extension integrations that need CLI `--local`-equivalent behavior.
- Keep local installs and updates on bundled npm package assets, with CLI messaging that clarifies the local asset source.
- Add npm package update guidance when a newer `@azure/functions-skills` version is available.
- Update docs and tests for the simplified local-install model.

## Context
This replaces the abandoned repository-template/source-ref approach from #187 with a simpler npm-package-based local install path. The goal is to support VS Code extension library usage for local apply/install without fetching templates from GitHub.

## Validation
- npm test -- tests/package-update.test.ts tests/local-install.test.ts tests/integration-commands.test.ts
- npm run compile
- npm run lint
- npm run typecheck
- npm test
- npm run validate:skills
- npm run build
- npm run build:plugin-payload && npm run verify:plugin-payload
- E2E: GHCP / Claude / Codex local install and local update in isolated workspaces
- E2E: `installLocalSkills()` library API in an isolated workspace

## Note
`npm run check` is currently blocked by the existing npm publish audit finding in `azure-pipelines/templates/npm-publish-steps.yml:17`; this is unrelated to this change.

## Fix
https://github.com/Azure/azure-functions-bucees-planning/issues/1224