### PR TITLE
Update azure-functions-agents skill for observability and endpoint validation

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/SKILL.md
@@ -31,7 +31,12 @@ agents using Azure Functions": agents are defined in markdown files, runtime def
   needed actions into Python custom tools or use a hosted remote MCP endpoint.
 - Use Connector Namespaces, represented as `Microsoft.Web/connectorGateways` resources in Bicep.
 - Generated apps should include a ready-to-edit `src/local.settings.json`, not only a template.
-- Generated `requirements.txt` must use the official PyPI package: `azurefunctions-agents-runtime`.
+- Generated `requirements.txt` should use `azurefunctions-agents-runtime[monitor]` whenever the app
+  includes `APPLICATIONINSIGHTS_CONNECTION_STRING` (the scaffolded infra provisions it by default),
+  so the runtime auto-exports `agent.run` and `dynamic_session.execute` spans to Application Insights
+  with no extra code. If the retrieved template ships the base `azurefunctions-agents-runtime`, add
+  the `[monitor]` extra. When the app has no Application Insights, use the base package and either
+  prompt the user to add it or omit telemetry.
 
 ## Progressive References
 

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/infra-and-deployment.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/infra-and-deployment.md
@@ -237,6 +237,90 @@ within available quota.
 
 If the model deployment fails, revert to `gpt-4.1` values and provision again.
 
+## Observability
+
+The runtime emits OpenTelemetry traces and metrics to Application Insights for every agent run —
+without any telemetry code in `function_app.py`.
+
+**Enable in two steps:**
+
+1. Use the `[monitor]` extra in `requirements.txt`:
+
+   ```text
+   azurefunctions-agents-runtime[monitor]
+   ```
+
+2. Ensure `APPLICATIONINSIGHTS_CONNECTION_STRING` is set (already provisioned and injected by the
+   scaffolded Bicep).
+
+When both are present, `create_function_app()` automatically configures Azure Monitor export and
+Microsoft Agent Framework (MAF) `gen_ai` instrumentation.
+
+**Spans emitted:**
+
+| Span | What it covers |
+| --- | --- |
+| `agent.run {name}` | Full agent invocation: trigger type, model, session ID, tool call count, outcome |
+| `dynamic_session.execute` | Each `execute_python` call: session ID, stderr presence, ACA operation correlation |
+
+Runtime-added attributes use the `af.` prefix (standard OpenTelemetry attributes such as
+`server.address` are reused as-is). Failures are tagged with `af.fault_domain` (values:
+`app`, `runtime`, `platform`, `model`, `connector`, `sandbox`, `unknown`) for fast triage.
+
+**Sandbox failure visibility:** previously, a `dynamic_session.execute` call that returned
+non-empty stderr still looked like a success in telemetry. With observability enabled, the
+`dynamic_session.execute` span is marked ERROR and `af.fault_domain=sandbox` whenever stderr is
+present or an exception occurs, even though the tool still returns its string to the model.
+
+**Sensitive content (off by default):**
+
+Content attributes (`af.agent.input`, `af.agent.response`, `af.dynamic_session.code`,
+`af.dynamic_session.stdout`, `af.dynamic_session.stderr`) are gated behind
+`ENABLE_SENSITIVE_DATA=true`. Without it, only metadata (byte counts, call counts, outcome) is
+recorded. Keep this off in production to protect PII.
+
+**Optional host+worker correlation:**
+
+Add `"telemetryMode": "OpenTelemetry"` to `host.json` to align the Functions host's request
+telemetry with the runtime's worker spans under the same end-to-end operation ID. This is
+additive — runtime spans work without it.
+
+**Reduce log noise:**
+
+The runtime automatically quiets known-noisy loggers (Azure SDK HTTP, `azure.identity`, `httpx`,
+OpenTelemetry internals). To also quiet host-side startup noise, add log-level overrides in
+`host.json`:
+
+```json
+{
+  "logging": {
+    "logLevel": {
+      "default": "Warning",
+      "Host.Startup": "Warning",
+      "Host.Function.Console": "Warning",
+      "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService": "Warning"
+    }
+  }
+}
+```
+
+**Useful KQL (Transaction Search covers a full run):**
+
+```kql
+// Everything from one run, in order
+union AppRequests, AppDependencies, AppTraces, AppExceptions
+| where OperationId == "<operation-id>"
+| project TimeGenerated, itemType, Name, Message, Success, DurationMs
+| order by TimeGenerated asc
+
+// Sandbox calls that actually failed (stderr or exception)
+AppDependencies
+| where Name == "dynamic_session.execute"
+| extend stderr_present = tostring(Properties["af.dynamic_session.stderr_present"])
+| where Success == false or stderr_present == "true"
+| project TimeGenerated, OperationId, DurationMs, Properties
+```
+
 ## Deployed Function Keys
 
 Built-in chat endpoints use the default function key:

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/project-files.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/project-files.md
@@ -28,13 +28,29 @@ app = create_function_app()
 
 ## requirements.txt
 
-Use the official PyPI package:
+Use `azurefunctions-agents-runtime[monitor]` whenever the app includes
+`APPLICATIONINSIGHTS_CONNECTION_STRING` — which the scaffolded Bicep always provisions. With the
+extra installed, the runtime's `agent.run` and `dynamic_session.execute` spans are exported to
+Application Insights automatically and no extra code is needed.
+
+```text
+azurefunctions-agents-runtime[monitor]
+```
+
+Without the `[monitor]` extra the runtime cannot export spans even when
+`APPLICATIONINSIGHTS_CONNECTION_STRING` is set, and it logs a one-time warning directing the user
+to install the extra.
+
+When the app does **not** include Application Insights, use the base package:
 
 ```text
 azurefunctions-agents-runtime
 ```
 
-Add app-specific dependencies below it.
+In that case, either prompt the user about adding Application Insights (so they get the full
+observability stack) or proceed without telemetry if the user has explicitly opted out.
+
+Add app-specific dependencies below the runtime line.
 
 ## host.json
 

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/quickstart-reference.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/quickstart-reference.md
@@ -22,7 +22,9 @@ The official template includes:
 - `src/daily_microsoft_blog_summary.agent.md` with a 30-minute timer-agent timeout
 - `src/mcp.json`
 - `src/local.settings.json.sample`
-- `src/requirements.txt` with the official `azurefunctions-agents-runtime` PyPI package
+- `src/requirements.txt` with `azurefunctions-agents-runtime[monitor]` so Application Insights
+  observability is enabled by default (add the `[monitor]` extra if the retrieved copy ships the
+  base `azurefunctions-agents-runtime` package)
 
 ## How to Use It
 

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/sessions.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/sessions.md
@@ -58,6 +58,24 @@ system_tools:
     client_id: $SESSION_POOL_CLIENT_ID
 ```
 
+## Endpoint Validation
+
+The runtime validates the session pool endpoint before creating the `execute_python` tool. The
+endpoint must be an HTTPS URL whose host is a subdomain of `dynamicsessions.io`
+(`*.dynamicsessions.io`). Endpoints that use a non-HTTPS scheme, embed userinfo (`user@host`), or
+target any other host are rejected and the `execute_python` tool will not be available to agents.
+A warning is logged in that state.
+
+Correct endpoint format:
+
+```
+https://<region>.dynamicsessions.io/subscriptions/.../sessionPools/<pool>
+```
+
+If `execute_python` is missing at runtime after setting the endpoint, check that
+`ACA_SESSION_POOL_ENDPOINT` resolves to a valid `https://<region>.dynamicsessions.io/...` URL and
+look for a "failed validation" warning in startup logs.
+
 ## Local Development
 
 Local execution still calls the real Azure session pool. The developer's `az login` identity

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/troubleshooting.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/troubleshooting.md
@@ -86,6 +86,7 @@ agent run.
 | --- | --- | --- |
 | `execute_python` missing | `agents.config.yaml` lacks dynamic session config | Add `system_tools.dynamic_sessions_code_interpreter.endpoint`. |
 | Session endpoint unresolved | `ACA_SESSION_POOL_ENDPOINT` missing | Set it in app settings or `local.settings.json`. |
+| `execute_python` missing after endpoint is set | Endpoint URL failed validation | Ensure `ACA_SESSION_POOL_ENDPOINT` is an `https://<region>.dynamicsessions.io/...` URL. The runtime silently skips endpoints that are not on `*.dynamicsessions.io` or use non-HTTPS. Check startup logs for "failed validation". |
 | 403 from session pool | Identity lacks role | Assign `Azure ContainerApps Session Executor` to app identity and local user. |
 | Browser/code work unavailable | Agent instructions do not mention using Python/Playwright | Tell the agent when to use `execute_python`. |
 
@@ -355,3 +356,18 @@ traces
 | order by timestamp desc
 | project timestamp, message, severityLevel
 ```
+
+## Observability
+
+The runtime emits `agent.run {name}` and `dynamic_session.execute` spans to Application Insights.
+These are spans (not logs) — look in **Transaction Search** and the end-to-end transaction view,
+not the Logs blade.
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| No `agent.run` spans in Application Insights | `[monitor]` extra not installed | Use `azurefunctions-agents-runtime[monitor]` in `requirements.txt`. |
+| Runtime logs "install azurefunctions-agents-runtime[monitor]" warning | Connection string present but `[monitor]` extra missing | Install `azurefunctions-agents-runtime[monitor]`. |
+| Spans missing even with `[monitor]` installed | `APPLICATIONINSIGHTS_CONNECTION_STRING` not set | Set the connection string in app settings or (for local runs) `local.settings.json`. |
+| No content in span attributes, only byte counts | `ENABLE_SENSITIVE_DATA` is off (default) | Set `ENABLE_SENSITIVE_DATA=true` to capture input/response/code content. Keep off in production. |
+| Sandbox failure shows `Success` in telemetry | `[monitor]` extra not installed or old runtime version | Install `azurefunctions-agents-runtime[monitor]`. Stderr/exceptions mark the `dynamic_session.execute` span ERROR with `af.fault_domain=sandbox`. |
+| Can't find runtime spans in the Logs (`AppTraces`) list | Runtime telemetry is emitted as spans (dependencies), not trace logs | Query `AppDependencies` — both `agent.run {name}` and `dynamic_session.execute` are `INTERNAL` spans and land there (not `AppRequests`). Use Transaction Search for the full end-to-end view. |

--- a/templates/skills/azure-functions-agents/SKILL.md
+++ b/templates/skills/azure-functions-agents/SKILL.md
@@ -30,7 +30,12 @@ agents using Azure Functions": agents are defined in markdown files, runtime def
   needed actions into Python custom tools or use a hosted remote MCP endpoint.
 - Use Connector Namespaces, represented as `Microsoft.Web/connectorGateways` resources in Bicep.
 - Generated apps should include a ready-to-edit `src/local.settings.json`, not only a template.
-- Generated `requirements.txt` must use the official PyPI package: `azurefunctions-agents-runtime`.
+- Generated `requirements.txt` should use `azurefunctions-agents-runtime[monitor]` whenever the app
+  includes `APPLICATIONINSIGHTS_CONNECTION_STRING` (the scaffolded infra provisions it by default),
+  so the runtime auto-exports `agent.run` and `dynamic_session.execute` spans to Application Insights
+  with no extra code. If the retrieved template ships the base `azurefunctions-agents-runtime`, add
+  the `[monitor]` extra. When the app has no Application Insights, use the base package and either
+  prompt the user to add it or omit telemetry.
 
 ## Progressive References
 

--- a/templates/skills/azure-functions-agents/references/infra-and-deployment.md
+++ b/templates/skills/azure-functions-agents/references/infra-and-deployment.md
@@ -237,6 +237,90 @@ within available quota.
 
 If the model deployment fails, revert to `gpt-4.1` values and provision again.
 
+## Observability
+
+The runtime emits OpenTelemetry traces and metrics to Application Insights for every agent run —
+without any telemetry code in `function_app.py`.
+
+**Enable in two steps:**
+
+1. Use the `[monitor]` extra in `requirements.txt`:
+
+   ```text
+   azurefunctions-agents-runtime[monitor]
+   ```
+
+2. Ensure `APPLICATIONINSIGHTS_CONNECTION_STRING` is set (already provisioned and injected by the
+   scaffolded Bicep).
+
+When both are present, `create_function_app()` automatically configures Azure Monitor export and
+Microsoft Agent Framework (MAF) `gen_ai` instrumentation.
+
+**Spans emitted:**
+
+| Span | What it covers |
+| --- | --- |
+| `agent.run {name}` | Full agent invocation: trigger type, model, session ID, tool call count, outcome |
+| `dynamic_session.execute` | Each `execute_python` call: session ID, stderr presence, ACA operation correlation |
+
+Runtime-added attributes use the `af.` prefix (standard OpenTelemetry attributes such as
+`server.address` are reused as-is). Failures are tagged with `af.fault_domain` (values:
+`app`, `runtime`, `platform`, `model`, `connector`, `sandbox`, `unknown`) for fast triage.
+
+**Sandbox failure visibility:** previously, a `dynamic_session.execute` call that returned
+non-empty stderr still looked like a success in telemetry. With observability enabled, the
+`dynamic_session.execute` span is marked ERROR and `af.fault_domain=sandbox` whenever stderr is
+present or an exception occurs, even though the tool still returns its string to the model.
+
+**Sensitive content (off by default):**
+
+Content attributes (`af.agent.input`, `af.agent.response`, `af.dynamic_session.code`,
+`af.dynamic_session.stdout`, `af.dynamic_session.stderr`) are gated behind
+`ENABLE_SENSITIVE_DATA=true`. Without it, only metadata (byte counts, call counts, outcome) is
+recorded. Keep this off in production to protect PII.
+
+**Optional host+worker correlation:**
+
+Add `"telemetryMode": "OpenTelemetry"` to `host.json` to align the Functions host's request
+telemetry with the runtime's worker spans under the same end-to-end operation ID. This is
+additive — runtime spans work without it.
+
+**Reduce log noise:**
+
+The runtime automatically quiets known-noisy loggers (Azure SDK HTTP, `azure.identity`, `httpx`,
+OpenTelemetry internals). To also quiet host-side startup noise, add log-level overrides in
+`host.json`:
+
+```json
+{
+  "logging": {
+    "logLevel": {
+      "default": "Warning",
+      "Host.Startup": "Warning",
+      "Host.Function.Console": "Warning",
+      "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService": "Warning"
+    }
+  }
+}
+```
+
+**Useful KQL (Transaction Search covers a full run):**
+
+```kql
+// Everything from one run, in order
+union AppRequests, AppDependencies, AppTraces, AppExceptions
+| where OperationId == "<operation-id>"
+| project TimeGenerated, itemType, Name, Message, Success, DurationMs
+| order by TimeGenerated asc
+
+// Sandbox calls that actually failed (stderr or exception)
+AppDependencies
+| where Name == "dynamic_session.execute"
+| extend stderr_present = tostring(Properties["af.dynamic_session.stderr_present"])
+| where Success == false or stderr_present == "true"
+| project TimeGenerated, OperationId, DurationMs, Properties
+```
+
 ## Deployed Function Keys
 
 Built-in chat endpoints use the default function key:

--- a/templates/skills/azure-functions-agents/references/project-files.md
+++ b/templates/skills/azure-functions-agents/references/project-files.md
@@ -28,13 +28,29 @@ app = create_function_app()
 
 ## requirements.txt
 
-Use the official PyPI package:
+Use `azurefunctions-agents-runtime[monitor]` whenever the app includes
+`APPLICATIONINSIGHTS_CONNECTION_STRING` — which the scaffolded Bicep always provisions. With the
+extra installed, the runtime's `agent.run` and `dynamic_session.execute` spans are exported to
+Application Insights automatically and no extra code is needed.
+
+```text
+azurefunctions-agents-runtime[monitor]
+```
+
+Without the `[monitor]` extra the runtime cannot export spans even when
+`APPLICATIONINSIGHTS_CONNECTION_STRING` is set, and it logs a one-time warning directing the user
+to install the extra.
+
+When the app does **not** include Application Insights, use the base package:
 
 ```text
 azurefunctions-agents-runtime
 ```
 
-Add app-specific dependencies below it.
+In that case, either prompt the user about adding Application Insights (so they get the full
+observability stack) or proceed without telemetry if the user has explicitly opted out.
+
+Add app-specific dependencies below the runtime line.
 
 ## host.json
 

--- a/templates/skills/azure-functions-agents/references/quickstart-reference.md
+++ b/templates/skills/azure-functions-agents/references/quickstart-reference.md
@@ -22,7 +22,9 @@ The official template includes:
 - `src/daily_microsoft_blog_summary.agent.md` with a 30-minute timer-agent timeout
 - `src/mcp.json`
 - `src/local.settings.json.sample`
-- `src/requirements.txt` with the official `azurefunctions-agents-runtime` PyPI package
+- `src/requirements.txt` with `azurefunctions-agents-runtime[monitor]` so Application Insights
+  observability is enabled by default (add the `[monitor]` extra if the retrieved copy ships the
+  base `azurefunctions-agents-runtime` package)
 
 ## How to Use It
 

--- a/templates/skills/azure-functions-agents/references/sessions.md
+++ b/templates/skills/azure-functions-agents/references/sessions.md
@@ -58,6 +58,24 @@ system_tools:
     client_id: $SESSION_POOL_CLIENT_ID
 ```
 
+## Endpoint Validation
+
+The runtime validates the session pool endpoint before creating the `execute_python` tool. The
+endpoint must be an HTTPS URL whose host is a subdomain of `dynamicsessions.io`
+(`*.dynamicsessions.io`). Endpoints that use a non-HTTPS scheme, embed userinfo (`user@host`), or
+target any other host are rejected and the `execute_python` tool will not be available to agents.
+A warning is logged in that state.
+
+Correct endpoint format:
+
+```
+https://<region>.dynamicsessions.io/subscriptions/.../sessionPools/<pool>
+```
+
+If `execute_python` is missing at runtime after setting the endpoint, check that
+`ACA_SESSION_POOL_ENDPOINT` resolves to a valid `https://<region>.dynamicsessions.io/...` URL and
+look for a "failed validation" warning in startup logs.
+
 ## Local Development
 
 Local execution still calls the real Azure session pool. The developer's `az login` identity

--- a/templates/skills/azure-functions-agents/references/troubleshooting.md
+++ b/templates/skills/azure-functions-agents/references/troubleshooting.md
@@ -86,6 +86,7 @@ agent run.
 | --- | --- | --- |
 | `execute_python` missing | `agents.config.yaml` lacks dynamic session config | Add `system_tools.dynamic_sessions_code_interpreter.endpoint`. |
 | Session endpoint unresolved | `ACA_SESSION_POOL_ENDPOINT` missing | Set it in app settings or `local.settings.json`. |
+| `execute_python` missing after endpoint is set | Endpoint URL failed validation | Ensure `ACA_SESSION_POOL_ENDPOINT` is an `https://<region>.dynamicsessions.io/...` URL. The runtime silently skips endpoints that are not on `*.dynamicsessions.io` or use non-HTTPS. Check startup logs for "failed validation". |
 | 403 from session pool | Identity lacks role | Assign `Azure ContainerApps Session Executor` to app identity and local user. |
 | Browser/code work unavailable | Agent instructions do not mention using Python/Playwright | Tell the agent when to use `execute_python`. |
 
@@ -355,3 +356,18 @@ traces
 | order by timestamp desc
 | project timestamp, message, severityLevel
 ```
+
+## Observability
+
+The runtime emits `agent.run {name}` and `dynamic_session.execute` spans to Application Insights.
+These are spans (not logs) — look in **Transaction Search** and the end-to-end transaction view,
+not the Logs blade.
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| No `agent.run` spans in Application Insights | `[monitor]` extra not installed | Use `azurefunctions-agents-runtime[monitor]` in `requirements.txt`. |
+| Runtime logs "install azurefunctions-agents-runtime[monitor]" warning | Connection string present but `[monitor]` extra missing | Install `azurefunctions-agents-runtime[monitor]`. |
+| Spans missing even with `[monitor]` installed | `APPLICATIONINSIGHTS_CONNECTION_STRING` not set | Set the connection string in app settings or (for local runs) `local.settings.json`. |
+| No content in span attributes, only byte counts | `ENABLE_SENSITIVE_DATA` is off (default) | Set `ENABLE_SENSITIVE_DATA=true` to capture input/response/code content. Keep off in production. |
+| Sandbox failure shows `Success` in telemetry | `[monitor]` extra not installed or old runtime version | Install `azurefunctions-agents-runtime[monitor]`. Stderr/exceptions mark the `dynamic_session.execute` span ERROR with `af.fault_domain=sandbox`. |
+| Can't find runtime spans in the Logs (`AppTraces`) list | Runtime telemetry is emitted as spans (dependencies), not trace logs | Query `AppDependencies` — both `agent.run {name}` and `dynamic_session.execute` are `INTERNAL` spans and land there (not `AppRequests`). Use Transaction Search for the full end-to-end view. |


### PR DESCRIPTION
## Why

The `azure-functions-agents-runtime` recently shipped two behavior changes the skill did not yet teach agents about:

- **Observability** ([39c9ef0](https://github.com/Azure/azure-functions-agents-runtime/commit/39c9ef0fbda7e712a89c6c79dddc54a95efe969b)): zero-code OpenTelemetry tracing to Application Insights via the optional `[monitor]` extra, with fault-domain attribution and sandbox failure visibility.
- **Session endpoint validation** ([90836bb](https://github.com/Azure/azure-functions-agents-runtime/commit/90836bb7228397833b340a13069c4d4f08a07997)): the `execute_python` tool is now silently skipped unless its endpoint is an HTTPS `*.dynamicsessions.io` URL.

Without these updates, generated apps miss telemetry, and users who hit the new validation get a silently-missing tool with no guidance.

## What changed

All edits are in the `azure-functions-agents` skill under `templates/` (the canonical source), regenerated into the plugin payload with `npm run build:plugin-payload`.

- **`[monitor]` is now the default** whenever `APPLICATIONINSIGHTS_CONNECTION_STRING` is present, which the scaffolded Bicep always provisions. When App Insights is absent, the skill tells the agent to prompt the user or fall back to the base package. (`SKILL.md`, `project-files.md`, quickstart `requirements.txt` and README)
- **New Observability section** in `infra-and-deployment.md`: enablement steps, the `agent.run` / `dynamic_session.execute` span reference, `af.fault_domain` triage values, `ENABLE_SENSITIVE_DATA` gating, optional host+worker correlation, noise control, and copy-paste KQL.
- **New Endpoint Validation section** in `sessions.md` plus troubleshooting rows documenting the `*.dynamicsessions.io` requirement and the silent-skip + "failed validation" warning behavior.
- **New Observability troubleshooting table** in `troubleshooting.md`.

## Notes for reviewers

- Every claim was validated against the runtime source (`_observability.py`, `sandbox.py`, `_handlers.py`, `docs/observability.md`), not just the commit messages. A self-review pass caught and fixed two of my own errors: `agent.run` spans are `INTERNAL` so they land in `AppDependencies` (not `AppRequests`), and `server.address` is a reused standard OpenTelemetry attribute (not `af.`-prefixed).
- The `package-lock.json` diff is incidental churn from running `npm install` in the worktree. It only drops `libc` metadata fields on optional native deps (a cross-npm-version artifact); no dependencies changed.
- Docs-only skill change. `npm run validate:skills`, `build:plugin-payload`, and `verify:plugin-payload` all pass.