### PR TITLE
docs(azure-functions-agents): document Connector Namespace parameterValueSet requirement

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/connector-schemas.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/connector-schemas.md
@@ -1,9 +1,33 @@
 # Connector Operation Schemas
 
-Use this reference to discover connector operation IDs, action parameters, and dynamic schemas.
-This is the source of truth before writing `mcpserverconfigs` operations. For Microsoft Teams
-targets, links, posting body shapes, and direct runtime smoke tests, use
-[connector-teams.md](./connector-teams.md) after reading the generic discovery flow here.
+Use this reference to discover connector operation IDs, action parameters, dynamic schemas, and
+connection authentication schemes. This is the source of truth before writing `mcpserverconfigs`
+operations or a connection resource. For Microsoft Teams targets, links, posting body shapes, and
+direct runtime smoke tests, use [connector-teams.md](./connector-teams.md) after reading the
+generic discovery flow here.
+
+## Discover Connection Authentication Schemes
+
+Before writing a connection resource for a connector other than Office 365 Outlook, check whether
+it exposes multiple named authentication schemes:
+
+```bash
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+LOCATION="westcentralus"
+CONNECTOR_NAME="visualstudioteamservices"
+
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Web/locations/$LOCATION/managedApis/$CONNECTOR_NAME?api-version=2016-06-01" \
+  --query "properties.connectionParameterSets.values[].{name:name,displayName:uiDefinition.displayName}" \
+  --output table
+```
+
+If this returns any rows, the connection resource must set `properties.parameterValueSet.name` to
+one of those exact names, or it silently falls back to a default scheme that may not work for the
+target organization or tenant. See
+[connectors.md](./connectors.md#connection-authentication-schemes) for the Bicep shape, why this
+can fail with an opaque `500` during OAuth sign-in instead of a clear error, and why fixing it on
+an already-created connection requires deleting and recreating it.
 
 ## Validate Operation IDs
 

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/connectors.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/connectors.md
@@ -55,6 +55,74 @@ See [connector-mcp.md](./connector-mcp.md#inspect-existing-connector-namespaces)
 that inspect connections, MCP server configs, and trigger configs without printing endpoint or
 callback URLs.
 
+## Connection Authentication Schemes
+
+Do not assume every connector uses one implicit authentication flow the way Office 365 Outlook
+does in the quickstart. Some connectors expose multiple named authentication schemes
+(`connectionParameterSets`), and the connection resource must select one explicitly or it silently
+falls back to a default that may not work for the target organization or tenant.
+
+Check before creating a new connection type:
+
+```bash
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+LOCATION="westcentralus"
+CONNECTOR_NAME="visualstudioteamservices"
+
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Web/locations/$LOCATION/managedApis/$CONNECTOR_NAME?api-version=2016-06-01" \
+  --query "properties.connectionParameterSets.values[].{name:name,displayName:uiDefinition.displayName}" \
+  --output table
+```
+
+If this returns any rows, select one explicitly with `properties.parameterValueSet` on the
+connection resource:
+
+```bicep
+resource connection 'Microsoft.Web/connectorGateways/connections@2026-05-01-preview' = {
+  parent: connectorGateway
+  name: connectionName
+  properties: {
+    connectorName: connectorName
+    displayName: displayName
+    parameterValueSet: {
+      name: 'EntraOAuth'
+      values: {}
+    }
+  }
+}
+```
+
+Do not guess the parameter set name; read it from `connectionParameterSets.values[].name` for the
+target connector and region, since names and defaults vary by connector. As one concrete example,
+the `visualstudioteamservices` (Azure DevOps) connector exposes `EntraOAuth`, `OauthSP`, and
+`CertOauth` in addition to its default legacy native OAuth identity provider. Signing in against
+the wrong (default) scheme on a Microsoft Entra-backed organization typically fails with an opaque
+`500` during the OAuth redirect rather than a clear permission error, and the connection stays
+`Unauthenticated` no matter how many times the user retries sign-in. If a working connection
+already exists elsewhere (created through the Azure portal or `connectors.azure.com`, for
+example), reading its `properties.parameterValueSet` is the fastest way to confirm the correct
+scheme name instead of guessing from the managed API metadata alone.
+
+`parameterValueSet` only takes effect when the connection is created for this preview resource
+type. Changing it on an already-created connection and redeploying does not update the live
+resource. If a connection was created without it, or with the wrong scheme, delete the connection
+and redeploy so Bicep recreates it correctly:
+
+```bash
+az rest --method delete \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/<resource-group>/providers/Microsoft.Web/connectorGateways/<gateway>/connections/<connection>?api-version=2026-05-01-preview"
+```
+
+`azd provision` compares the template against its own recorded deployment state, not live Azure
+state, so it can report "no changes to provision" after a manual out-of-band delete like this. Use
+`azd provision --no-state` (or `az deployment group create` directly against the resource group)
+to force Bicep to reconcile against what is actually deployed.
+
+See [troubleshooting.md](./troubleshooting.md#connection-never-reaches-connected--oauth-sign-in-fails-with-a-generic-500)
+for the full diagnostic flow, including how this is easy to mis-diagnose as an organization policy
+or service outage.
+
 ## Bicep Files
 
 Use [../assets/infra/app/connector-gateway.bicep](../assets/infra/app/connector-gateway.bicep)
@@ -71,6 +139,11 @@ MCP server config names, and trigger config names should use short lowercase app
 `office365-outlook`, `teams-channel-post`, or `o365-outlook-send-email-only`. Avoid reserved or
 product-owner words such as `microsoft` in resource names. Display names and descriptions can use
 friendly product names like Microsoft Teams or Office 365 Outlook.
+
+The asset's connection resource works as-is for Office 365 Outlook, which does not need an
+explicit `parameterValueSet`. When adapting it to a different connector, check
+[Connection Authentication Schemes](#connection-authentication-schemes) above first — do not
+assume every connector behaves like Office 365 Outlook.
 
 ## Safety Boundary
 
@@ -94,6 +167,9 @@ business apps. That is powerful, but unsafe if overexposed. For user-delegated c
 
 ## Common Next Steps
 
+- Before creating a connection for a new connector, check whether it needs an explicit
+  [`parameterValueSet`](#connection-authentication-schemes) — do not assume it behaves like
+  Office 365 Outlook.
 - Before deploying MCP server configs, validate operation IDs and parameter schemas with
   [connector-schemas.md](./connector-schemas.md).
 - For Teams posts, parse Teams links and choose the correct Teams target shape with

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/connectors.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/connectors.md
@@ -93,6 +93,17 @@ resource connection 'Microsoft.Web/connectorGateways/connections@2026-05-01-prev
 }
 ```
 
+`values: {}` is only valid for a parameter set whose own schema has no required fields, such as
+the interactive `EntraOAuth` set shown above. Read each candidate set's `parameters` from the same
+`connectionParameterSets.values[]` response before assuming empty `values` is correct — some sets
+require real, non-empty values before the OAuth handshake even starts. For example,
+`visualstudioteamservices` also exposes `OauthSP` (service principal auth, requiring
+`token:TenantId`, `token:clientId`, and a `token:clientSecret`) and `CertOauth` (certificate auth,
+requiring `token:TenantId`, `token:clientId`, and a `token:clientCertificateSecret`). If the user's
+organization requires one of those instead of `EntraOAuth`, populate `values` with the
+corresponding keys, and source any secret values from Key Vault rather than literal Bicep
+parameters.
+
 Do not guess the parameter set name; read it from `connectionParameterSets.values[].name` for the
 target connector and region, since names and defaults vary by connector. As one concrete example,
 the `visualstudioteamservices` (Azure DevOps) connector exposes `EntraOAuth`, `OauthSP`, and
@@ -118,6 +129,18 @@ az rest --method delete \
 state, so it can report "no changes to provision" after a manual out-of-band delete like this. Use
 `azd provision --no-state` (or `az deployment group create` directly against the resource group)
 to force Bicep to reconcile against what is actually deployed.
+
+`connectionParameterSets` is not the only way a connector can need more than `connectorName` and
+`displayName`. Some connectors (database and file-transfer connectors such as `sql` are one
+example) have no `connectionParameterSets` at all, but instead have several required top-level
+`connectionParameters` that are plain `string`/`securestring` values, not an `oauthSetting` —
+there is no interactive sign-in step, and the connection needs real values (such as a server name,
+username, and password) supplied some other way at creation time. The general rule is: always
+read `properties.connectionParameters` and `properties.connectionParameterSets` for the specific
+connector before writing its connection resource, rather than assuming it behaves like a
+previously-integrated connector. This skill does not yet have a verified Bicep pattern for that
+non-OAuth, value-based case — treat it as unsupported until someone validates the correct
+connection property shape against a real deployment, rather than guessing at one.
 
 See [troubleshooting.md](./troubleshooting.md#connection-never-reaches-connected--oauth-sign-in-fails-with-a-generic-500)
 for the full diagnostic flow, including how this is easy to mis-diagnose as an organization policy

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/troubleshooting.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/troubleshooting.md
@@ -170,7 +170,10 @@ use.
 3. Add `parameterValueSet: { name: '<scheme-name>', values: {} }` to the connection's Bicep
    properties — see [connectors.md](./connectors.md#connection-authentication-schemes). For
    `visualstudioteamservices` (Azure DevOps) against a Microsoft Entra-backed organization, this
-   is normally `EntraOAuth`.
+   is normally `EntraOAuth`, which needs no other values. Other schemes on the same connector,
+   such as `OauthSP` or `CertOauth`, require real (non-empty) `values` for fields like
+   `token:TenantId`, `token:clientId`, and a secret — check that scheme's own `parameters` in the
+   step 1 response before assuming `values: {}` is enough.
 4. Delete the existing connection and redeploy; changing `parameterValueSet` on an already-created
    connection and redeploying does not update the live resource:
    ```bash

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/troubleshooting.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-agents/references/troubleshooting.md
@@ -130,6 +130,66 @@ Check connection status:
 az resource show --ids "$(azd env get-value O365_CONNECTION_ID)" --query properties.overallStatus -o tsv
 ```
 
+### Connection Never Reaches `Connected` / OAuth Sign-In Fails With a Generic 500
+
+If a connection stays `Unauthenticated` no matter how many times the user signs in at
+`connectors.azure.com`, and the sign-in page itself shows a generic `500 - Something went wrong!`
+error with a correlation ID rather than a clear permission or consent error, suspect a missing or
+wrong `parameterValueSet` before anything else. It is easy to mis-diagnose this as an organization
+policy problem (such as Azure DevOps's "Third-party application access via OAuth") or a service
+outage, when the real cause is that the connection was never told which authentication scheme to
+use.
+
+1. Check whether the connector exposes multiple authentication schemes:
+   ```bash
+   SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+   LOCATION="westcentralus"
+   CONNECTOR_NAME="visualstudioteamservices"
+
+   az rest --method get \
+     --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Web/locations/$LOCATION/managedApis/$CONNECTOR_NAME?api-version=2016-06-01" \
+     --query "properties.connectionParameterSets.values[].{name:name,displayName:uiDefinition.displayName}" \
+     --output table
+   ```
+2. If that returns rows, inspect the deployed connection for a `parameterValueSet`:
+   ```bash
+   RESOURCE_GROUP="rg-$(azd env get-value AZURE_ENV_NAME)"
+   CONNECTOR_GATEWAY="$(azd env get-value CONNECTOR_GATEWAY_NAME 2>/dev/null || azd env get-value O365_CONNECTOR_GATEWAY_NAME)"
+   CONNECTION_NAME="<connection-name>"
+
+   az rest --method get \
+     --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Web/connectorGateways/$CONNECTOR_GATEWAY/connections/$CONNECTION_NAME?api-version=2026-05-01-preview" \
+     --query "properties.parameterValueSet" \
+     --output jsonc
+   ```
+   If this is empty or `null`, the connection was created without selecting a scheme and is
+   falling back to the connector's default (often a legacy identity provider), which can 500 on
+   Microsoft Entra-backed organizations. If a working connection to the same connector already
+   exists elsewhere, reading its `parameterValueSet` is the fastest way to get the exact name to
+   use instead of guessing from the managed API metadata alone.
+3. Add `parameterValueSet: { name: '<scheme-name>', values: {} }` to the connection's Bicep
+   properties — see [connectors.md](./connectors.md#connection-authentication-schemes). For
+   `visualstudioteamservices` (Azure DevOps) against a Microsoft Entra-backed organization, this
+   is normally `EntraOAuth`.
+4. Delete the existing connection and redeploy; changing `parameterValueSet` on an already-created
+   connection and redeploying does not update the live resource:
+   ```bash
+   az rest --method delete \
+     --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Web/connectorGateways/$CONNECTOR_GATEWAY/connections/$CONNECTION_NAME?api-version=2026-05-01-preview"
+
+   azd provision --no-state
+   ```
+   Plain `azd provision` can report "no changes to provision" here because it diffs the template
+   against its own recorded deployment state, not live Azure state, after an out-of-band delete
+   like this.
+5. Retry sign-in at `connectors.azure.com`. It should now present the scheme named in
+   `parameterValueSet` (for example, "Log in with Microsoft Entra ID" instead of a legacy
+   Azure DevOps credentials prompt).
+
+Only investigate organization-level or tenant-level policies after ruling this out — they can
+produce the exact same generic failure and are easy to chase first, wasting time on a policy that
+was never the problem.
+
 ### Expected Connector Action Did Not Happen
 
 Sometimes a connector action fails as a missing side effect rather than a clear exception. For

--- a/templates/skills/azure-functions-agents/references/connector-schemas.md
+++ b/templates/skills/azure-functions-agents/references/connector-schemas.md
@@ -1,9 +1,33 @@
 # Connector Operation Schemas
 
-Use this reference to discover connector operation IDs, action parameters, and dynamic schemas.
-This is the source of truth before writing `mcpserverconfigs` operations. For Microsoft Teams
-targets, links, posting body shapes, and direct runtime smoke tests, use
-[connector-teams.md](./connector-teams.md) after reading the generic discovery flow here.
+Use this reference to discover connector operation IDs, action parameters, dynamic schemas, and
+connection authentication schemes. This is the source of truth before writing `mcpserverconfigs`
+operations or a connection resource. For Microsoft Teams targets, links, posting body shapes, and
+direct runtime smoke tests, use [connector-teams.md](./connector-teams.md) after reading the
+generic discovery flow here.
+
+## Discover Connection Authentication Schemes
+
+Before writing a connection resource for a connector other than Office 365 Outlook, check whether
+it exposes multiple named authentication schemes:
+
+```bash
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+LOCATION="westcentralus"
+CONNECTOR_NAME="visualstudioteamservices"
+
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Web/locations/$LOCATION/managedApis/$CONNECTOR_NAME?api-version=2016-06-01" \
+  --query "properties.connectionParameterSets.values[].{name:name,displayName:uiDefinition.displayName}" \
+  --output table
+```
+
+If this returns any rows, the connection resource must set `properties.parameterValueSet.name` to
+one of those exact names, or it silently falls back to a default scheme that may not work for the
+target organization or tenant. See
+[connectors.md](./connectors.md#connection-authentication-schemes) for the Bicep shape, why this
+can fail with an opaque `500` during OAuth sign-in instead of a clear error, and why fixing it on
+an already-created connection requires deleting and recreating it.
 
 ## Validate Operation IDs
 

--- a/templates/skills/azure-functions-agents/references/connectors.md
+++ b/templates/skills/azure-functions-agents/references/connectors.md
@@ -55,6 +55,74 @@ See [connector-mcp.md](./connector-mcp.md#inspect-existing-connector-namespaces)
 that inspect connections, MCP server configs, and trigger configs without printing endpoint or
 callback URLs.
 
+## Connection Authentication Schemes
+
+Do not assume every connector uses one implicit authentication flow the way Office 365 Outlook
+does in the quickstart. Some connectors expose multiple named authentication schemes
+(`connectionParameterSets`), and the connection resource must select one explicitly or it silently
+falls back to a default that may not work for the target organization or tenant.
+
+Check before creating a new connection type:
+
+```bash
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+LOCATION="westcentralus"
+CONNECTOR_NAME="visualstudioteamservices"
+
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Web/locations/$LOCATION/managedApis/$CONNECTOR_NAME?api-version=2016-06-01" \
+  --query "properties.connectionParameterSets.values[].{name:name,displayName:uiDefinition.displayName}" \
+  --output table
+```
+
+If this returns any rows, select one explicitly with `properties.parameterValueSet` on the
+connection resource:
+
+```bicep
+resource connection 'Microsoft.Web/connectorGateways/connections@2026-05-01-preview' = {
+  parent: connectorGateway
+  name: connectionName
+  properties: {
+    connectorName: connectorName
+    displayName: displayName
+    parameterValueSet: {
+      name: 'EntraOAuth'
+      values: {}
+    }
+  }
+}
+```
+
+Do not guess the parameter set name; read it from `connectionParameterSets.values[].name` for the
+target connector and region, since names and defaults vary by connector. As one concrete example,
+the `visualstudioteamservices` (Azure DevOps) connector exposes `EntraOAuth`, `OauthSP`, and
+`CertOauth` in addition to its default legacy native OAuth identity provider. Signing in against
+the wrong (default) scheme on a Microsoft Entra-backed organization typically fails with an opaque
+`500` during the OAuth redirect rather than a clear permission error, and the connection stays
+`Unauthenticated` no matter how many times the user retries sign-in. If a working connection
+already exists elsewhere (created through the Azure portal or `connectors.azure.com`, for
+example), reading its `properties.parameterValueSet` is the fastest way to confirm the correct
+scheme name instead of guessing from the managed API metadata alone.
+
+`parameterValueSet` only takes effect when the connection is created for this preview resource
+type. Changing it on an already-created connection and redeploying does not update the live
+resource. If a connection was created without it, or with the wrong scheme, delete the connection
+and redeploy so Bicep recreates it correctly:
+
+```bash
+az rest --method delete \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/<resource-group>/providers/Microsoft.Web/connectorGateways/<gateway>/connections/<connection>?api-version=2026-05-01-preview"
+```
+
+`azd provision` compares the template against its own recorded deployment state, not live Azure
+state, so it can report "no changes to provision" after a manual out-of-band delete like this. Use
+`azd provision --no-state` (or `az deployment group create` directly against the resource group)
+to force Bicep to reconcile against what is actually deployed.
+
+See [troubleshooting.md](./troubleshooting.md#connection-never-reaches-connected--oauth-sign-in-fails-with-a-generic-500)
+for the full diagnostic flow, including how this is easy to mis-diagnose as an organization policy
+or service outage.
+
 ## Bicep Files
 
 Use [../assets/infra/app/connector-gateway.bicep](../assets/infra/app/connector-gateway.bicep)
@@ -71,6 +139,11 @@ MCP server config names, and trigger config names should use short lowercase app
 `office365-outlook`, `teams-channel-post`, or `o365-outlook-send-email-only`. Avoid reserved or
 product-owner words such as `microsoft` in resource names. Display names and descriptions can use
 friendly product names like Microsoft Teams or Office 365 Outlook.
+
+The asset's connection resource works as-is for Office 365 Outlook, which does not need an
+explicit `parameterValueSet`. When adapting it to a different connector, check
+[Connection Authentication Schemes](#connection-authentication-schemes) above first — do not
+assume every connector behaves like Office 365 Outlook.
 
 ## Safety Boundary
 
@@ -94,6 +167,9 @@ business apps. That is powerful, but unsafe if overexposed. For user-delegated c
 
 ## Common Next Steps
 
+- Before creating a connection for a new connector, check whether it needs an explicit
+  [`parameterValueSet`](#connection-authentication-schemes) — do not assume it behaves like
+  Office 365 Outlook.
 - Before deploying MCP server configs, validate operation IDs and parameter schemas with
   [connector-schemas.md](./connector-schemas.md).
 - For Teams posts, parse Teams links and choose the correct Teams target shape with

--- a/templates/skills/azure-functions-agents/references/connectors.md
+++ b/templates/skills/azure-functions-agents/references/connectors.md
@@ -93,6 +93,17 @@ resource connection 'Microsoft.Web/connectorGateways/connections@2026-05-01-prev
 }
 ```
 
+`values: {}` is only valid for a parameter set whose own schema has no required fields, such as
+the interactive `EntraOAuth` set shown above. Read each candidate set's `parameters` from the same
+`connectionParameterSets.values[]` response before assuming empty `values` is correct — some sets
+require real, non-empty values before the OAuth handshake even starts. For example,
+`visualstudioteamservices` also exposes `OauthSP` (service principal auth, requiring
+`token:TenantId`, `token:clientId`, and a `token:clientSecret`) and `CertOauth` (certificate auth,
+requiring `token:TenantId`, `token:clientId`, and a `token:clientCertificateSecret`). If the user's
+organization requires one of those instead of `EntraOAuth`, populate `values` with the
+corresponding keys, and source any secret values from Key Vault rather than literal Bicep
+parameters.
+
 Do not guess the parameter set name; read it from `connectionParameterSets.values[].name` for the
 target connector and region, since names and defaults vary by connector. As one concrete example,
 the `visualstudioteamservices` (Azure DevOps) connector exposes `EntraOAuth`, `OauthSP`, and
@@ -118,6 +129,18 @@ az rest --method delete \
 state, so it can report "no changes to provision" after a manual out-of-band delete like this. Use
 `azd provision --no-state` (or `az deployment group create` directly against the resource group)
 to force Bicep to reconcile against what is actually deployed.
+
+`connectionParameterSets` is not the only way a connector can need more than `connectorName` and
+`displayName`. Some connectors (database and file-transfer connectors such as `sql` are one
+example) have no `connectionParameterSets` at all, but instead have several required top-level
+`connectionParameters` that are plain `string`/`securestring` values, not an `oauthSetting` —
+there is no interactive sign-in step, and the connection needs real values (such as a server name,
+username, and password) supplied some other way at creation time. The general rule is: always
+read `properties.connectionParameters` and `properties.connectionParameterSets` for the specific
+connector before writing its connection resource, rather than assuming it behaves like a
+previously-integrated connector. This skill does not yet have a verified Bicep pattern for that
+non-OAuth, value-based case — treat it as unsupported until someone validates the correct
+connection property shape against a real deployment, rather than guessing at one.
 
 See [troubleshooting.md](./troubleshooting.md#connection-never-reaches-connected--oauth-sign-in-fails-with-a-generic-500)
 for the full diagnostic flow, including how this is easy to mis-diagnose as an organization policy

--- a/templates/skills/azure-functions-agents/references/troubleshooting.md
+++ b/templates/skills/azure-functions-agents/references/troubleshooting.md
@@ -170,7 +170,10 @@ use.
 3. Add `parameterValueSet: { name: '<scheme-name>', values: {} }` to the connection's Bicep
    properties — see [connectors.md](./connectors.md#connection-authentication-schemes). For
    `visualstudioteamservices` (Azure DevOps) against a Microsoft Entra-backed organization, this
-   is normally `EntraOAuth`.
+   is normally `EntraOAuth`, which needs no other values. Other schemes on the same connector,
+   such as `OauthSP` or `CertOauth`, require real (non-empty) `values` for fields like
+   `token:TenantId`, `token:clientId`, and a secret — check that scheme's own `parameters` in the
+   step 1 response before assuming `values: {}` is enough.
 4. Delete the existing connection and redeploy; changing `parameterValueSet` on an already-created
    connection and redeploying does not update the live resource:
    ```bash

--- a/templates/skills/azure-functions-agents/references/troubleshooting.md
+++ b/templates/skills/azure-functions-agents/references/troubleshooting.md
@@ -130,6 +130,66 @@ Check connection status:
 az resource show --ids "$(azd env get-value O365_CONNECTION_ID)" --query properties.overallStatus -o tsv
 ```
 
+### Connection Never Reaches `Connected` / OAuth Sign-In Fails With a Generic 500
+
+If a connection stays `Unauthenticated` no matter how many times the user signs in at
+`connectors.azure.com`, and the sign-in page itself shows a generic `500 - Something went wrong!`
+error with a correlation ID rather than a clear permission or consent error, suspect a missing or
+wrong `parameterValueSet` before anything else. It is easy to mis-diagnose this as an organization
+policy problem (such as Azure DevOps's "Third-party application access via OAuth") or a service
+outage, when the real cause is that the connection was never told which authentication scheme to
+use.
+
+1. Check whether the connector exposes multiple authentication schemes:
+   ```bash
+   SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+   LOCATION="westcentralus"
+   CONNECTOR_NAME="visualstudioteamservices"
+
+   az rest --method get \
+     --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Web/locations/$LOCATION/managedApis/$CONNECTOR_NAME?api-version=2016-06-01" \
+     --query "properties.connectionParameterSets.values[].{name:name,displayName:uiDefinition.displayName}" \
+     --output table
+   ```
+2. If that returns rows, inspect the deployed connection for a `parameterValueSet`:
+   ```bash
+   RESOURCE_GROUP="rg-$(azd env get-value AZURE_ENV_NAME)"
+   CONNECTOR_GATEWAY="$(azd env get-value CONNECTOR_GATEWAY_NAME 2>/dev/null || azd env get-value O365_CONNECTOR_GATEWAY_NAME)"
+   CONNECTION_NAME="<connection-name>"
+
+   az rest --method get \
+     --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Web/connectorGateways/$CONNECTOR_GATEWAY/connections/$CONNECTION_NAME?api-version=2026-05-01-preview" \
+     --query "properties.parameterValueSet" \
+     --output jsonc
+   ```
+   If this is empty or `null`, the connection was created without selecting a scheme and is
+   falling back to the connector's default (often a legacy identity provider), which can 500 on
+   Microsoft Entra-backed organizations. If a working connection to the same connector already
+   exists elsewhere, reading its `parameterValueSet` is the fastest way to get the exact name to
+   use instead of guessing from the managed API metadata alone.
+3. Add `parameterValueSet: { name: '<scheme-name>', values: {} }` to the connection's Bicep
+   properties — see [connectors.md](./connectors.md#connection-authentication-schemes). For
+   `visualstudioteamservices` (Azure DevOps) against a Microsoft Entra-backed organization, this
+   is normally `EntraOAuth`.
+4. Delete the existing connection and redeploy; changing `parameterValueSet` on an already-created
+   connection and redeploying does not update the live resource:
+   ```bash
+   az rest --method delete \
+     --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Web/connectorGateways/$CONNECTOR_GATEWAY/connections/$CONNECTION_NAME?api-version=2026-05-01-preview"
+
+   azd provision --no-state
+   ```
+   Plain `azd provision` can report "no changes to provision" here because it diffs the template
+   against its own recorded deployment state, not live Azure state, after an out-of-band delete
+   like this.
+5. Retry sign-in at `connectors.azure.com`. It should now present the scheme named in
+   `parameterValueSet` (for example, "Log in with Microsoft Entra ID" instead of a legacy
+   Azure DevOps credentials prompt).
+
+Only investigate organization-level or tenant-level policies after ruling this out — they can
+produce the exact same generic failure and are easy to chase first, wasting time on a policy that
+was never the problem.
+
 ### Expected Connector Action Did Not Happen
 
 Sometimes a connector action fails as a missing side effect rather than a clear exception. For


### PR DESCRIPTION
## Problem

Some Connector Namespace connectors (e.g. isualstudioteamservices / Azure DevOps) expose multiple named authentication schemes via connectionParameterSets. The skill's only worked example (Office 365 Outlook in connector-gateway.bicep) doesn't need one, and none of the connector references mentioned that other connectors might.

Creating a connection resource without explicitly setting properties.parameterValueSet silently falls back to a default scheme. For isualstudioteamservices against a Microsoft Entra-backed org, that default is a legacy native OAuth identity provider which fails OAuth sign-in with an opaque `500 - Something went wrong!` instead of a clear permission error — while the connection resource itself still reports provisioningState: Succeeded. This is very easy to mis-diagnose as an org-level policy problem (e.g. Azure DevOps's "Third-party application access via OAuth") or a service outage, since the real cause (a missing connection-level property) produces no distinguishing symptom on its own.

Found and root-caused this while building an agent that mirrors GitHub issues into Azure DevOps work items via connector triggers/actions: GitHub's connection authorized fine, Azure DevOps's did not, and the fix was found by comparing against a separately, manually-created working ADO connection and diffing its properties.parameterValueSet against ours (absent).

## Fix

Documentation-only change, no asset/Bicep behavior change (the shipped Office 365 example still doesn't need this):

- **connectors.md**: new *Connection Authentication Schemes* section — discovery command for connectionParameterSets, the Bicep shape for parameterValueSet, and why fixing it requires deleting + recreating the connection (the property is only applied at creation, and zd provision needs --no-state afterward since it diffs against recorded state, not live Azure state). Cross-linked from *Bicep Files* and *Common Next Steps*.
- **connector-schemas.md**: new short *Discover Connection Parameter Sets* section alongside the existing operation/action schema discovery flow, cross-linking connectors.md.
- **	roubleshooting.md**: new *Connection Never Reaches Connected / OAuth Sign-In Fails With a Generic 500* entry with the full diagnostic flow, explicitly calling out that org/tenant policies are a common but usually-wrong first suspect.

## Validation

- 
pm run validate:skills ✅
- 
pm run build:plugin-payload / 
pm run verify:plugin-payload ✅ (payload regenerated and matches templates)
- 
pm run check ✅ (lint, typecheck, tests, build all pass)

Only 	emplates/skills/azure-functions-agents/references/{connectors,connector-schemas,troubleshooting}.md and their generated .github/plugins/... mirrors are touched.