### PR TITLE
Fix Vally eval routing checks

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: azure-functions-create
-description: "Scaffold a new Azure Functions project with language and template selection"
+description: "Scaffold a new Azure Functions project, or add a new function/trigger to an existing project without re-initializing it"
 ---
 
 
 > **Language**: Always respond in the same language the user is using.
 
-# azure-functions-create — Create Azure Functions App
+# azure-functions-create — Create or Extend Azure Functions App
 
-Guide the user through creating a new Azure Functions project.
+Guide the user through creating a new Azure Functions project or adding a function to an existing Azure Functions project.
 
 ## Prerequisites
 

--- a/evals/azure-functions-agents/eval.yaml
+++ b/evals/azure-functions-agents/eval.yaml
@@ -21,6 +21,8 @@ scoring:
   threshold: 0.8
   weights:
     skill-invocation: 2.0
+    file-exists: 1.0
+    file-matches: 1.0
     output-matches: 1.0
     output-not-matches: 1.5
     completed: 1.0
@@ -122,12 +124,19 @@ stimuli:
       - type: output-matches
         config:
           pattern: "(?i)Connector Namespace|connectorGateways|Microsoft.Web/connectorGateways"
-      - type: output-matches
+      # Validate the generated connector-triggered agent file instead of relying on
+      # the final assistant summary to repeat implementation-specific trigger names.
+      - type: file-matches
         config:
-          pattern: "(?i)generic_trigger|connectorTrigger|trigger.args"
-      - type: output-matches
+          path: "**/*.agent.md"
+          pattern: "(?s)trigger:\\s*\\n\\s*type:\\s*generic_trigger\\s*\\n\\s*args:\\s*\\n\\s*type:\\s*connectorTrigger"
+      - type: file-exists
         config:
-          pattern: "(?i)mcp.json|connection MCP|draft"
+          path: "**/mcp.json"
+      - type: file-matches
+        config:
+          path: "**/*.agent.md"
+          pattern: "(?i)draft|draft reply|CreateDraftReply"
       - type: output-matches
         config:
           pattern: "(?i)trigger-config|connector_extension|second-step"
@@ -268,7 +277,7 @@ stimuli:
           pattern: 'service\.flow\.microsoft\.com//\.default'
       - type: output-matches
         config:
-          pattern: 'apihub\.azure\.com/\.default'
+          pattern: "(?i)connectionRuntimeUrl|connection runtime|az rest"
       - type: completed
       - type: output-not-matches
         config:
@@ -302,9 +311,6 @@ stimuli:
       - type: output-matches
         config:
           pattern: "(?i)body.*contentType.*html|body.*content"
-      - type: output-matches
-        config:
-          pattern: 'apihub\.azure\.com/\.default'
       - type: completed
       - type: output-not-matches
         config:

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: azure-functions-create
-title: Create Azure Functions App
-description: Scaffold a new Azure Functions project with language and template selection
+title: Create or Extend Azure Functions App
+description: Scaffold a new Azure Functions project, or add a new function/trigger to an existing project without re-initializing it
 category: task
 ---
 
 > **Language**: Always respond in the same language the user is using.
 
-# azure-functions-create — Create Azure Functions App
+# azure-functions-create — Create or Extend Azure Functions App
 
-Guide the user through creating a new Azure Functions project.
+Guide the user through creating a new Azure Functions project or adding a function to an existing Azure Functions project.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Update `azure-functions-create` skill metadata so existing-project function/trigger additions route to the create skill.
- Change the Outlook connector-triggered agent eval to inspect generated files for `generic_trigger` / `connectorTrigger` and `mcp.json` evidence instead of relying on final summary text.
- Align Teams direct connector smoke checks with the documented direct-runtime flow by requiring `service.flow.microsoft.com//.default` and connection runtime evidence instead of `apihub.azure.com/.default`.

## Local validation
- `npx vally lint --eval-spec evals`
- `npm run check`

Note: I did not run the LLM-backed `vally eval` locally; this repository gates Vally eval execution through the reviewed GitHub Environment because eval skill content is loaded as agent instructions.