### PR TITLE
ci: use npm registry for public CI

### DIFF
--- a/azure-pipelines/public-build.yml
+++ b/azure-pipelines/public-build.yml
@@ -50,14 +50,14 @@ extends:
               jobs:
                   - template: /azure-pipelines/templates/test.yml@self
                     parameters:
-                        npmRegistry: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/nodejs-upstream/npm/registry/'
+                        npmRegistry: 'https://registry.npmjs.org/'
 
             - stage: LinuxUnitTests
               dependsOn: []
               jobs:
                   - template: /azure-pipelines/templates/test.yml@self
                     parameters:
-                        npmRegistry: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/nodejs-upstream/npm/registry/'
+                        npmRegistry: 'https://registry.npmjs.org/'
               pool:
                   name: 1es-pool-azfunc-public
                   image: 1es-ubuntu-22.04
@@ -69,4 +69,4 @@ extends:
                   - template: /azure-pipelines/templates/build.yml@self
                     parameters:
                         IsPrerelease: true
-                        npmRegistry: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/nodejs-upstream/npm/registry/'
+                        npmRegistry: 'https://registry.npmjs.org/'


### PR DESCRIPTION
## Summary
- Replace the public CI npm registry feed with `https://registry.npmjs.org/`
- Apply the registry to Windows unit tests, Linux unit tests, and build stages

## Validation
- Confirmed the old Azure Artifacts feed and package feed proxy no longer appear in `azure-pipelines/public-build.yml`
- Confirmed the latest commit is SSH-signed and does not include a Co-authored-by trailer

## Notes
- This PR is intended to validate whether public CI can use the general npm registry instead of maintaining the public feed.