### PR TITLE
build: use shared ESRP npm release template

### DIFF
--- a/azure-pipelines/pre-release.yml
+++ b/azure-pipelines/pre-release.yml
@@ -17,6 +17,10 @@ resources:
           type: git
           name: 1ESPipelineTemplates/1ESPipelineTemplates
           ref: refs/tags/release
+        - repository: eng
+          type: git
+          name: engineering
+          ref: refs/heads/main
 
 variables:
     - group: azure-functions-skills-release
@@ -57,23 +61,12 @@ extends:
                               displayName: 'Download artifact'
                             - template: /azure-pipelines/templates/npm-publish-steps.yml@self
                               parameters:
-                                  tgzPath: '$(Pipeline.Workspace)/drop'
-                                  NpmPublishTag: ${{ parameters.NpmPublishTag }}
-                                  NpmPublishDryRun: true
+                                tgzPath: '$(Pipeline.Workspace)/drop'
+                                NpmPublishTag: ${{ parameters.NpmPublishTag }}
                   - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
-                      - job: Release
-                        templateContext:
-                            type: releaseJob
-                            isProduction: true
-                            environment: azure-functions-skills-npm-prod
-                            inputs:
-                                - input: pipelineArtifact
-                                  artifactName: drop
-                                  targetPath: $(Pipeline.Workspace)/drop
-                        steps:
-                            - checkout: none
-                            - template: /azure-pipelines/templates/npm-publish-steps.yml@self
-                              parameters:
-                                  tgzPath: '$(Pipeline.Workspace)/drop'
-                                  NpmPublishTag: ${{ parameters.NpmPublishTag }}
-                                  NpmPublishDryRun: false
+                      - template: /ci/release-npm-package.yml@eng
+                        parameters:
+                            artifact: drop
+                            publishMethod: esrp
+                            esrpNpmTag: ${{ parameters.NpmPublishTag }}
+                            approvers: '$(EsrpManualApprovers)'

--- a/azure-pipelines/pre-release.yml
+++ b/azure-pipelines/pre-release.yml
@@ -20,7 +20,7 @@ resources:
         - repository: eng
           type: git
           name: engineering
-          ref: refs/heads/main
+          ref: refs/tags/release
 
 variables:
     - group: azure-functions-skills-release

--- a/azure-pipelines/pre-release.yml
+++ b/azure-pipelines/pre-release.yml
@@ -46,15 +46,34 @@ extends:
             - stage: Release
               dependsOn: Build
               jobs:
-                  - job: Release
-                    steps:
-                        - task: DownloadPipelineArtifact@2
-                          inputs:
-                              artifact: drop
-                              path: $(Pipeline.Workspace)/drop
-                          displayName: 'Download artifact'
-                        - template: /azure-pipelines/templates/npm-publish-steps.yml@self
-                          parameters:
-                              tgzPath: '$(Pipeline.Workspace)/drop'
-                              NpmPublishTag: ${{ parameters.NpmPublishTag }}
-                              NpmPublishDryRun: ${{ parameters.NpmPublishDryRun }}
+                  - ${{ if eq(parameters.NpmPublishDryRun, true) }}:
+                      - job: ValidateRelease
+                        displayName: 'Validate npm release'
+                        steps:
+                            - task: DownloadPipelineArtifact@2
+                              inputs:
+                                  artifact: drop
+                                  path: $(Pipeline.Workspace)/drop
+                              displayName: 'Download artifact'
+                            - template: /azure-pipelines/templates/npm-publish-steps.yml@self
+                              parameters:
+                                  tgzPath: '$(Pipeline.Workspace)/drop'
+                                  NpmPublishTag: ${{ parameters.NpmPublishTag }}
+                                  NpmPublishDryRun: true
+                  - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
+                      - job: Release
+                        templateContext:
+                            type: releaseJob
+                            isProduction: true
+                            environment: azure-functions-skills-npm-prod
+                            inputs:
+                                - input: pipelineArtifact
+                                  artifactName: drop
+                                  targetPath: $(Pipeline.Workspace)/drop
+                        steps:
+                            - checkout: none
+                            - template: /azure-pipelines/templates/npm-publish-steps.yml@self
+                              parameters:
+                                  tgzPath: '$(Pipeline.Workspace)/drop'
+                                  NpmPublishTag: ${{ parameters.NpmPublishTag }}
+                                  NpmPublishDryRun: false

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -17,6 +17,10 @@ resources:
           type: git
           name: 1ESPipelineTemplates/1ESPipelineTemplates
           ref: refs/tags/release
+        - repository: eng
+          type: git
+          name: engineering
+          ref: refs/heads/main
     pipelines:
         - pipeline: officialBuild
           project: internal
@@ -53,25 +57,15 @@ extends:
                               parameters:
                                   tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
                                   NpmPublishTag: ${{ parameters.NpmPublishTag }}
-                                  NpmPublishDryRun: true
                   - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
-                      - job: Release
-                        templateContext:
-                            type: releaseJob
-                            isProduction: true
-                            environment: azure-functions-skills-npm-prod
-                            inputs:
-                                - input: pipelineArtifact
-                                  pipeline: officialBuild
-                                  artifactName: drop
-                                  targetPath: $(Pipeline.Workspace)/officialBuild/drop
-                        steps:
-                            - checkout: none
-                            - template: /azure-pipelines/templates/npm-publish-steps.yml@self
-                              parameters:
-                                  tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
-                                  NpmPublishTag: ${{ parameters.NpmPublishTag }}
-                                  NpmPublishDryRun: false
+                      - template: /ci/release-npm-package.yml@eng
+                        parameters:
+                            artifact:
+                                name: drop
+                                pipeline: officialBuild
+                            publishMethod: esrp
+                            esrpNpmTag: ${{ parameters.NpmPublishTag }}
+                            approvers: '$(EsrpManualApprovers)'
             - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
                 - stage: GitHubTagAndRelease
                   dependsOn: Release

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -20,7 +20,7 @@ resources:
         - repository: eng
           type: git
           name: engineering
-          ref: refs/heads/main
+          ref: refs/tags/release
     pipelines:
         - pipeline: officialBuild
           project: internal

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -23,6 +23,9 @@ resources:
           source: functions-skills.official
           branch: main
 
+variables:
+    - group: azure-functions-skills-release
+
 extends:
     template: v1/1ES.Official.PipelineTemplate.yml@1es
     parameters:
@@ -41,43 +44,64 @@ extends:
                   image: 1es-ubuntu-22.04
                   os: linux
               jobs:
-                  - job: Release
-                    steps:
-                        - download: officialBuild
-                        - template: /azure-pipelines/templates/npm-publish-steps.yml@self
-                          parameters:
-                              tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
-                              NpmPublishTag: ${{ parameters.NpmPublishTag }}
-                              NpmPublishDryRun: ${{ parameters.NpmPublishDryRun }}
-            - stage: GitHubTagAndRelease
-              dependsOn: Release
-              pool:
-                  name: 1es-pool-azfunc
-                  image: 1es-windows-2022
-                  os: windows
-              jobs:
-                  - job: GitHubTagAndRelease
-                    steps:
-                        - download: officialBuild
-                        - task: DownloadPipelineArtifact@2
-                          inputs:
-                              artifact: drop
-                              path: $(Pipeline.Workspace)/drop
-                          displayName: 'Download drop artifact'
-                        - powershell: |
-                              $files = Get-ChildItem "$(Pipeline.Workspace)\drop" -Filter "*.tgz"
-                              if ($files.Count -ne 1) {
-                                  Write-Error "Expected one .tgz file, found $($files.Count)"
-                                  exit 1
-                              }
-                              $file = $files[0].Name
-                              if ($file -match '.*-(\d+\.\d+\.\d+.*)\.tgz') {
-                                  $version = $Matches[1]
-                                  Write-Host "Parsed version: $version"
-                                  Write-Host "##vso[task.setvariable variable=version]$version"
-                              } else {
-                                  Write-Error "Filename did not match expected pattern"
-                                  exit 1
-                              }
-                          displayName: 'Extract version from .tgz filename'
-                        - template: /azure-pipelines/templates/github-release.yml@self
+                  - ${{ if eq(parameters.NpmPublishDryRun, true) }}:
+                      - job: ValidateRelease
+                        displayName: 'Validate npm release'
+                        steps:
+                            - download: officialBuild
+                            - template: /azure-pipelines/templates/npm-publish-steps.yml@self
+                              parameters:
+                                  tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
+                                  NpmPublishTag: ${{ parameters.NpmPublishTag }}
+                                  NpmPublishDryRun: true
+                  - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
+                      - job: Release
+                        templateContext:
+                            type: releaseJob
+                            isProduction: true
+                            environment: azure-functions-skills-npm-prod
+                            inputs:
+                                - input: pipelineArtifact
+                                  pipeline: officialBuild
+                                  artifactName: drop
+                                  targetPath: $(Pipeline.Workspace)/officialBuild/drop
+                        steps:
+                            - checkout: none
+                            - template: /azure-pipelines/templates/npm-publish-steps.yml@self
+                              parameters:
+                                  tgzPath: '$(Pipeline.Workspace)/officialBuild/drop'
+                                  NpmPublishTag: ${{ parameters.NpmPublishTag }}
+                                  NpmPublishDryRun: false
+            - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
+                - stage: GitHubTagAndRelease
+                  dependsOn: Release
+                  pool:
+                      name: 1es-pool-azfunc
+                      image: 1es-windows-2022
+                      os: windows
+                  jobs:
+                      - job: GitHubTagAndRelease
+                        steps:
+                            - download: officialBuild
+                            - task: DownloadPipelineArtifact@2
+                              inputs:
+                                  artifact: drop
+                                  path: $(Pipeline.Workspace)/drop
+                              displayName: 'Download drop artifact'
+                            - powershell: |
+                                  $files = Get-ChildItem "$(Pipeline.Workspace)\drop" -Filter "*.tgz"
+                                  if ($files.Count -ne 1) {
+                                      Write-Error "Expected one .tgz file, found $($files.Count)"
+                                      exit 1
+                                  }
+                                  $file = $files[0].Name
+                                  if ($file -match '.*-(\d+\.\d+\.\d+.*)\.tgz') {
+                                      $version = $Matches[1]
+                                      Write-Host "Parsed version: $version"
+                                      Write-Host "##vso[task.setvariable variable=version]$version"
+                                  } else {
+                                      Write-Error "Filename did not match expected pattern"
+                                      exit 1
+                                  }
+                              displayName: 'Extract version from .tgz filename'
+                            - template: /azure-pipelines/templates/github-release.yml@self

--- a/azure-pipelines/templates/npm-publish-steps.yml
+++ b/azure-pipelines/templates/npm-publish-steps.yml
@@ -3,9 +3,6 @@ parameters:
       type: string
     - name: NpmPublishTag
       type: string
-    - name: NpmPublishDryRun
-      type: boolean
-      default: true
 
 steps:
     - pwsh: |
@@ -18,32 +15,10 @@ steps:
           Write-Host "##vso[task.setvariable variable=npmPackagePath]$($packages[0].FullName)"
       displayName: 'Validate npm package artifact'
 
-    - ${{ if eq(parameters.NpmPublishDryRun, true) }}:
-        - task: NodeTool@0
-          displayName: 'Install Node.js'
-          inputs:
-              versionSpec: 22.x
+    - task: NodeTool@0
+      displayName: 'Install Node.js'
+      inputs:
+          versionSpec: 22.x
 
-        - script: npm publish "$(npmPackagePath)" --tag "${{ parameters.NpmPublishTag }}" --registry "https://registry.npmjs.org" --dry-run --ignore-scripts
-          displayName: 'Validate npm publish (dry run)'
-
-    - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
-        - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@12
-          displayName: 'Publish npm package through ESRP Release'
-          inputs:
-              connectedservicename: '$(EsrpReleaseServiceConnection)'
-              usemanagedidentity: true
-              keyvaultname: '$(EsrpReleaseKeyVaultName)'
-              signcertname: '$(EsrpReleaseSignCertName)'
-              clientid: '$(EsrpReleaseClientId)'
-              intent: 'PackageDistribution'
-              contenttype: 'npm'
-              contentsource: 'Folder'
-              folderlocation: '${{ parameters.tgzPath }}'
-              waitforreleasecompletion: true
-              owners: '$(EsrpReleaseOwner)'
-              approvers: '$(EsrpReleaseApprover)'
-              serviceendpointurl: 'https://api.esrp.microsoft.com'
-              mainpublisher: '$(EsrpReleaseMainPublisher)'
-              domaintenantid: '$(EsrpReleaseDomainTenantId)'
-              productstate: '${{ parameters.NpmPublishTag }}'
+    - script: npm publish "$(npmPackagePath)" --tag "${{ parameters.NpmPublishTag }}" --registry "https://registry.npmjs.org" --dry-run --ignore-scripts
+      displayName: 'Validate npm publish (dry run)'

--- a/azure-pipelines/templates/npm-publish-steps.yml
+++ b/azure-pipelines/templates/npm-publish-steps.yml
@@ -1,23 +1,49 @@
 parameters:
-    tgzPath: ''
-    NpmPublishTag: ''
-    NpmPublishDryRun: false
+    - name: tgzPath
+      type: string
+    - name: NpmPublishTag
+      type: string
+    - name: NpmPublishDryRun
+      type: boolean
+      default: true
 
 steps:
-    - task: NodeTool@0
-      displayName: 'Install Node.js'
-      inputs:
-          versionSpec: 22.x
+    - pwsh: |
+          $packages = @(Get-ChildItem -Path '${{ parameters.tgzPath }}' -Recurse -File -Filter '*.tgz')
+          if ($packages.Count -ne 1) {
+              throw "Expected exactly one npm package under '${{ parameters.tgzPath }}'; found $($packages.Count)."
+          }
 
-    - script: mv *.tgz package.tgz
-      displayName: 'Rename tgz file'
-      workingDirectory: '${{ parameters.tgzPath }}'
+          Write-Host "Using npm package $($packages[0].FullName)"
+          Write-Host "##vso[task.setvariable variable=npmPackagePath]$($packages[0].FullName)"
+      displayName: 'Validate npm package artifact'
 
-    - task: Npm@1
-      displayName: 'npm publish'
-      inputs:
-          command: custom
-          workingDir: '${{ parameters.tgzPath }}'
-          verbose: true
-          customCommand: 'publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ lower(parameters.NpmPublishDryRun) }}'
-          customEndpoint: azure-functions-skills-npm
+    - ${{ if eq(parameters.NpmPublishDryRun, true) }}:
+        - task: NodeTool@0
+          displayName: 'Install Node.js'
+          inputs:
+              versionSpec: 22.x
+
+        - script: npm publish "$(npmPackagePath)" --tag "${{ parameters.NpmPublishTag }}" --registry "https://registry.npmjs.org" --dry-run --ignore-scripts
+          displayName: 'Validate npm publish (dry run)'
+
+    - ${{ if eq(parameters.NpmPublishDryRun, false) }}:
+        - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@12
+          displayName: 'Publish npm package through ESRP Release'
+          inputs:
+              connectedservicename: '$(EsrpReleaseServiceConnection)'
+              usemanagedidentity: true
+              keyvaultname: '$(EsrpReleaseKeyVaultName)'
+              signcertname: '$(EsrpReleaseSignCertName)'
+              clientid: '$(EsrpReleaseClientId)'
+              intent: 'PackageDistribution'
+              contenttype: 'npm'
+              contentsource: 'Folder'
+              folderlocation: '${{ parameters.tgzPath }}'
+              waitforreleasecompletion: true
+              owners: '$(EsrpReleaseOwner)'
+              approvers: '$(EsrpReleaseApprover)'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: '$(EsrpReleaseMainPublisher)'
+              domaintenantid: '$(EsrpReleaseDomainTenantId)'
+              productstate: '${{ parameters.NpmPublishTag }}'

--- a/docs/internal/telemetry-release.md
+++ b/docs/internal/telemetry-release.md
@@ -23,7 +23,8 @@ replaces that placeholder immediately before `npm pack`.
    ```
 
 6. `azure-pipelines/release.yml` consumes the official build's `drop` artifact
-   for npm publishing. It does not manually upload to partner blob storage.
+   and publishes it to npm through ESRP Release v12. It does not use an npm
+   token or manually upload to partner blob storage.
 
 If the official build mirroring is delayed or a controlled re-upload is needed,
 run `azure-pipelines/partner-drop-upload.yml`. It consumes the selected
@@ -41,6 +42,26 @@ Required AzDO variable group: `azure-functions-skills-release`.
 | `PartnerBlobAzureServiceConnection` | Azure service connection used by the helper upload pipeline. |
 | `PartnerBlobStorageAccount` | Partner storage account name, expected to be `azuresdkpartnerdrops`. |
 | `PartnerBlobContainer` | Partner blob container name, expected to be `drops`. |
+| `EsrpReleaseServiceConnection` | Azure Resource Manager service connection used by ESRP Release. The shared Azure Functions value is `azfunc-internal-esrp-prod`. |
+| `EsrpReleaseKeyVaultName` | Key Vault containing the ESRP signing certificate. The shared Azure Functions value is `kv-azfunc-esrp-prod`. |
+| `EsrpReleaseSignCertName` | ESRP request-signing certificate name. The shared Azure Functions value is `esrp-signing`. |
+| `EsrpReleaseClientId` | Managed identity or app client ID onboarded to ESRP Release for npm publishing. |
+| `EsrpReleaseOwner` | Individual Microsoft alias that owns the ESRP release. Distribution lists and security groups are not supported. |
+| `EsrpReleaseApprover` | Individual Microsoft alias that approves the ESRP release; use a different person from the owner. |
+| `EsrpReleaseMainPublisher` | Main publisher assigned during ESRP onboarding, normally `ESRPRELPACMAN` for npm. |
+| `EsrpReleaseDomainTenantId` | Domain tenant ID assigned during ESRP onboarding. |
+
+The mirror project must also contain an
+`azure-functions-skills-npm-prod` Azure DevOps environment. Configure its
+approval check before enabling real publishing, authorize the release
+pipelines to use the variable group, environment, service connection, and
+official-build pipeline resource, and add `microsoft1es` plus
+`microsoft-oss-releases` as read/write collaborators for the npm package.
+
+Both release pipelines default to a local npm dry run. Queue with
+`NpmPublishDryRun: false` only after checking the package version and tag.
+ESRP Release is auto-approved after the environment checks complete, and
+`NpmPublishTag` is passed as ESRP's npm `productstate`.
 
 ## Runtime telemetry hook
 

--- a/docs/internal/telemetry-release.md
+++ b/docs/internal/telemetry-release.md
@@ -43,7 +43,6 @@ Required AzDO variable group: `azure-functions-skills-release`.
 | `PartnerBlobAzureServiceConnection` | Azure service connection used by the helper upload pipeline. |
 | `PartnerBlobStorageAccount` | Partner storage account name, expected to be `azuresdkpartnerdrops`. |
 | `PartnerBlobContainer` | Partner blob container name, expected to be `drops`. |
-| `EsrpReleaseSignCertName` | ESRP Release request-signing certificate name provisioned in the internal Key Vault. |
 | `EsrpOwners` | Comma- or newline-separated individual Microsoft aliases that own the ESRP release. Distribution lists and security groups are not supported. |
 | `EsrpApprovers` | Comma- or newline-separated individual Microsoft aliases that approve the ESRP release; these must differ from the owners. |
 | `EsrpManualApprovers` | Azure DevOps users or groups allowed to approve the manual validation before ESRP publishing. |

--- a/docs/internal/telemetry-release.md
+++ b/docs/internal/telemetry-release.md
@@ -23,8 +23,9 @@ replaces that placeholder immediately before `npm pack`.
    ```
 
 6. `azure-pipelines/release.yml` consumes the official build's `drop` artifact
-   and publishes it to npm through ESRP Release v12. It does not use an npm
-   token or manually upload to partner blob storage.
+   and delegates npm publishing to the internal engineering
+   `release-npm-package.yml` template with its ESRP option enabled. It does not
+   expose the fixed ESRP infrastructure configuration or use an npm token.
 
 If the official build mirroring is delayed or a controlled re-upload is needed,
 run `azure-pipelines/partner-drop-upload.yml`. It consumes the selected
@@ -42,26 +43,21 @@ Required AzDO variable group: `azure-functions-skills-release`.
 | `PartnerBlobAzureServiceConnection` | Azure service connection used by the helper upload pipeline. |
 | `PartnerBlobStorageAccount` | Partner storage account name, expected to be `azuresdkpartnerdrops`. |
 | `PartnerBlobContainer` | Partner blob container name, expected to be `drops`. |
-| `EsrpReleaseServiceConnection` | Azure Resource Manager service connection used by ESRP Release. The shared Azure Functions value is `azfunc-internal-esrp-prod`. |
-| `EsrpReleaseKeyVaultName` | Key Vault containing the ESRP signing certificate. The shared Azure Functions value is `kv-azfunc-esrp-prod`. |
-| `EsrpReleaseSignCertName` | ESRP request-signing certificate name. The shared Azure Functions value is `esrp-signing`. |
-| `EsrpReleaseClientId` | Managed identity or app client ID onboarded to ESRP Release for npm publishing. |
-| `EsrpReleaseOwner` | Individual Microsoft alias that owns the ESRP release. Distribution lists and security groups are not supported. |
-| `EsrpReleaseApprover` | Individual Microsoft alias that approves the ESRP release; use a different person from the owner. |
-| `EsrpReleaseMainPublisher` | Main publisher assigned during ESRP onboarding, normally `ESRPRELPACMAN` for npm. |
-| `EsrpReleaseDomainTenantId` | Domain tenant ID assigned during ESRP onboarding. |
+| `EsrpReleaseSignCertName` | ESRP Release request-signing certificate name provisioned in the internal Key Vault. |
+| `EsrpOwners` | Comma- or newline-separated individual Microsoft aliases that own the ESRP release. Distribution lists and security groups are not supported. |
+| `EsrpApprovers` | Comma- or newline-separated individual Microsoft aliases that approve the ESRP release; these must differ from the owners. |
+| `EsrpManualApprovers` | Azure DevOps users or groups allowed to approve the manual validation before ESRP publishing. |
 
-The mirror project must also contain an
-`azure-functions-skills-npm-prod` Azure DevOps environment. Configure its
-approval check before enabling real publishing, authorize the release
-pipelines to use the variable group, environment, service connection, and
-official-build pipeline resource, and add `microsoft1es` plus
-`microsoft-oss-releases` as read/write collaborators for the npm package.
+Authorize the release pipelines to use the variable group, internal engineering
+repository, ESRP service connection, and official-build pipeline resource. Add
+`microsoft1es` plus `microsoft-oss-releases` as read/write collaborators for
+the npm package.
 
 Both release pipelines default to a local npm dry run. Queue with
 `NpmPublishDryRun: false` only after checking the package version and tag.
-ESRP Release is auto-approved after the environment checks complete, and
-`NpmPublishTag` is passed as ESRP's npm `productstate`.
+Real publishing requires Azure DevOps manual validation before the engineering
+template invokes ESRP Release. `NpmPublishTag` is passed to the engineering
+template as `esrpNpmTag`.
 
 ## Runtime telemetry hook
 


### PR DESCRIPTION
## Summary
- preserve npmjs dry-run validation as the default release behavior
- delegate real npm publishing to the reviewed engineering `release-npm-package.yml` template through its managed `release` tag
- consume ESRP owner/approver values from the authorized internal variable group
- remove fixed ESRP infrastructure and all GitHub credentials from Azure DevOps
- create draft GitHub Releases through the existing tag-triggered GitHub Actions workflow
- mirror signed `v*` tags from GitHub to the internal Azure DevOps repository

## Dependency
- Azure DevOps engineering PR 1713 has merged and is available through `refs/tags/release`

## Validation
- changed Azure Pipeline YAML parses successfully
- targeted pipeline tests pass (56 passed, 2 skipped)
- npm package dry run succeeds against `https://registry.npmjs.org`
- no fixed ESRP service, Key Vault, client, tenant, publisher, task configuration, GitHub PAT, or GitHub username remains in public pipeline files