### PR TITLE
fix: show expected results in doctor E2E summary

### DIFF
--- a/docs/bad-app-fixtures.md
+++ b/docs/bad-app-fixtures.md
@@ -51,12 +51,20 @@ Each fixture's report is saved to `<fixture>/doctor-result.json`. A summary tabl
 
 ```text
 ===== Summary =====
-Name                                 ExitCode Status  Critical High Medium AiChecks Duration
-----                                 -------- ------  -------- ---- ------ -------- --------
-csharp-deep-blocking-async                  1 fail           0    4      2        8     78.2
-node-deep-client-reuse                      1 fail           1    3      2        9     65.4
+Name                         ExitCode Expected Actual Expectation MissingFindings UnexpectedFindings AiChecks Duration
+----                         -------- -------- ------ ----------- --------------- ------------------ -------- --------
+01-missing-host-json                1 fail     fail   match       -               -                  -        0.8
 …
 ```
+
+`match` means the status and every minimum required Tier 1 finding match
+`expected-results.json`. `partial` means the status matches but required findings
+are missing, while `mismatch` means the status differs. Runs with `-Deep` are
+`advisory` because LLM findings are non-deterministic; deterministic differences
+remain visible in the finding columns. `unconfigured` flags a fixture missing
+from the machine-readable expectations. Additional findings are shown in
+`UnexpectedFindings` for investigation but do not change a `match` verdict
+because required findings are minimum assertions.
 
 ### 3. Generate HTML validation report
 

--- a/scripts/doctor-e2e-compare.mjs
+++ b/scripts/doctor-e2e-compare.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { evaluateDoctorExpectation } from '../lib/doctor/e2e-summary.js';
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(path), 'utf8'));
+}
+
+function parseArgs(argv) {
+  const args = { deep: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--deep') args.deep = true;
+    else if (arg === '--expectations') args.expectations = argv[++index];
+    else if (arg === '--fixture') args.fixture = argv[++index];
+    else if (arg === '--report') args.report = argv[++index];
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.expectations || !args.fixture || !args.report) {
+  throw new Error('Usage: doctor-e2e-compare.mjs --expectations <path> --fixture <name> --report <path> [--deep]');
+}
+
+const expectations = readJson(args.expectations);
+const report = readJson(args.report);
+const result = evaluateDoctorExpectation(expectations[args.fixture], report, args.deep);
+process.stdout.write(JSON.stringify(result));

--- a/scripts/doctor-e2e-setup.ps1
+++ b/scripts/doctor-e2e-setup.ps1
@@ -100,8 +100,8 @@ foreach ($fixture in $fixtures) {
     Write-Host "  [+] $($fixture.Name)" -ForegroundColor Green
 }
 
-# Copy expected-results.md and README.md for reference
-foreach ($refFile in @('expected-results.md', 'README.md')) {
+# Copy expectations and fixture documentation
+foreach ($refFile in @('expected-results.json', 'expected-results.md', 'README.md')) {
     $src = Join-Path $fixturesDir $refFile
     if (Test-Path $src) {
         Copy-Item -Path $src -Destination (Join-Path $Target $refFile) -Force
@@ -122,6 +122,7 @@ param(
 )
 
 $env:AZURE_FUNCTIONS_DOCTOR_STACKS_OFFLINE = '1'
+$expectationsPath = Join-Path $PSScriptRoot 'expected-results.json'
 $dirs = Get-ChildItem -Path $PSScriptRoot -Directory |
     Where-Object { $_.Name -like $Filter } |
     Sort-Object Name
@@ -155,11 +156,21 @@ foreach ($d in $dirs) {
     # Parse summary from the --output file (always JSON when $Format -eq 'json')
     $summary = $null
     $aiCount = '-'
+    $comparison = $null
     if ($Format -eq 'json' -and (Test-Path $outFile)) {
         try {
             $json = Get-Content $outFile -Raw | ConvertFrom-Json
             $summary = $json.summary
             if ($json.tiers.ai) { $aiCount = @($json.tiers.ai.checks).Count }
+
+            $compareArgs = @(
+                $COMPARE_PATH,
+                '--expectations', $expectationsPath,
+                '--fixture', $d.Name,
+                '--report', $outFile
+            )
+            if ($Deep) { $compareArgs += '--deep' }
+            $comparison = (& node @compareArgs) | ConvertFrom-Json
         } catch {
             Write-Host "  -> WARN: failed to parse $outFile : $($_.Exception.Message)" -ForegroundColor Yellow
         }
@@ -168,10 +179,15 @@ foreach ($d in $dirs) {
     $results += [PSCustomObject]@{
         Name      = $d.Name
         ExitCode  = $exitCode
-        Status    = if ($summary) { $summary.status } else { 'unknown' }
-        Critical  = if ($summary) { $summary.critical } else { '-' }
-        High      = if ($summary) { $summary.high } else { '-' }
-        Medium    = if ($summary) { $summary.medium } else { '-' }
+        Expected  = if ($comparison) { $comparison.expected } else { '-' }
+        Actual    = if ($comparison) { $comparison.actual } elseif ($summary) { $summary.status } else { 'unknown' }
+        Expectation = if ($comparison) { $comparison.expectation } else { 'unknown' }
+        MissingFindings = if ($comparison -and $comparison.missingFindings.Count -gt 0) {
+            $comparison.missingFindings -join ', '
+        } else { '-' }
+        UnexpectedFindings = if ($comparison -and $comparison.unexpectedFindings.Count -gt 0) {
+            $comparison.unexpectedFindings -join ', '
+        } else { '-' }
         AiChecks  = $aiCount
         Duration  = [Math]::Round($fixtureDuration.TotalSeconds, 1)
     }
@@ -187,8 +203,9 @@ Write-Host ""
 Write-Host "Per-fixture reports saved to <fixture>/doctor-result.json" -ForegroundColor DarkGray
 '@
 
-# Inject the CLI path after param() block
-$runAllScript = $runAllContent -replace "(?m)^(\`$env:AZURE_FUNCTIONS_DOCTOR_STACKS_OFFLINE)", "`$CLI_PATH = '$cliPath'`n`$1"
+# Inject repository tool paths after param() block
+$comparePath = Join-Path $repoRoot 'scripts\doctor-e2e-compare.mjs'
+$runAllScript = $runAllContent -replace "(?m)^(\`$env:AZURE_FUNCTIONS_DOCTOR_STACKS_OFFLINE)", "`$CLI_PATH = '$cliPath'`n`$COMPARE_PATH = '$comparePath'`n`$1"
 $runAllPath = Join-Path $Target 'run-all.ps1'
 Set-Content -Path $runAllPath -Value $runAllScript -Encoding utf8
 

--- a/src/doctor/e2e-summary.ts
+++ b/src/doctor/e2e-summary.ts
@@ -1,0 +1,67 @@
+export interface DoctorE2eExpectation {
+  readonly expectedStatus: 'pass' | 'fail';
+  readonly requiredFindings: readonly string[];
+}
+
+interface DoctorE2eCheck {
+  readonly id: string;
+  readonly status: string;
+}
+
+export interface DoctorE2eReport {
+  readonly summary?: {
+    readonly status?: string;
+  };
+  readonly tiers?: {
+    readonly builtin?: {
+      readonly checks?: readonly DoctorE2eCheck[];
+    };
+  };
+}
+
+export interface DoctorE2eEvaluation {
+  readonly expected: string;
+  readonly actual: string;
+  readonly expectation: 'match' | 'partial' | 'mismatch' | 'advisory' | 'unconfigured';
+  readonly missingFindings: readonly string[];
+  readonly unexpectedFindings: readonly string[];
+}
+
+export function evaluateDoctorExpectation(
+  expected: DoctorE2eExpectation | undefined,
+  report: DoctorE2eReport | undefined,
+  deep: boolean,
+): DoctorE2eEvaluation {
+  const actualStatus = report?.summary?.status ?? 'unknown';
+  const checks = report?.tiers?.builtin?.checks ?? [];
+  const actualFindings = checks
+    .filter(check => check.status !== 'pass')
+    .map(check => `${check.id}:${check.status}`);
+  const unexpectedFindings = checks
+    .filter(check => check.status === 'fail' || check.status === 'warn')
+    .map(check => `${check.id}:${check.status}`)
+    .filter(finding => !(expected?.requiredFindings ?? []).includes(finding));
+  const requiredFindings = expected?.requiredFindings ?? [];
+  const missingFindings = requiredFindings.filter(finding => !actualFindings.includes(finding));
+
+  let expectation: DoctorE2eEvaluation['expectation'];
+  if (deep) {
+    expectation = 'advisory';
+  } else if (!expected) {
+    expectation = 'unconfigured';
+  } else if (actualStatus !== expected.expectedStatus) {
+    expectation = 'mismatch';
+  } else if (missingFindings.length > 0) {
+    expectation = 'partial';
+  } else {
+    expectation = 'match';
+  }
+
+  return {
+    expected: expected?.expectedStatus ?? '-',
+    actual: actualStatus,
+    expectation,
+    missingFindings,
+    unexpectedFindings,
+  };
+}

--- a/tests/doctor-e2e-summary.test.ts
+++ b/tests/doctor-e2e-summary.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateDoctorExpectation,
+  type DoctorE2eExpectation,
+} from '../src/doctor/e2e-summary.js';
+
+const EXPECTATION: DoctorE2eExpectation = {
+  expectedStatus: 'fail',
+  requiredFindings: ['project-exists:fail', 'local-settings:warn'],
+};
+
+describe('evaluateDoctorExpectation', () => {
+  it('matches when status and all minimum findings match', () => {
+    expect(evaluateDoctorExpectation(EXPECTATION, {
+      summary: { status: 'fail' },
+      tiers: {
+        builtin: {
+          checks: [
+            { id: 'project-exists', status: 'fail' },
+            { id: 'local-settings', status: 'warn' },
+          ],
+        },
+      },
+    }, false)).toEqual({
+      expected: 'fail',
+      actual: 'fail',
+      expectation: 'match',
+      missingFindings: [],
+      unexpectedFindings: [],
+    });
+  });
+
+  it('is partial when status matches but a minimum finding is missing', () => {
+    expect(evaluateDoctorExpectation(EXPECTATION, {
+      summary: { status: 'fail' },
+      tiers: {
+        builtin: {
+          checks: [{ id: 'project-exists', status: 'fail' }],
+        },
+      },
+    }, false)).toEqual({
+      expected: 'fail',
+      actual: 'fail',
+      expectation: 'partial',
+      missingFindings: ['local-settings:warn'],
+      unexpectedFindings: [],
+    });
+  });
+
+  it('is a mismatch when the actual status differs', () => {
+    expect(evaluateDoctorExpectation(EXPECTATION, {
+      summary: { status: 'pass' },
+      tiers: {
+        builtin: {
+          checks: [{ id: 'local-settings', status: 'warn' }],
+        },
+      },
+    }, false)).toEqual({
+      expected: 'fail',
+      actual: 'pass',
+      expectation: 'mismatch',
+      missingFindings: ['project-exists:fail'],
+      unexpectedFindings: [],
+    });
+  });
+
+  it('keeps deep results advisory while exposing deterministic differences', () => {
+    expect(evaluateDoctorExpectation(EXPECTATION, {
+      summary: { status: 'fail' },
+      tiers: {
+        builtin: {
+          checks: [
+            { id: 'project-exists', status: 'fail' },
+            { id: 'unexpected-check', status: 'warn' },
+          ],
+        },
+      },
+    }, true)).toEqual({
+      expected: 'fail',
+      actual: 'fail',
+      expectation: 'advisory',
+      missingFindings: ['local-settings:warn'],
+      unexpectedFindings: ['unexpected-check:warn'],
+    });
+  });
+
+  it('reports an unconfigured fixture separately from deep advisory results', () => {
+    expect(evaluateDoctorExpectation(undefined, {
+      summary: { status: 'pass' },
+      tiers: { builtin: { checks: [] } },
+    }, false).expectation).toBe('unconfigured');
+  });
+
+  it('can require a deterministic skipped finding', () => {
+    const expected: DoctorE2eExpectation = {
+      expectedStatus: 'pass',
+      requiredFindings: ['dotnet-version:skip'],
+    };
+
+    expect(evaluateDoctorExpectation(expected, {
+      summary: { status: 'pass' },
+      tiers: {
+        builtin: {
+          checks: [{ id: 'dotnet-version', status: 'skip' }],
+        },
+      },
+    }, false)).toEqual({
+      expected: 'pass',
+      actual: 'pass',
+      expectation: 'match',
+      missingFindings: [],
+      unexpectedFindings: [],
+    });
+  });
+});

--- a/tests/fixtures/doctor-bad-apps/README.md
+++ b/tests/fixtures/doctor-bad-apps/README.md
@@ -24,7 +24,9 @@ node bin/azure-functions-skills.js doctor `
 
 > **CI cost note:** Each Tier 2 fixture spawns an LLM agent for semantic analysis. Consider using `SKIP_DEEP_TESTS=1` for CI runs that should only validate Tier 1 checks.
 
-Use `expected-results.md` for expected findings. Tier 1 findings are strict; Tier 2 findings are advisory (LLM output is non-deterministic).
+Use `expected-results.md` for documented expectations and `expected-results.json`
+for machine-readable Tier 1 assertions. Tier 1 findings are strict; Tier 2
+findings are advisory (LLM output is non-deterministic).
 
 ## Fixture list
 
@@ -93,7 +95,7 @@ Use `expected-results.md` for expected findings. Tier 1 findings are strict; Tie
 | `node-supply-chain-unpinned-deps` | Node.js | `unpinned-prod-deps:warn`, `missing-lockfile:warn` | — |
 | `node-supply-chain-tracked-env` | Node.js | `tracked-secret-files:fail`, `missing-lockfile:warn` | SC-109 hardcoded secrets in source |
 | `node-supply-chain-dropper-pattern` | Node.js | `missing-lockfile:warn` | SC-101+102+103+104+108 (durabletask Node.js port) |
-| `node-supply-chain-credential-collector` | Node.js | `missing-lockfile:warn` | SC-105 credential harvest, SC-106 .bashrc persistence |
+| `node-supply-chain-credential-collector` | Node.js | `function-bindings:warn`, `missing-lockfile:warn` | SC-105 credential harvest, SC-106 .bashrc persistence |
 | `python-supply-chain-c2-import` | Python | — | SC-101+102+103+104+108 (durabletask Python port) |
 
 ## Check ID reference

--- a/tests/fixtures/doctor-bad-apps/expected-results.json
+++ b/tests/fixtures/doctor-bad-apps/expected-results.json
@@ -1,0 +1,202 @@
+{
+  "01-missing-host-json": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["project-exists:fail"]
+  },
+  "02-host-json-missing-version": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["runtime-version:fail", "extension-bundle:warn", "local-settings:warn"]
+  },
+  "03-extension-bundle-missing-version": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["extension-bundle:fail"]
+  },
+  "04-extension-bundle-outdated": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["extension-bundle:fail"]
+  },
+  "05-unsupported-node-version": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["node-version:fail"]
+  },
+  "06-missing-worker-runtime": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["local-settings:warn"]
+  },
+  "07-non-http-missing-storage": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["connection-strings:fail"]
+  },
+  "08-deprecated-settings": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["deprecated-settings:warn"]
+  },
+  "09-unknown-trigger-type": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["function-bindings:warn"]
+  },
+  "10-entrypoint-tsconfig-errors": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["entry-point:fail", "typescript-build:fail"]
+  },
+  "csharp-clean": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "csharp-deep-blocking-async": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "csharp-deep-inprocess-antipatterns": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "go-clean": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "go-deep-toolchain-and-runtime": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["go-version:fail", "go-version:warn", "local-settings:warn"]
+  },
+  "java-clean": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "java-deep-client-reuse": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["extension-bundle:warn"]
+  },
+  "node-clean": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "node-deep-anonymous-admin": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "node-deep-client-reuse": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["extension-bundle:fail"]
+  },
+  "node-deep-durable-nondeterministic": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "node-deep-eventhub-no-idempotency": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "node-deep-output-binding-errors": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "node-deep-secrets-obfuscated": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "node-deep-servicebus-autocomplete": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["function-bindings:warn"]
+  },
+  "node-supply-chain-credential-collector": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["function-bindings:warn"]
+  },
+  "node-supply-chain-dropper-pattern": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "node-supply-chain-postinstall": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["lifecycle-scripts:fail"]
+  },
+  "node-supply-chain-tracked-env": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["tracked-secret-files:fail"]
+  },
+  "node-supply-chain-unpinned-deps": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["unpinned-prod-deps:warn", "missing-lockfile:warn"]
+  },
+  "powershell-clean": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "powershell-deep-install-module": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "powershell-deep-managed-deps": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["deprecated-settings:warn"]
+  },
+  "python-clean": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "python-deep-blocking-sync": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["local-settings:warn"]
+  },
+  "python-deep-secrets-sql-injection": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "python-deep-v1-incomplete-deps": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["deprecated-settings:warn"]
+  },
+  "python-deep-v2-async-antipatterns": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "python-blueprint-unregistered": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["python-blueprint-registration:warn"]
+  },
+  "python-deploy-artifacts": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["python-deploy-artifacts:warn"]
+  },
+  "python-durable-defaults": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["python-durable-configuration:warn"]
+  },
+  "python-missing-application-insights": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["application-insights:warn"]
+  },
+  "python-missing-azure-functions": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["python-azure-functions:fail"]
+  },
+  "python-missing-dependency-manifest": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["python-dependency-manifest:fail"]
+  },
+  "python-mixed-model": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["python-programming-model:warn"]
+  },
+  "python-native-dependencies": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["python-native-dependencies:warn"]
+  },
+  "python-outdated-azure-functions": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["python-azure-functions:fail"]
+  },
+  "python-supply-chain-c2-import": {
+    "expectedStatus": "pass",
+    "requiredFindings": []
+  },
+  "python-v2-missing-storage": {
+    "expectedStatus": "fail",
+    "requiredFindings": ["connection-strings:fail"]
+  },
+  "python-worker-dependency": {
+    "expectedStatus": "pass",
+    "requiredFindings": ["python-worker-dependency:warn"]
+  }
+}

--- a/tests/fixtures/doctor-bad-apps/expected-results.md
+++ b/tests/fixtures/doctor-bad-apps/expected-results.md
@@ -2,6 +2,10 @@
 
 Run with `AZURE_FUNCTIONS_DOCTOR_STACKS_OFFLINE=1` to keep version checks deterministic.
 
+`expected-results.json` is the machine-readable source used by `run-all.ps1` for
+Tier 1 status and minimum-finding comparisons. Keep its deterministic entries in
+sync with the tables below.
+
 ## Tier 1 (deterministic) — strict assertions
 
 These findings are produced by built-in checks (`--no-deep`) and can be validated automatically.
@@ -65,7 +69,7 @@ These fixtures also have deterministic issues detectable by `--no-deep`:
 | `python-deep-v1-incomplete-deps` | `deprecated-settings:warn` (AzureWebJobsDashboard) |
 | `python-deep-v2-async-antipatterns` | None expected |
 | `python-deep-secrets-sql-injection` | None expected |
-| `csharp-deep-blocking-async` | `dotnet-version:skip` (stacks API needed for .NET version validation; net6.0 EOL detected only with live stacks) |
+| `csharp-deep-blocking-async` | None expected offline (net6.0 EOL is detected only with live stacks) |
 | `csharp-deep-inprocess-antipatterns` | None expected (extension bundle check skips for .NET projects) |
 | `java-deep-client-reuse` | `extension-bundle:warn` (missing extension bundle) |
 | `powershell-deep-install-module` | None expected |
@@ -209,7 +213,10 @@ Tier 2 advisory:
 - 🚫 SC-104: hardcoded raw IP host in URL (`192.0.2.42`)
 - 🚫 SC-108: anti-analysis gates (Linux only, CPU > 2, skip Russian LANG)
 
-**`node-supply-chain-credential-collector`** — Tier 2 only:
+**`node-supply-chain-credential-collector`** — Tier 1:
+- `function-bindings:warn` (the fixture exports helper functions without a recognized Azure Functions trigger)
+
+Tier 2:
 - 🚫 SC-105: systematic credential harvesting from cloud / SSH / git / npm / docker / shell-history paths plus regex over env vars matching `TOKEN|SECRET|KEY|PASSWORD`
 - 🚫 SC-106: persistence installation via append to `~/.bashrc`
 - ⚠️ SC-103: silent empty catch around filesystem reads and persistence write


### PR DESCRIPTION
## Summary

- add machine-readable Tier 1 expectations for all doctor E2E fixtures
- show expected status, actual status, verdict, missing findings, and unexpected findings in `run-all.ps1`
- keep deep/LLM results advisory and distinguish missing expectation configuration

## Validation

- `npm test -- --maxWorkers=1` (271 tests)
- `npm run lint`
- `npm run typecheck`
- all 50 Tier 1 fixture expectations return `match`

Closes #223