### PR TITLE
fix: improve doctor deep validation accuracy

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-doctor/references/ci-usage.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-doctor/references/ci-usage.md
@@ -11,7 +11,7 @@ The recommended CI mode is built-in checks plus deep analysis.
     node-version: '22'
 - run: az version
 # Install/authenticate the selected agent CLI before this step.
-- run: npx @azure/functions-skills doctor --deep --accept-deep-risk --agent github-copilot --format json --output doctor-report.json --severity high
+- run: npx @azure/functions-skills doctor --deep --accept-deep-risk --agent github-copilot --model gpt-5.6-sol --format json --output doctor-report.json --severity high
 - uses: actions/upload-artifact@v4
   if: always()
   with:
@@ -36,12 +36,16 @@ The recommended CI mode is built-in checks plus deep analysis.
 |------|--------------|
 | Node.js | Running `@azure/functions-skills` |
 | Azure CLI | Runtime metadata via ARM functionAppStacks |
-| `copilot`, `claude`, or `codex` CLI | `--deep --agent <name>` |
+| `copilot`, `claude`, or `codex` CLI | `--deep --agent <name> [--model <model-id>]` |
 | Azure login / federated credentials | Azure resource tier checks |
 
 `az functionapp list-runtimes` / ARM stack metadata does not normally require reading subscription resources, but Azure CLI must be installed. Azure resource checks require login.
 
 For deterministic offline tests or intentionally network-free runs, set `AZURE_FUNCTIONS_DOCTOR_STACKS_OFFLINE=1` to skip live stack metadata resolution and use cache/fallback data.
+
+Pass an explicit `--model` for reproducible deep comparisons. The requested
+model is recorded in `tiers.ai.requestedModel`; `tiers.ai.effectiveModel` is
+recorded only when the selected launcher exposes the effective model.
 
 ## Exit codes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ See [docs/bad-app-fixtures.md](docs/bad-app-fixtures.md) for the manual E2E work
 ```powershell
 .\scripts\doctor-e2e-setup.ps1 -Target Q:\temp\doctor-deep-test -DeepOnly
 cd Q:\temp\doctor-deep-test
-.\run-all.ps1 -Deep -Agent github-copilot
+.\run-all.ps1 -Deep -Agent github-copilot -Model gpt-5.6-sol
 ```
 
 This validates that doctor catches the expected findings on every fixture.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Catch configuration mistakes, deprecated settings, **and semantic code issues** 
 npx @azure/functions-skills doctor --dir . \
   --deep --accept-deep-risk \
   --agent github-copilot \
+  --model gpt-5.6-sol \
   --format html --output doctor-report.html
 ```
 
@@ -199,6 +200,7 @@ jobs:
           npx @azure/functions-skills doctor \
             --deep --accept-deep-risk \
             --agent github-copilot \
+            --model gpt-5.6-sol \
             --format markdown --output doctor.md \
             --severity high
       - name: Publish summary

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -233,16 +233,23 @@ async function runDoctorCommand() {
   const output = getFlag('--output') || join(dir, '.azure-functions-doctor', 'doctor-report.json');
   const checksFlag = getFlag('--checks');
   const format = getFlag('--format') || 'text';
+  const model = getFlag('--model');
   try {
     if (!DOCTOR_FORMATS.includes(format)) {
       throw new Error(`Unsupported report format: ${format}. Available: ${DOCTOR_FORMATS.join(', ')}`);
+    }
+    if (args.includes('--model') && (!model || model.startsWith('-'))) {
+      throw new Error('--model requires a model ID, for example --model gpt-5.6-sol.');
+    }
+    if (model && (!args.includes('--deep') || args.includes('--no-deep'))) {
+      throw new Error('--model requires --deep because deterministic checks do not launch an AI agent.');
     }
     const { report, exitCode } = await runDoctor({
       dir,
       deep: args.includes('--deep') && !args.includes('--no-deep'),
       acceptDeepRisk: args.includes('--accept-deep-risk'),
       agent: getFlag('--agent'),
-      model: getFlag('--model') || 'auto',
+      model: model || 'auto',
       timeout: Number.parseInt(getFlag('--timeout') || '300', 10),
       format,
       output,

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -33,6 +33,7 @@ Options:
   --deep                    Run AI-assisted analysis
   --accept-deep-risk        Acknowledge elevated agent permissions
   --agent <name>            github-copilot, claude-code, or codex
+  --model <model-id>        Agent model (default: auto)
   --timeout <seconds>       AI analysis timeout (default: 300)
 `;
 
@@ -241,6 +242,7 @@ async function runDoctorCommand() {
       deep: args.includes('--deep') && !args.includes('--no-deep'),
       acceptDeepRisk: args.includes('--accept-deep-risk'),
       agent: getFlag('--agent'),
+      model: getFlag('--model') || 'auto',
       timeout: Number.parseInt(getFlag('--timeout') || '300', 10),
       format,
       output,

--- a/docs/bad-app-fixtures.md
+++ b/docs/bad-app-fixtures.md
@@ -31,7 +31,7 @@ cd <repo-root>
 Options:
 - `-Target <path>` — destination (default: `$env:TEMP\doctor-e2e-<timestamp>`)
 - `-Filter <glob>` — pattern, e.g. `"python-*"` or `"node-deep-*"`
-- `-DeepOnly` — copy only `*-deep-*` fixtures (skips numbered and clean fixtures)
+- `-DeepOnly` — copy all fixtures with Tier 2 expectations, including supply-chain fixtures
 
 The target must not already contain a selected fixture. Use a new target or run
 `doctor-e2e-cleanup.ps1` first; setup refuses to merge or nest fixture copies.
@@ -46,7 +46,7 @@ cd Q:\temp\doctor-deep-test
 # Tier 1 only — fast, no LLM cost
 .\run-all.ps1
 
-# Tier 2 — invokes the agent for each fixture (~60–120s each, 16 fixtures ≈ 25 min total)
+# Tier 2 — invokes the agent for each fixture (~60–120s each, 22 fixtures ≈ 35–45 min total)
 .\run-all.ps1 -Deep -Agent github-copilot -Model gpt-5.6-sol
 ```
 

--- a/docs/bad-app-fixtures.md
+++ b/docs/bad-app-fixtures.md
@@ -33,6 +33,9 @@ Options:
 - `-Filter <glob>` — pattern, e.g. `"python-*"` or `"node-deep-*"`
 - `-DeepOnly` — copy only `*-deep-*` fixtures (skips numbered and clean fixtures)
 
+The target must not already contain a selected fixture. Use a new target or run
+`doctor-e2e-cleanup.ps1` first; setup refuses to merge or nest fixture copies.
+
 The script also writes a `run-all.ps1` helper inside the target directory.
 
 ### 2. Run doctor against every fixture
@@ -44,7 +47,7 @@ cd Q:\temp\doctor-deep-test
 .\run-all.ps1
 
 # Tier 2 — invokes the agent for each fixture (~60–120s each, 16 fixtures ≈ 25 min total)
-.\run-all.ps1 -Deep -Agent github-copilot
+.\run-all.ps1 -Deep -Agent github-copilot -Model gpt-5.6-sol
 ```
 
 Each fixture's report is saved to `<fixture>/doctor-result.json`. A summary table is printed at the end:
@@ -73,8 +76,11 @@ Writes `ai-validation-report.html` to the fixtures directory with:
 - Overall recall metric (% of expected findings matched)
 - Per-fixture: matched / missed / extra findings
 - Drill-down: AI title, severity badge, file:line, full message
+- Match evidence, including required signals and findings covering multiple expectations
+- Requested/effective model provenance and invalid workspace results
 
-Typical recall on 16 fixtures with GitHub Copilot CLI: **~95%**.
+Deep recall is advisory and model-dependent. Always pass `-Model` when comparing
+runs, and do not compare reports marked invalid.
 
 > The deterministic Node.js script above is the only supported way to generate the validation report. A previous "ask a coding agent to write the report" option was withdrawn: pointing a general-purpose agent at adversarial fixture content is itself a prompt-injection surface.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -38,10 +38,13 @@ The result contains `agents`, `filesWritten`, `plannedFiles`, `dryRun`, and npm 
 
 ```bash
 npx @azure/functions-skills doctor --dir ./my-app
-npx @azure/functions-skills doctor --dir ./my-app --deep --accept-deep-risk --agent github-copilot
+npx @azure/functions-skills doctor --dir ./my-app --deep --accept-deep-risk --agent github-copilot --model gpt-5.6-sol
 ```
 
-`doctor` writes to `.azure-functions-doctor/doctor-report.json` by default. Deep analysis installs workspace-local skill assets only when the selected agent cannot already see `azure-functions-doctor`.
+`doctor` writes to `.azure-functions-doctor/doctor-report.json` by default. Deep
+analysis installs workspace-local skill assets only when the selected agent
+cannot already see `azure-functions-doctor`. Use `--model <model-id>` for
+reproducible deep runs; omitted models are recorded as `auto`.
 
 ## Templates
 

--- a/docs/doctor-guide.md
+++ b/docs/doctor-guide.md
@@ -52,6 +52,10 @@ npx @azure/functions-skills doctor --dir . \
 
 ⚠️ `--deep` runs the agent with elevated permissions on workspace files. Use only on trusted workspaces. The `--accept-deep-risk` flag is required to acknowledge this — running with `--deep` alone refuses to start the agent. Pass `--model` when comparing runs; the requested model is persisted in `tiers.ai`.
 
+The agent must write the requested findings file even when no issues are found
+(`[]`). If it exits without producing that file, doctor reports an AI execution
+error instead of reusing findings from an earlier run.
+
 ## Output formats
 
 | Format | Best for | Notes |

--- a/docs/doctor-guide.md
+++ b/docs/doctor-guide.md
@@ -46,10 +46,11 @@ Returns exit code `1` if any finding is at or above the `--severity` threshold (
 npx @azure/functions-skills doctor --dir . \
   --deep --accept-deep-risk \
   --agent github-copilot \
+  --model gpt-5.6-sol \
   --format html --output doctor-deep.html
 ```
 
-⚠️ `--deep` runs the agent with elevated permissions on workspace files. Use only on trusted workspaces. The `--accept-deep-risk` flag is required to acknowledge this — running with `--deep` alone refuses to start the agent.
+⚠️ `--deep` runs the agent with elevated permissions on workspace files. Use only on trusted workspaces. The `--accept-deep-risk` flag is required to acknowledge this — running with `--deep` alone refuses to start the agent. Pass `--model` when comparing runs; the requested model is persisted in `tiers.ai`.
 
 ## Output formats
 
@@ -190,7 +191,7 @@ A library of intentionally broken Azure Functions projects exercises the full do
 # Windows
 .\scripts\doctor-e2e-setup.ps1 -Target Q:\temp\doctor-deep-test -DeepOnly
 cd Q:\temp\doctor-deep-test
-.\run-all.ps1 -Deep -Agent github-copilot
+.\run-all.ps1 -Deep -Agent github-copilot -Model gpt-5.6-sol
 ```
 
 ## Troubleshooting

--- a/scripts/doctor-e2e-setup.ps1
+++ b/scripts/doctor-e2e-setup.ps1
@@ -96,6 +96,9 @@ Write-Host ""
 # Copy each fixture
 foreach ($fixture in $fixtures) {
     $dest = Join-Path $Target $fixture.Name
+    if (Test-Path $dest) {
+        throw "Fixture destination already exists: $dest. Use a new target or run doctor-e2e-cleanup.ps1 first."
+    }
     Copy-Item -Path $fixture.FullName -Destination $dest -Recurse -Force
     Write-Host "  [+] $($fixture.Name)" -ForegroundColor Green
 }
@@ -116,6 +119,7 @@ $runAllContent = @'
 param(
     [switch]$Deep,
     [string]$Agent = 'github-copilot',
+    [string]$Model = 'auto',
     [string]$Format = 'json',
     [int]$Timeout = 300,
     [string]$Filter = '*'
@@ -142,6 +146,10 @@ foreach ($d in $dirs) {
         $doctorArgs += '--accept-deep-risk'
         $doctorArgs += '--agent'
         $doctorArgs += $Agent
+        if ($Model -ne 'auto') {
+            $doctorArgs += '--model'
+            $doctorArgs += $Model
+        }
         $doctorArgs += '--timeout'
         $doctorArgs += $Timeout
     }
@@ -201,10 +209,10 @@ Write-Host "  cd $Target"
 Write-Host "  .\run-all.ps1"
 Write-Host ""
 Write-Host "  # Tier 2 (deep) — run all:"
-Write-Host "  .\run-all.ps1 -Deep -Agent github-copilot"
+Write-Host "  .\run-all.ps1 -Deep -Agent github-copilot -Model gpt-5.6-sol"
 Write-Host ""
 Write-Host "  # Single fixture:"
-Write-Host "  node $cliPath doctor --dir $Target\<fixture> --deep --agent github-copilot --format json"
+Write-Host "  node $cliPath doctor --dir $Target\<fixture> --deep --accept-deep-risk --agent github-copilot --model gpt-5.6-sol --format json"
 Write-Host ""
 Write-Host "Cleanup:"
 Write-Host "  .\scripts\doctor-e2e-cleanup.ps1 -Target $Target"

--- a/scripts/doctor-e2e-setup.ps1
+++ b/scripts/doctor-e2e-setup.ps1
@@ -15,7 +15,7 @@
   Examples: "node-deep-*", "python-*", "*-clean"
 
 .PARAMETER DeepOnly
-  When set, copies only the "*-deep-*" fixtures (skips numbered and clean).
+  When set, copies fixtures with Tier 2 expectations (skips deterministic-only and clean fixtures).
 
 .EXAMPLE
   # Copy all fixtures to temp
@@ -45,6 +45,7 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $fixturesDir = Join-Path $repoRoot 'tests\fixtures\doctor-bad-apps'
 $cliPath = Join-Path $repoRoot 'bin\azure-functions-skills.js'
+$validationReportPath = Join-Path $repoRoot 'scripts\doctor-validation-report.mjs'
 
 if (-not (Test-Path $cliPath)) {
     Write-Error "CLI not found: $cliPath"
@@ -71,7 +72,13 @@ $fixtures = @(Get-ChildItem -Path $fixturesDir -Directory |
     Sort-Object Name)
 
 if ($DeepOnly) {
-    $fixtures = $fixtures | Where-Object { $_.Name -match '-deep-' }
+    $catalogJson = (& node $validationReportPath --list-expectations | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to load deep fixture expectations from $validationReportPath"
+    }
+    $catalog = $catalogJson | ConvertFrom-Json
+    $deepFixtureNames = @($catalog.PSObject.Properties.Name)
+    $fixtures = $fixtures | Where-Object { $_.Name -in $deepFixtureNames }
 }
 
 if ($fixtures.Count -eq 0) {

--- a/scripts/doctor-validation-report.mjs
+++ b/scripts/doctor-validation-report.mjs
@@ -41,7 +41,8 @@ function parseArgs(argv) {
 
 const args = parseArgs(process.argv.slice(2));
 if (args.help) {
-  console.log(`Usage: node doctor-validation-report.mjs [--fixtures-dir <path>] [--output <path>]`);
+  console.log(`Usage: node doctor-validation-report.mjs [--fixtures-dir <path>] [--output <path>]
+       node doctor-validation-report.mjs --list-expectations`);
   process.exit(0);
 }
 const fixturesDir = resolve(args.fixturesDir || process.cwd());
@@ -58,9 +59,9 @@ const EXPECTED = {
     { id: 'CQ-001/JS-006', desc: 'CosmosClient created inside handler (should be module-level)',
       keywords: [['cosmosclient', 'cosmos client', 'cosmos db client'], ['per invocation', 'inside handler', 'module-level', 'reuse', 'each invocation', 'every request', 'singleton']] },
     { id: 'CQ-004', desc: 'Fire-and-forget promise — items.create not awaited',
-      keywords: [['await', 'fire-and-forget', 'fire and forget', 'unawaited', 'not awaited', 'floating promise']] },
+      keywords: [['fire-and-forget', 'fire and forget', 'unawaited', 'not awaited', 'floating promise']] },
     { id: 'CQ-007', desc: 'No try/catch around external fetch()',
-      keywords: [['try', 'catch', 'error handling', 'exception']] },
+      keywords: [['try', 'catch', 'error handling', 'exception'], ['fetch', 'shipping api', 'network', 'external call']] },
   ],
   'node-deep-anonymous-admin': [
     { id: 'SC-002', desc: 'Anonymous auth on admin/destructive endpoint',
@@ -68,7 +69,7 @@ const EXPECTED = {
     { id: 'SC-009', desc: 'SQL injection via unvalidated userId',
       keywords: [['sql injection', 'sql', 'injection', 'parameteriz', 'sanitiz', 'unvalidat']] },
     { id: 'CQ-003', desc: 'CPU-intensive computeHash blocking',
-      keywords: [['cpu', 'blocking', 'expensive', 'sync', 'computehash', 'iteration', 'hash', 'tight loop']] },
+      keywords: [['computehash', 'iteration', 'hash', 'tight loop'], ['cpu', 'blocking', 'expensive', 'synchronous']] },
   ],
   'node-deep-secrets-obfuscated': [
     { id: 'SC-001', desc: 'Storage account key split across variables',
@@ -80,17 +81,17 @@ const EXPECTED = {
     { id: 'Durable', desc: 'Date.now() in orchestrator',
       keywords: [['date.now', 'date now', 'currentutcdatetime', 'current utc']] },
     { id: 'Durable', desc: 'Math.random() in orchestrator',
-      keywords: [['math.random', 'random', 'non-deterministic', 'nondeterministic', 'deterministic']] },
+      keywords: [['math.random', 'random value', 'random number'], ['orchestrator', 'durable', 'non-deterministic', 'nondeterministic']] },
     { id: 'Durable', desc: 'fetch() in orchestrator',
-      keywords: [['fetch', 'http', 'callhttp', 'activity']] },
+      keywords: [['fetch', 'callhttp'], ['orchestrator', 'durable', 'activity']] },
     { id: 'Durable', desc: 'setTimeout in orchestrator',
-      keywords: [['settimeout', 'createtimer', 'timer']] },
+      keywords: [['settimeout', 'createtimer'], ['orchestrator', 'durable', 'timer']] },
   ],
   'node-deep-eventhub-no-idempotency': [
     { id: 'CQ-005/EH-005', desc: 'Payment without idempotency key',
       keywords: [['idempot'], ['payment', 'charge', 'replay', 'duplicate']] },
     { id: 'EH-004', desc: 'Throwing blocks checkpoint',
-      keywords: [['throw', 'exception', 'checkpoint', 'batch', 'block']] },
+      keywords: [['throw', 'exception', 'failure'], ['checkpoint', 'event batch', 'entire batch']] },
     { id: 'CQ-005', desc: 'Irreversible side effect (email) before state tracking',
       keywords: [['email', 'side effect', 'irreversible', 'before', 'order', 'tracking']] },
   ],
@@ -204,9 +205,9 @@ const EXPECTED = {
     { id: 'GO-004', desc: 'FUNCTIONS_WORKER_RUNTIME must be native',
       keywords: [['functions_worker_runtime', 'worker runtime'], ['native', 'must use native', 'set to go']] },
     { id: 'GO-002', desc: 'Worker module pinned to pseudo-version',
-      keywords: [['pseudo-version', 'pseudo version', 'untagged'], ['worker', 'module', 'release', 'version']] },
+      keywords: [['pseudo-version', 'pseudo version', 'untagged'], ['worker module', 'worker sdk', 'published release']] },
     { id: 'SC-002', desc: 'Anonymous HTTP trigger',
-      keywords: [['anonymous', 'withauth'], ['http', 'trigger', 'public', 'auth']] },
+      keywords: [['anonymous', 'withauth'], ['http', 'trigger', 'public', 'endpoint']] },
   ],
   'node-supply-chain-postinstall': [
     { id: 'SC-101', desc: 'Module-load side effect (detached spawn at require)',
@@ -224,7 +225,7 @@ const EXPECTED = {
     { id: 'SC-102', desc: 'Fetch then execute downloaded file',
       keywords: [['fetch', 'download', 'https.get', 'urlretrieve', 'retrieve'], ['execute', 'spawn', 'subprocess', 'run']] },
     { id: 'SC-103', desc: 'Empty catch suppresses errors',
-      keywords: [['empty catch', 'silent', 'swallow'], ['error', 'exception', 'suppress', 'catch']] },
+      keywords: [['empty catch', 'silent', 'swallow'], ['error', 'exception', 'suppress']] },
     { id: 'SC-104', desc: 'Raw IP host (C2 indicator)',
       keywords: [['raw ip', 'ip address', '192.0.2', '192.', 'numeric host'], ['c2', 'command and control', 'host', 'url']] },
     { id: 'SC-108', desc: 'Anti-analysis gates (Linux only, CPU >2, skip Russian)',
@@ -294,10 +295,18 @@ function matchExpectation(expectation, check) {
   const matchedGroups = [];
   for (const group of expectation.keywords) {
     const signal = group
-      .filter(keyword => haystack.includes(keyword.toLowerCase()))
+      .filter(keyword => signalMatches(haystack, keyword))
       .sort((left, right) => right.length - left.length)[0];
     if (!signal) return null;
     matchedGroups.push(signal);
+  }
+
+  function signalMatches(haystack, keyword) {
+    const signal = keyword.toLowerCase();
+    if (!/^[a-z0-9_]+$/.test(signal)) return haystack.includes(signal);
+    const escaped = signal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const suffix = signal.length >= 3 ? '\\w*' : '\\b';
+    return new RegExp(`\\b${escaped}${suffix}`).test(haystack);
   }
   return {
     check,
@@ -322,27 +331,17 @@ function validateFixture(fixtureDir, name, report) {
   if (report && report.tiers?.ai?.ran !== true) {
     errors.push('deep analysis did not run (tiers.ai.ran is not true)');
   }
+  if (report?.tiers?.ai?.error) {
+    errors.push(`AI tier error: ${report.tiers.ai.error}`);
+  }
   const cachePath = join(fixtureDir, '.azure-functions-doctor', 'doctor-ai-findings.json');
   if (report && existsSync(cachePath)) {
     try {
       const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
       if (!Array.isArray(cached)) {
         errors.push('cached AI findings are not a JSON array');
-      } else {
-        const validCached = cached.filter(finding =>
-          finding && typeof finding === 'object'
-          && typeof finding.id === 'string'
-          && typeof finding.category === 'string'
-          && typeof finding.severity === 'string'
-          && typeof finding.status === 'string'
-          && typeof finding.title === 'string'
-          && typeof finding.message === 'string'
-        );
-        if (validCached.length !== cached.length) {
-          errors.push('cached AI findings contain invalid entries');
-        } else if (stableJson(validCached) !== stableJson(report.tiers?.ai?.checks || [])) {
-          errors.push('cached AI findings conflict with doctor-result.json');
-        }
+      } else if (stableJson(cached) !== stableJson(report.tiers?.ai?.checks || [])) {
+        errors.push('cached AI findings conflict with doctor-result.json');
       }
     } catch (error) {
       errors.push(`cached AI findings are invalid: ${error.message}`);
@@ -370,8 +369,9 @@ function statusBadge(matched, total) {
 }
 
 function severityBadge(sev) {
-  const cls = `sev-${sev}`;
-  return `<span class="sev ${cls}">${escapeHtml(sev)}</span>`;
+  const allowed = new Set(['critical', 'high', 'medium', 'low', 'info']);
+  const safeSeverity = allowed.has(sev) ? sev : 'info';
+  return `<span class="sev sev-${safeSeverity}">${escapeHtml(sev)}</span>`;
 }
 
 function statusGlyph(matched) {
@@ -393,7 +393,6 @@ let totalExpected = 0;
 let totalMatched = 0;
 let totalExtra = 0;
 let invalidFixtures = 0;
-const findingEdges = new Map();
 const selectedFindingCoverage = new Map();
 
 for (const name of fixtures) {
@@ -415,10 +414,11 @@ for (const name of fixtures) {
     const candidates = aiChecks
       .map(check => matchExpectation(exp, check))
       .filter(Boolean)
-      .sort((left, right) => right.score - left.score);
-    for (const candidate of candidates) {
-      findingEdges.set(candidate.check, (findingEdges.get(candidate.check) || 0) + 1);
-    }
+      .sort((left, right) =>
+        right.score - left.score
+        || compareText(left.check.id, right.check.id)
+        || compareText(left.check.title, right.check.title)
+      );
     return { ...exp, matched: candidates[0] || null, candidates };
   });
   for (const expectation of expectations) {
@@ -435,9 +435,11 @@ for (const name of fixtures) {
   );
   const matchedCount = expectations.filter(e => e.matched).length;
 
-  totalExpected += expectations.length;
-  totalMatched += matchedCount;
-  totalExtra += extras.length;
+  if (integrityErrors.length === 0) {
+    totalExpected += expectations.length;
+    totalMatched += matchedCount;
+    totalExtra += extras.length;
+  }
 
   fixtureResults.push({
     name,
@@ -456,7 +458,24 @@ for (const name of fixtures) {
 }
 
 const recall = totalExpected > 0 ? (totalMatched / totalExpected) * 100 : 0;
-const associatedFindings = findingEdges.size;
+const validFixtureResults = fixtureResults.filter(result =>
+  !result.error && result.integrityErrors.length === 0
+);
+const validFindingEdges = new Set(
+  validFixtureResults.flatMap(result =>
+    result.expectations.flatMap(expectation =>
+      expectation.candidates.map(candidate => candidate.check)
+    )
+  )
+);
+const associatedFindings = validFindingEdges.size;
+const validFixtureCount = validFixtureResults.length;
+
+function compareText(left, right) {
+  const a = String(left);
+  const b = String(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
 
 // ── Render HTML ──
 
@@ -530,7 +549,7 @@ const html = `<!DOCTYPE html>
 
   <h2>Overall Summary</h2>
   <div class="overall">
-    <div class="card"><div class="num">${fixtures.length}</div><div class="label">Fixtures</div></div>
+    <div class="card"><div class="num">${validFixtureCount}/${fixtures.length}</div><div class="label">Valid fixtures</div></div>
     <div class="card"><div class="num">${totalExpected}</div><div class="label">Expected findings</div></div>
     <div class="card"><div class="num">${totalMatched}</div><div class="label">Matched by AI</div></div>
     <div class="card"><div class="num">${recall.toFixed(0)}%</div><div class="label">Recall</div></div>
@@ -603,7 +622,7 @@ const html = `<!DOCTYPE html>
         <div class="finding-msg">
           → matched: <strong>${escapeHtml(exp.matched.check.title)}</strong> ${severityBadge(exp.matched.check.severity)}
           · required groups: ${exp.matched.matchedGroups.map(escapeHtml).join(', ')}
-          ${exp.matched.check.file ? `<br><span class="finding-file">${escapeHtml(exp.matched.check.file)}${exp.matched.check.line ? ':' + exp.matched.check.line : ''}</span>` : ''}
+          ${exp.matched.check.file ? `<br><span class="finding-file">${escapeHtml(exp.matched.check.file)}${exp.matched.check.line ? ':' + escapeHtml(exp.matched.check.line) : ''}</span>` : ''}
           ${selectedFindingCoverage.get(exp.matched.check) > 1 ? `<br><strong>matched ${selectedFindingCoverage.get(exp.matched.check)} expectations</strong>` : ''}
           <details><summary>Show AI message</summary><div>${escapeHtml(exp.matched.check.message)}</div></details>
           ${exp.candidates.length > 1 ? `<details><summary>Show ${exp.candidates.length - 1} alternative candidate(s)</summary><div>${exp.candidates.slice(1).map(candidate => `${escapeHtml(candidate.check.id)}: ${escapeHtml(candidate.check.title)} (signals: ${candidate.matchedGroups.map(escapeHtml).join(', ')})`).join('<br>')}</div></details>` : ''}
@@ -619,7 +638,7 @@ const html = `<!DOCTYPE html>
         <span class="finding-id">[${escapeHtml(extra.id)}]</span> ${escapeHtml(extra.title)} ${severityBadge(extra.severity)}
       </div>
       <div class="finding-msg">${escapeHtml(extra.message)}</div>
-      ${extra.file ? `<div class="finding-file">${escapeHtml(extra.file)}${extra.line ? ':' + extra.line : ''}</div>` : ''}
+      ${extra.file ? `<div class="finding-file">${escapeHtml(extra.file)}${extra.line ? ':' + escapeHtml(extra.line) : ''}</div>` : ''}
     </div>`).join('')}
     ` : ''}
   </div>`).join('')}
@@ -627,7 +646,7 @@ const html = `<!DOCTYPE html>
   <h2>Notes</h2>
   <ul>
     <li><strong>Matching strategy:</strong> Every expected finding is evaluated against every AI finding. A match requires every required keyword group, and a single AI finding may cover multiple expectations.</li>
-    <li><strong>Recall</strong> = matched expected findings ÷ total expected findings.</li>
+    <li><strong>Recall</strong> = matched expected findings ÷ total expected findings across valid fixtures only.</li>
     <li><strong>Extras</strong> are AI findings not matching any expected entry. These may be valid (LLM found additional issues) or hallucinations (false positives).</li>
     <li>This report is <strong>advisory</strong> — LLM output is non-deterministic; rerun to see variability.</li>
   </ul>
@@ -636,12 +655,15 @@ const html = `<!DOCTYPE html>
 
 writeFileSync(outputPath, html, 'utf-8');
 console.log(`Report written: ${outputPath}`);
-console.log(`Overall: ${totalMatched}/${totalExpected} expected findings matched (${recall.toFixed(1)}% recall)`);
+console.log(`Overall: ${totalMatched}/${totalExpected} expected findings matched (${recall.toFixed(1)}% recall) across ${validFixtureCount}/${fixtures.length} valid fixtures`);
 console.log(`Extras: ${totalExtra} AI findings not in expected list`);
 if (invalidFixtures > 0) {
   console.log(`INVALID: ${invalidFixtures} fixture workspace(s) failed integrity validation`);
   for (const fixture of fixtureResults.filter(result => result.integrityErrors?.length)) {
     console.log(`  ${fixture.name}: ${fixture.integrityErrors.join('; ')}`);
+  }
+  for (const fixture of fixtureResults.filter(result => result.error)) {
+    console.log(`  ${fixture.name}: ${fixture.error}`);
   }
   process.exitCode = 1;
 }

--- a/scripts/doctor-validation-report.mjs
+++ b/scripts/doctor-validation-report.mjs
@@ -8,6 +8,7 @@
  *
  * Usage:
  *   node scripts/doctor-validation-report.mjs [--fixtures-dir <path>] [--output <path>]
+ *   node scripts/doctor-validation-report.mjs --list-expectations
  *
  * Defaults:
  *   --fixtures-dir  current working directory
@@ -32,6 +33,7 @@ function parseArgs(argv) {
     if (a === '--fixtures-dir' || a === '-d') out.fixturesDir = argv[++i];
     else if (a === '--output' || a === '-o') out.output = argv[++i];
     else if (a === '--help' || a === '-h') out.help = true;
+    else if (a === '--list-expectations') out.listExpectations = true;
     else if (!a.startsWith('-') && !out.fixturesDir) out.fixturesDir = a;
   }
   return out;
@@ -72,7 +74,7 @@ const EXPECTED = {
     { id: 'SC-001', desc: 'Storage account key split across variables',
       keywords: [['secret', 'key', 'credential', 'connection string', 'hardcod'], ['split', 'concatenat', 'obfuscat', 'accountkey', 'storage']] },
     { id: 'JS-005', desc: 'tsconfig CommonJS vs ESM mismatch',
-      keywords: [['tsconfig', 'module', 'commonjs', 'esm', 'esmodule', 'cjs']] },
+      keywords: [['commonjs', 'cjs'], ['esm', 'es module', 'import syntax', 'module mismatch']] },
   ],
   'node-deep-durable-nondeterministic': [
     { id: 'Durable', desc: 'Date.now() in orchestrator',
@@ -104,7 +106,7 @@ const EXPECTED = {
     { id: 'CQ-008', desc: 'Cosmos DB output binding without conflict handling',
       keywords: [['output binding', 'cosmos'], ['conflict', 'throttl', 'error', 'failure', 'no way to handle']] },
     { id: 'CQ-007', desc: 'Returns success without verifying output binding',
-      keywords: [['success', 'verif', 'confirm', 'binding succeed', 'before', 'return']] },
+      keywords: [['output binding', 'cosmos output', 'extraoutputs'], ['success', 'verif', 'confirm', 'binding succeed', 'write complete']] },
   ],
   'python-deep-blocking-sync': [
     { id: 'PY-002', desc: 'requests library — synchronous HTTP',
@@ -194,6 +196,18 @@ const EXPECTED = {
     { id: 'CQ-007', desc: 'No error handling around Invoke-RestMethod',
       keywords: [['invoke-restmethod', 'invoke restmethod'], ['try', 'catch', 'error', 'exception', 'handling']] },
   ],
+  'go-deep-toolchain-and-runtime': [
+    { id: 'GO-001', desc: 'Unrecovered panic in worker goroutine',
+      keywords: [['panic', 'mustprocess'], ['goroutine', 'worker process', 'recoverto', 'errgroup']] },
+    { id: 'GO-003', desc: 'http.Client constructed inside handler',
+      keywords: [['http.client', 'http client'], ['inside', 'handler', 'package scope', 'reuse', 'per invocation']] },
+    { id: 'GO-004', desc: 'FUNCTIONS_WORKER_RUNTIME must be native',
+      keywords: [['functions_worker_runtime', 'worker runtime'], ['native', 'must use native', 'set to go']] },
+    { id: 'GO-002', desc: 'Worker module pinned to pseudo-version',
+      keywords: [['pseudo-version', 'pseudo version', 'untagged'], ['worker', 'module', 'release', 'version']] },
+    { id: 'SC-002', desc: 'Anonymous HTTP trigger',
+      keywords: [['anonymous', 'withauth'], ['http', 'trigger', 'public', 'auth']] },
+  ],
   'node-supply-chain-postinstall': [
     { id: 'SC-101', desc: 'Module-load side effect (detached spawn at require)',
       keywords: [['spawn', 'detached', 'unref', 'module load', 'import time', 'at load'], ['side effect', 'module', 'load', 'import', 'startup']] },
@@ -209,6 +223,8 @@ const EXPECTED = {
       keywords: [['iife', 'self-executing', 'immediately', 'module load', 'import time'], ['side effect', 'load', 'startup']] },
     { id: 'SC-102', desc: 'Fetch then execute downloaded file',
       keywords: [['fetch', 'download', 'https.get', 'urlretrieve', 'retrieve'], ['execute', 'spawn', 'subprocess', 'run']] },
+    { id: 'SC-103', desc: 'Empty catch suppresses errors',
+      keywords: [['empty catch', 'silent', 'swallow'], ['error', 'exception', 'suppress', 'catch']] },
     { id: 'SC-104', desc: 'Raw IP host (C2 indicator)',
       keywords: [['raw ip', 'ip address', '192.0.2', '192.', 'numeric host'], ['c2', 'command and control', 'host', 'url']] },
     { id: 'SC-108', desc: 'Anti-analysis gates (Linux only, CPU >2, skip Russian)',
@@ -236,6 +252,18 @@ const EXPECTED = {
   ],
 };
 
+if (args.listExpectations) {
+  console.log(JSON.stringify(
+    Object.fromEntries(Object.entries(EXPECTED).map(([fixture, expectations]) => [
+      fixture,
+      expectations.map(expectation => expectation.id),
+    ])),
+    null,
+    2,
+  ));
+  process.exit(0);
+}
+
 function loadFixtureResult(fixtureDir) {
   const reportPath = join(fixtureDir, 'doctor-result.json');
   if (!existsSync(reportPath)) return null;
@@ -259,6 +287,68 @@ function findingHaystack(check) {
     check.file || '',
     check.recommendation || '',
   ].join(' ').toLowerCase();
+}
+
+function matchExpectation(expectation, check) {
+  const haystack = findingHaystack(check);
+  const matchedGroups = [];
+  for (const group of expectation.keywords) {
+    const signal = group
+      .filter(keyword => haystack.includes(keyword.toLowerCase()))
+      .sort((left, right) => right.length - left.length)[0];
+    if (!signal) return null;
+    matchedGroups.push(signal);
+  }
+  return {
+    check,
+    matchedGroups,
+    score: matchedGroups.reduce((total, signal) => total + signal.length, 0),
+  };
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function validateFixture(fixtureDir, name, report) {
+  const errors = [];
+  if (existsSync(join(fixtureDir, name))) {
+    errors.push(`nested fixture directory detected: ${name}/${name}`);
+  }
+  if (report && report.tiers?.ai?.ran !== true) {
+    errors.push('deep analysis did not run (tiers.ai.ran is not true)');
+  }
+  const cachePath = join(fixtureDir, '.azure-functions-doctor', 'doctor-ai-findings.json');
+  if (report && existsSync(cachePath)) {
+    try {
+      const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      if (!Array.isArray(cached)) {
+        errors.push('cached AI findings are not a JSON array');
+      } else {
+        const validCached = cached.filter(finding =>
+          finding && typeof finding === 'object'
+          && typeof finding.id === 'string'
+          && typeof finding.category === 'string'
+          && typeof finding.severity === 'string'
+          && typeof finding.status === 'string'
+          && typeof finding.title === 'string'
+          && typeof finding.message === 'string'
+        );
+        if (validCached.length !== cached.length) {
+          errors.push('cached AI findings contain invalid entries');
+        } else if (stableJson(validCached) !== stableJson(report.tiers?.ai?.checks || [])) {
+          errors.push('cached AI findings conflict with doctor-result.json');
+        }
+      }
+    } catch (error) {
+      errors.push(`cached AI findings are invalid: ${error.message}`);
+    }
+  }
+  return errors;
 }
 
 function escapeHtml(s) {
@@ -302,40 +392,47 @@ const fixtureResults = [];
 let totalExpected = 0;
 let totalMatched = 0;
 let totalExtra = 0;
+let invalidFixtures = 0;
+const findingEdges = new Map();
+const selectedFindingCoverage = new Map();
 
 for (const name of fixtures) {
   const fixtureDir = join(fixturesDir, name);
   const report = loadFixtureResult(fixtureDir);
   if (!report) {
     fixtureResults.push({ name, error: 'doctor-result.json not found or invalid' });
+    invalidFixtures++;
     continue;
   }
+  const integrityErrors = validateFixture(fixtureDir, name, report);
+  if (integrityErrors.length > 0) invalidFixtures++;
 
   const aiChecks = report.tiers?.ai?.checks || [];
   const aiError = report.tiers?.ai?.error;
   const aiDuration = report.tiers?.ai?.durationMs;
   const expected = EXPECTED[name] || [];
-  const usedAiChecks = new Set();
-
   const expectations = expected.map(exp => {
-    // Find a matching AI check that's not yet used
-    let matchedCheck = null;
-    for (const check of aiChecks) {
-      if (usedAiChecks.has(check)) continue;
-      const hay = findingHaystack(check);
-      const allGroupsHit = exp.keywords.every(group =>
-        group.some(kw => hay.includes(kw.toLowerCase()))
-      );
-      if (allGroupsHit) {
-        matchedCheck = check;
-        usedAiChecks.add(check);
-        break;
-      }
+    const candidates = aiChecks
+      .map(check => matchExpectation(exp, check))
+      .filter(Boolean)
+      .sort((left, right) => right.score - left.score);
+    for (const candidate of candidates) {
+      findingEdges.set(candidate.check, (findingEdges.get(candidate.check) || 0) + 1);
     }
-    return { ...exp, matched: matchedCheck };
+    return { ...exp, matched: candidates[0] || null, candidates };
   });
+  for (const expectation of expectations) {
+    if (expectation.matched) {
+      selectedFindingCoverage.set(
+        expectation.matched.check,
+        (selectedFindingCoverage.get(expectation.matched.check) || 0) + 1,
+      );
+    }
+  }
 
-  const extras = aiChecks.filter(c => !usedAiChecks.has(c));
+  const extras = aiChecks.filter(check =>
+    !expectations.some(expectation => expectation.candidates.some(candidate => candidate.check === check))
+  );
   const matchedCount = expectations.filter(e => e.matched).length;
 
   totalExpected += expectations.length;
@@ -348,14 +445,18 @@ for (const name of fixtures) {
     summary: report.summary,
     aiError,
     aiDuration,
+    requestedModel: report.tiers?.ai?.requestedModel || 'unknown',
+    effectiveModel: report.tiers?.ai?.effectiveModel,
     aiCount: aiChecks.length,
     expectations,
     extras,
     matchedCount,
+    integrityErrors,
   });
 }
 
 const recall = totalExpected > 0 ? (totalMatched / totalExpected) * 100 : 0;
+const associatedFindings = findingEdges.size;
 
 // ── Render HTML ──
 
@@ -434,6 +535,8 @@ const html = `<!DOCTYPE html>
     <div class="card"><div class="num">${totalMatched}</div><div class="label">Matched by AI</div></div>
     <div class="card"><div class="num">${recall.toFixed(0)}%</div><div class="label">Recall</div></div>
     <div class="card"><div class="num">${totalExtra}</div><div class="label">Extra findings</div></div>
+    <div class="card"><div class="num">${associatedFindings}</div><div class="label">Associated AI findings</div></div>
+    <div class="card"><div class="num">${invalidFixtures}</div><div class="label">Invalid fixtures</div></div>
   </div>
 
   <div class="legend">
@@ -485,8 +588,9 @@ const html = `<!DOCTYPE html>
     <div class="fixture-header">
       <div class="fixture-name">${escapeHtml(f.name)}</div>
       <div>${statusBadge(f.matchedCount, f.expectations.length)}</div>
-      <div class="fixture-meta">${escapeHtml(f.language)} · ${f.aiCount} AI checks · ${f.aiDuration ? (f.aiDuration / 1000).toFixed(1) + 's' : '—'}</div>
+      <div class="fixture-meta">${escapeHtml(f.language)} · ${f.aiCount} AI checks · ${f.aiDuration ? (f.aiDuration / 1000).toFixed(1) + 's' : '—'} · Requested model: ${escapeHtml(f.requestedModel)}${f.effectiveModel ? ` · Effective model: ${escapeHtml(f.effectiveModel)}` : ''}</div>
     </div>
+    ${f.integrityErrors.length > 0 ? `<div class="error-msg"><strong>INVALID:</strong> ${f.integrityErrors.map(escapeHtml).join('; ')}</div>` : ''}
     ${f.aiError ? `<div class="error-msg">AI tier error: ${escapeHtml(f.aiError)}</div>` : ''}
 
     <h3>Expected findings (${f.matchedCount}/${f.expectations.length} matched)</h3>
@@ -497,9 +601,12 @@ const html = `<!DOCTYPE html>
       </div>
       ${exp.matched ? `
         <div class="finding-msg">
-          → matched: <strong>${escapeHtml(exp.matched.title)}</strong> ${severityBadge(exp.matched.severity)}
-          ${exp.matched.file ? `<br><span class="finding-file">${escapeHtml(exp.matched.file)}${exp.matched.line ? ':' + exp.matched.line : ''}</span>` : ''}
-          <details><summary>Show AI message</summary><div>${escapeHtml(exp.matched.message)}</div></details>
+          → matched: <strong>${escapeHtml(exp.matched.check.title)}</strong> ${severityBadge(exp.matched.check.severity)}
+          · required groups: ${exp.matched.matchedGroups.map(escapeHtml).join(', ')}
+          ${exp.matched.check.file ? `<br><span class="finding-file">${escapeHtml(exp.matched.check.file)}${exp.matched.check.line ? ':' + exp.matched.check.line : ''}</span>` : ''}
+          ${selectedFindingCoverage.get(exp.matched.check) > 1 ? `<br><strong>matched ${selectedFindingCoverage.get(exp.matched.check)} expectations</strong>` : ''}
+          <details><summary>Show AI message</summary><div>${escapeHtml(exp.matched.check.message)}</div></details>
+          ${exp.candidates.length > 1 ? `<details><summary>Show ${exp.candidates.length - 1} alternative candidate(s)</summary><div>${exp.candidates.slice(1).map(candidate => `${escapeHtml(candidate.check.id)}: ${escapeHtml(candidate.check.title)} (signals: ${candidate.matchedGroups.map(escapeHtml).join(', ')})`).join('<br>')}</div></details>` : ''}
         </div>
       ` : `<div class="finding-msg" style="color:#a4262c">AI did not produce a matching finding.</div>`}
     </div>`).join('')}
@@ -519,7 +626,7 @@ const html = `<!DOCTYPE html>
 
   <h2>Notes</h2>
   <ul>
-    <li><strong>Matching strategy:</strong> Each expected finding has groups of keywords; a match requires <em>every group</em> to have at least one keyword present in the AI finding's title/message/file/id.</li>
+    <li><strong>Matching strategy:</strong> Every expected finding is evaluated against every AI finding. A match requires every required keyword group, and a single AI finding may cover multiple expectations.</li>
     <li><strong>Recall</strong> = matched expected findings ÷ total expected findings.</li>
     <li><strong>Extras</strong> are AI findings not matching any expected entry. These may be valid (LLM found additional issues) or hallucinations (false positives).</li>
     <li>This report is <strong>advisory</strong> — LLM output is non-deterministic; rerun to see variability.</li>
@@ -531,3 +638,10 @@ writeFileSync(outputPath, html, 'utf-8');
 console.log(`Report written: ${outputPath}`);
 console.log(`Overall: ${totalMatched}/${totalExpected} expected findings matched (${recall.toFixed(1)}% recall)`);
 console.log(`Extras: ${totalExtra} AI findings not in expected list`);
+if (invalidFixtures > 0) {
+  console.log(`INVALID: ${invalidFixtures} fixture workspace(s) failed integrity validation`);
+  for (const fixture of fixtureResults.filter(result => result.integrityErrors?.length)) {
+    console.log(`  ${fixture.name}: ${fixture.integrityErrors.join('; ')}`);
+  }
+  process.exitCode = 1;
+}

--- a/src/doctor/ai-analysis.ts
+++ b/src/doctor/ai-analysis.ts
@@ -150,11 +150,13 @@ export function buildAgentCommand(
   agent: string,
   prompt: string,
   _reportPath: string,
+  model = 'auto',
 ): AgentCommand {
+  const modelArgs = model === 'auto' ? [] : ['--model', model];
   switch (agent) {
     case 'github-copilot': {
       const resolved = resolveCliCommand('copilot');
-      const baseArgs = ['-p', prompt, '--allow-all-tools'];
+      const baseArgs = ['-p', prompt, '--allow-all-tools', ...modelArgs];
       return { command: resolved.command, args: [...resolved.argsPrefix, ...baseArgs] };
     }
 
@@ -167,6 +169,7 @@ export function buildAgentCommand(
           '-p', prompt,
           '--dangerously-skip-permissions',
           '--max-turns', '20',
+          ...modelArgs,
         ],
       };
     }
@@ -178,6 +181,7 @@ export function buildAgentCommand(
         '--sandbox', 'workspace-write',
         '--skip-git-repo-check',
         '--ephemeral',
+        ...modelArgs,
         prompt,
       ];
       return { command: resolved.command, args: [...resolved.argsPrefix, ...baseArgs] };
@@ -231,9 +235,10 @@ export async function runAiAnalysis(
   reportPath: string,
   dir: string,
   timeoutMs: number,
+  model = 'auto',
 ): Promise<AiAnalysisResult> {
   const startTime = Date.now();
-  const cmd = buildAgentCommand(agent, prompt, reportPath);
+  const cmd = buildAgentCommand(agent, prompt, reportPath, model);
 
   // Inform the user before spawning the agent — the agent has elevated permissions
   // and project content can prompt-inject it on untrusted workspaces.
@@ -375,6 +380,7 @@ export function mergeReports(
   durationMs: number,
   error?: string,
   severityThreshold: CheckSeverity = 'high',
+  requestedModel = 'auto',
 ): DoctorReport {
   const allChecks = [...report.tiers.builtin.checks, ...aiFindings];
   const thresholdRank = severityRank(severityThreshold);
@@ -405,6 +411,7 @@ export function mergeReports(
         ran: true,
         checks: aiFindings,
         agent,
+        requestedModel,
         durationMs,
         ...(error ? { error } : {}),
       },

--- a/src/doctor/ai-analysis.ts
+++ b/src/doctor/ai-analysis.ts
@@ -4,7 +4,7 @@
  * Builds the doctor prompt, launches an agent in headless mode,
  * reads the resulting report file, and merges findings into the report.
  */
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -239,6 +239,15 @@ export async function runAiAnalysis(
 ): Promise<AiAnalysisResult> {
   const startTime = Date.now();
   const cmd = buildAgentCommand(agent, prompt, reportPath, model);
+  try {
+    clearAiReport(reportPath);
+  } catch (err) {
+    return {
+      findings: [],
+      durationMs: Date.now() - startTime,
+      error: `AI analysis failed to clear the previous findings report: ${(err as Error).message}`,
+    };
+  }
 
   // Inform the user before spawning the agent — the agent has elevated permissions
   // and project content can prompt-inject it on untrusted workspaces.
@@ -284,6 +293,14 @@ export async function runAiAnalysis(
       agentOutput: spawnResult.stdout,
     };
   }
+  if (!existsSync(reportPath)) {
+    return {
+      findings: [],
+      durationMs: Date.now() - startTime,
+      error: 'Agent completed without writing the requested findings report.',
+      agentOutput: spawnResult.stdout,
+    };
+  }
 
   const findings = await readAiReport(reportPath);
   return {
@@ -291,6 +308,10 @@ export async function runAiAnalysis(
     durationMs: Date.now() - startTime,
     agentOutput: spawnResult.stdout,
   };
+}
+
+export function clearAiReport(reportPath: string): void {
+  if (existsSync(reportPath)) unlinkSync(reportPath);
 }
 
 function spawnAgent(cmd: AgentCommand, dir: string, timeoutMs: number): Promise<SpawnResult> {
@@ -339,21 +360,23 @@ export async function readAiReport(reportPath: string): Promise<DoctorCheckResul
     if (!Array.isArray(parsed)) return [];
 
     // Validate each entry has required fields
-    return parsed.filter((entry: unknown): entry is DoctorCheckResult => {
-      if (typeof entry !== 'object' || entry === null) return false;
-      const e = entry as Record<string, unknown>;
-      return (
-        typeof e.id === 'string' &&
-        typeof e.category === 'string' &&
-        typeof e.severity === 'string' &&
-        typeof e.status === 'string' &&
-        typeof e.title === 'string' &&
-        typeof e.message === 'string'
-      );
-    });
+    return parsed.filter(isDoctorCheckResult);
   } catch {
     return [];
   }
+}
+
+export function isDoctorCheckResult(entry: unknown): entry is DoctorCheckResult {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const finding = entry as Record<string, unknown>;
+  return (
+    typeof finding.id === 'string' &&
+    typeof finding.category === 'string' &&
+    typeof finding.severity === 'string' &&
+    typeof finding.status === 'string' &&
+    typeof finding.title === 'string' &&
+    typeof finding.message === 'string'
+  );
 }
 
 // ── Report merger ──

--- a/src/doctor/formatters.ts
+++ b/src/doctor/formatters.ts
@@ -36,7 +36,8 @@ function formatTextReport(report: DoctorReport): string {
   }
 
   if (report.tiers.ai.ran && report.tiers.ai.checks.length > 0) {
-    const agentLabel = report.tiers.ai.agent ? ` (${report.tiers.ai.agent})` : '';
+    const modelLabel = report.tiers.ai.requestedModel ? `, model: ${report.tiers.ai.requestedModel}` : '';
+    const agentLabel = report.tiers.ai.agent ? ` (${report.tiers.ai.agent}${modelLabel})` : '';
     lines.push(`AI analysis${agentLabel}:`);
     for (const c of report.tiers.ai.checks) {
       const icon = statusIcon(c.status);
@@ -155,6 +156,9 @@ function formatHtmlReport(report: DoctorReport): string {
   const overallStatus = summary.status === 'pass' ? 'PASS' : 'FAIL';
   const overallClass = summary.status === 'pass' ? 'status-pass' : 'status-fail';
   const aiAgent = tiers.ai.agent ? ` (${tiers.ai.agent})` : '';
+  const aiModel = tiers.ai.requestedModel
+    ? ` · Requested model: ${escapeHtml(tiers.ai.requestedModel)}${tiers.ai.effectiveModel ? ` · Effective model: ${escapeHtml(tiers.ai.effectiveModel)}` : ''}`
+    : '';
   const aiDurationStr = tiers.ai.durationMs ? `${(tiers.ai.durationMs / 1000).toFixed(1)}s` : '—';
 
   const builtinChecks = tiers.builtin.checks;
@@ -260,7 +264,7 @@ function formatHtmlReport(report: DoctorReport): string {
 
   ${tiers.ai.ran || tiers.ai.error ? `
     <h2>AI Analysis (Tier 2)${escapeHtml(aiAgent)}</h2>
-    <p class="meta">Duration: ${aiDurationStr}${tiers.ai.ran ? ` · Findings: ${aiChecks.length}` : ''}</p>
+    <p class="meta">Duration: ${aiDurationStr}${tiers.ai.ran ? ` · Findings: ${aiChecks.length}` : ''}${aiModel}</p>
     ${tiers.ai.error ? `<div class="ai-error"><strong>AI tier error:</strong> ${escapeHtml(tiers.ai.error)}</div>` : ''}
     ${aiChecks.length > 0 ? aiChecks.map(renderCheck).join('') : (tiers.ai.ran ? '<p class="empty">No AI findings reported.</p>' : '')}
   ` : ''}

--- a/src/doctor/formatters.ts
+++ b/src/doctor/formatters.ts
@@ -35,10 +35,13 @@ function formatTextReport(report: DoctorReport): string {
     lines.push('');
   }
 
-  if (report.tiers.ai.ran && report.tiers.ai.checks.length > 0) {
+  if (report.tiers.ai.ran || report.tiers.ai.error) {
     const modelLabel = report.tiers.ai.requestedModel ? `, model: ${report.tiers.ai.requestedModel}` : '';
     const agentLabel = report.tiers.ai.agent ? ` (${report.tiers.ai.agent}${modelLabel})` : '';
     lines.push(`AI analysis${agentLabel}:`);
+    if (report.tiers.ai.error) {
+      lines.push(`  Error: ${report.tiers.ai.error}`);
+    }
     for (const c of report.tiers.ai.checks) {
       const icon = statusIcon(c.status);
       const fileSuffix = c.file ? ` ${c.file}${c.line ? `:${c.line}` : ''}` : '';
@@ -77,16 +80,29 @@ function formatMarkdownReport(report: DoctorReport): string {
   }
   lines.push('');
 
-  if (report.tiers.ai.ran && report.tiers.ai.checks.length > 0) {
-    lines.push('## AI Analysis');
+  if (report.tiers.ai.ran || report.tiers.ai.error) {
+    const agent = report.tiers.ai.agent ? ` (${report.tiers.ai.agent})` : '';
+    lines.push(`## AI Analysis${agent}`);
     lines.push('');
-    lines.push('| Status | Check | Message |');
-    lines.push('|--------|-------|---------|');
-    for (const c of report.tiers.ai.checks) {
-      const icon = statusIcon(c.status);
-      lines.push(`| ${icon} | ${c.id} | ${c.message} |`);
+    if (report.tiers.ai.requestedModel) {
+      lines.push(`**Requested model:** ${report.tiers.ai.requestedModel}  `);
     }
-    lines.push('');
+    if (report.tiers.ai.effectiveModel) {
+      lines.push(`**Effective model:** ${report.tiers.ai.effectiveModel}  `);
+    }
+    if (report.tiers.ai.error) {
+      lines.push(`**AI tier error:** ${report.tiers.ai.error}`);
+      lines.push('');
+    }
+    if (report.tiers.ai.checks.length > 0) {
+      lines.push('| Status | Check | Message |');
+      lines.push('|--------|-------|---------|');
+      for (const c of report.tiers.ai.checks) {
+        const icon = statusIcon(c.status);
+        lines.push(`| ${icon} | ${c.id} | ${c.message} |`);
+      }
+      lines.push('');
+    }
   }
 
   const { summary } = report;

--- a/src/doctor/runner.ts
+++ b/src/doctor/runner.ts
@@ -178,7 +178,9 @@ export async function runDoctor(options: DoctorOptions): Promise<RunResult> {
     }
   }
 
-  const exitCode = report.summary.status === 'fail' ? 1 : 0;
+  const exitCode = report.tiers.ai.ran && report.tiers.ai.error
+    ? 2
+    : report.summary.status === 'fail' ? 1 : 0;
   return { report, exitCode };
 }
 

--- a/src/doctor/runner.ts
+++ b/src/doctor/runner.ts
@@ -156,14 +156,24 @@ export async function runDoctor(options: DoctorOptions): Promise<RunResult> {
         );
         const prompt = buildDoctorPrompt(results, reportPath);
         const timeoutMs = options.timeout * 1000;
+        const requestedModel = options.model ?? 'auto';
         const aiResult = await runAiAnalysis(
           resolvedAgent,
           prompt,
           reportPath,
           options.dir,
           timeoutMs,
+          requestedModel,
         );
-        report = mergeReports(report, aiResult.findings, resolvedAgent, aiResult.durationMs, aiResult.error, options.severity);
+        report = mergeReports(
+          report,
+          aiResult.findings,
+          resolvedAgent,
+          aiResult.durationMs,
+          aiResult.error,
+          options.severity,
+          requestedModel,
+        );
       }
     }
   }

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -76,6 +76,8 @@ export interface TierResult {
 
 export interface AiTierResult extends TierResult {
   agent?: string;
+  requestedModel?: string;
+  effectiveModel?: string;
   durationMs?: number;
   error?: string;
 }
@@ -110,6 +112,7 @@ export interface DoctorOptions {
   dir: string;
   deep: boolean;
   agent?: string;
+  model?: string;
   timeout: number;
   format: OutputFormat;
   output: string;

--- a/templates/skills/azure-functions-doctor/references/ci-usage.md
+++ b/templates/skills/azure-functions-doctor/references/ci-usage.md
@@ -11,7 +11,7 @@ The recommended CI mode is built-in checks plus deep analysis.
     node-version: '22'
 - run: az version
 # Install/authenticate the selected agent CLI before this step.
-- run: npx @azure/functions-skills doctor --deep --accept-deep-risk --agent github-copilot --format json --output doctor-report.json --severity high
+- run: npx @azure/functions-skills doctor --deep --accept-deep-risk --agent github-copilot --model gpt-5.6-sol --format json --output doctor-report.json --severity high
 - uses: actions/upload-artifact@v4
   if: always()
   with:
@@ -36,12 +36,16 @@ The recommended CI mode is built-in checks plus deep analysis.
 |------|--------------|
 | Node.js | Running `@azure/functions-skills` |
 | Azure CLI | Runtime metadata via ARM functionAppStacks |
-| `copilot`, `claude`, or `codex` CLI | `--deep --agent <name>` |
+| `copilot`, `claude`, or `codex` CLI | `--deep --agent <name> [--model <model-id>]` |
 | Azure login / federated credentials | Azure resource tier checks |
 
 `az functionapp list-runtimes` / ARM stack metadata does not normally require reading subscription resources, but Azure CLI must be installed. Azure resource checks require login.
 
 For deterministic offline tests or intentionally network-free runs, set `AZURE_FUNCTIONS_DOCTOR_STACKS_OFFLINE=1` to skip live stack metadata resolution and use cache/fallback data.
+
+Pass an explicit `--model` for reproducible deep comparisons. The requested
+model is recorded in `tiers.ai.requestedModel`; `tiers.ai.effectiveModel` is
+recorded only when the selected launcher exposes the effective model.
 
 ## Exit codes
 

--- a/tests/doctor-ai-analysis.test.ts
+++ b/tests/doctor-ai-analysis.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, afterAll, vi, afterEach } from 'vitest';
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createTempDir, removeDir } from './helpers/fs.js';
 import {
   buildDoctorPrompt,
   buildAgentCommand,
   buildDeepWarning,
+  clearAiReport,
   readAiReport,
   mergeReports,
 } from '../src/doctor/ai-analysis.js';
@@ -147,6 +148,16 @@ describe('buildDeepWarning', () => {
 // ── readAiReport ──
 
 describe('readAiReport', () => {
+  it('removes a stale findings file before a new agent run', () => {
+    const dir = makeTmp('ai-report-stale-');
+    const reportPath = join(dir, 'report.json');
+    writeFileSync(reportPath, JSON.stringify([{ id: 'old-run' }]));
+
+    clearAiReport(reportPath);
+
+    expect(() => readFileSync(reportPath, 'utf-8')).toThrow();
+  });
+
   it('reads valid report file', async () => {
     const dir = makeTmp('ai-report-ok-');
     const reportPath = join(dir, 'report.json');

--- a/tests/doctor-ai-analysis.test.ts
+++ b/tests/doctor-ai-analysis.test.ts
@@ -74,24 +74,28 @@ describe('buildDoctorPrompt', () => {
 
 describe('buildAgentCommand', () => {
   it('builds github-copilot headless command', () => {
-    const cmd = buildAgentCommand('github-copilot', 'analyze this', '/tmp/report.json');
+    const cmd = buildAgentCommand('github-copilot', 'analyze this', '/tmp/report.json', 'gpt-5.6-sol');
     // On Windows, command may be process.execPath when .cmd wrapper is resolved
     const validCommands = ['copilot', process.execPath];
     expect(validCommands).toContain(cmd.command);
     expect(cmd.args).toContain('-p');
     expect(cmd.args.some(a => a.includes('analyze this'))).toBe(true);
     expect(cmd.args).toContain('--allow-all-tools');
+    expect(cmd.args).toContain('--model');
+    expect(cmd.args).toContain('gpt-5.6-sol');
   });
 
   it('builds claude-code headless command', () => {
-    const cmd = buildAgentCommand('claude-code', 'analyze this', '/tmp/report.json');
+    const cmd = buildAgentCommand('claude-code', 'analyze this', '/tmp/report.json', 'claude-sonnet-5');
     expect(cmd.command).toBe('claude');
     expect(cmd.args).toContain('-p');
     expect(cmd.args).toContain('--dangerously-skip-permissions');
+    expect(cmd.args).toContain('--model');
+    expect(cmd.args).toContain('claude-sonnet-5');
   });
 
   it('builds codex headless command', () => {
-    const cmd = buildAgentCommand('codex', 'analyze this', '/tmp/report.json');
+    const cmd = buildAgentCommand('codex', 'analyze this', '/tmp/report.json', 'gpt-5.3-codex');
     const validCommands = ['codex', process.execPath];
     expect(validCommands).toContain(cmd.command);
     expect(cmd.args).toContain('exec');
@@ -101,6 +105,13 @@ describe('buildAgentCommand', () => {
     expect(cmd.args).toContain('--ephemeral');
     expect(cmd.args).not.toContain('--approval-mode');
     expect(cmd.args).not.toContain('-q');
+    expect(cmd.args).toContain('--model');
+    expect(cmd.args).toContain('gpt-5.3-codex');
+  });
+
+  it('does not pass a model flag when automatic model selection is requested', () => {
+    const cmd = buildAgentCommand('github-copilot', 'analyze this', '/tmp/report.json', 'auto');
+    expect(cmd.args).not.toContain('--model');
   });
 
   it('throws for unknown agent', () => {
@@ -232,11 +243,13 @@ describe('mergeReports', () => {
       message: 'Missing await',
     }];
 
-    const merged = mergeReports(report, aiFindings, 'github-copilot', 5000);
+    const merged = mergeReports(report, aiFindings, 'github-copilot', 5000, undefined, 'high', 'gpt-5.6-sol');
     expect(merged.tiers.ai.ran).toBe(true);
     expect(merged.tiers.ai.checks).toHaveLength(1);
     expect(merged.tiers.ai.agent).toBe('github-copilot');
     expect(merged.tiers.ai.durationMs).toBe(5000);
+    expect(merged.tiers.ai.requestedModel).toBe('gpt-5.6-sol');
+    expect(merged.tiers.ai.effectiveModel).toBeUndefined();
     expect(merged.summary.total).toBe(2);
     expect(merged.summary.high).toBe(1);
     expect(merged.summary.status).toBe('fail');
@@ -248,6 +261,12 @@ describe('mergeReports', () => {
     expect(merged.tiers.ai.ran).toBe(true);
     expect(merged.tiers.ai.checks).toHaveLength(0);
     expect(merged.summary.status).toBe('pass');
+  });
+
+  it('records automatic model selection explicitly without claiming an effective model', () => {
+    const merged = mergeReports(makeBaseReport(), [], 'github-copilot', 3000, undefined, 'high', 'auto');
+    expect(merged.tiers.ai.requestedModel).toBe('auto');
+    expect(merged.tiers.ai.effectiveModel).toBeUndefined();
   });
 
   it('recalculates summary totals', () => {

--- a/tests/doctor-cli.test.ts
+++ b/tests/doctor-cli.test.ts
@@ -271,4 +271,34 @@ describe('doctor CLI', () => {
     expect(stderr).toContain('Unsupported report format: sarif');
     expect(existsSync(reportPath)).toBe(false);
   });
+
+  it('rejects --model without a model ID', () => {
+    const dir = makeTmp('cli-doc-model-missing-');
+    writeFileSync(join(dir, 'host.json'), JSON.stringify({ version: '2.0' }));
+
+    const { exitCode, stderr } = runDoctor([
+      '--dir', dir,
+      '--deep',
+      '--agent', 'github-copilot',
+      '--model',
+      '--accept-deep-risk',
+    ]);
+
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('--model requires a model ID');
+  });
+
+  it('rejects --model when deep analysis is disabled', () => {
+    const dir = makeTmp('cli-doc-model-nodeep-');
+    writeFileSync(join(dir, 'host.json'), JSON.stringify({ version: '2.0' }));
+
+    const { exitCode, stderr } = runDoctor([
+      '--dir', dir,
+      '--no-deep',
+      '--model', 'gpt-5.6-sol',
+    ]);
+
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('--model requires --deep');
+  });
 });

--- a/tests/doctor-cli.test.ts
+++ b/tests/doctor-cli.test.ts
@@ -247,6 +247,7 @@ describe('doctor CLI', () => {
     })();
     expect(stdout).toContain('azure-functions-skills doctor');
     expect(stdout).toContain('--deep');
+    expect(stdout).toContain('--model');
     expect(stdout).toContain('text|json|markdown|html');
     expect(stdout).not.toContain('sarif');
   });

--- a/tests/doctor-e2e-setup.test.ts
+++ b/tests/doctor-e2e-setup.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createTempDir, removeDir } from './helpers/fs.js';
 
@@ -18,6 +18,17 @@ afterAll(() => {
 });
 
 describe('doctor E2E fixture setup', () => {
+  it('defines destination protection and model forwarding in the generated helper', () => {
+    const source = readFileSync(SETUP_SCRIPT, 'utf-8');
+    expect(source).toContain('Fixture destination already exists');
+    expect(source).toContain("[string]$Model = 'auto'");
+    expect(source).toContain("$doctorArgs += '--model'");
+    expect(source).toContain('$doctorArgs += $Model');
+    expect(source).toContain('--list-expectations');
+    expect(source).toContain('$deepFixtureNames');
+    expect(source).not.toContain("Name -ne 'node-supply-chain-unpinned-deps'");
+  });
+
   it.runIf(process.platform === 'win32')('rejects an existing fixture destination instead of nesting a copy', () => {
     const target = makeTmp('doctor-e2e-setup-');
     execFileSync('powershell.exe', [

--- a/tests/doctor-e2e-setup.test.ts
+++ b/tests/doctor-e2e-setup.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+const TEMP_DIRS: string[] = [];
+const SETUP_SCRIPT = join(import.meta.dirname, '..', 'scripts', 'doctor-e2e-setup.ps1');
+
+function makeTmp(prefix: string): string {
+  const dir = createTempDir(prefix);
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of TEMP_DIRS) removeDir(dir);
+});
+
+describe('doctor E2E fixture setup', () => {
+  it.runIf(process.platform === 'win32')('rejects an existing fixture destination instead of nesting a copy', () => {
+    const target = makeTmp('doctor-e2e-setup-');
+    execFileSync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-File', SETUP_SCRIPT,
+      '-Target', target,
+      '-Filter', 'node-deep-client-reuse',
+    ], { encoding: 'utf-8' });
+
+    expect(() => execFileSync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-File', SETUP_SCRIPT,
+      '-Target', target,
+      '-Filter', 'node-deep-client-reuse',
+    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }))
+      .toThrow(/already exists|cleanup/i);
+    expect(existsSync(join(
+      target,
+      'node-deep-client-reuse',
+      'node-deep-client-reuse',
+    ))).toBe(false);
+  });
+
+  it.runIf(process.platform === 'win32')('generates a run-all helper that forwards an explicit model', () => {
+    const target = makeTmp('doctor-e2e-model-');
+    execFileSync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-File', SETUP_SCRIPT,
+      '-Target', target,
+      '-Filter', 'node-deep-client-reuse',
+    ], { encoding: 'utf-8' });
+
+    const command = [
+      `$content = Get-Content '${join(target, 'run-all.ps1').replaceAll("'", "''")}' -Raw`,
+      `if ($content -notmatch '\\[string\\]\\$Model' -or $content -notmatch "'--model'") { exit 1 }`,
+    ].join('; ');
+    expect(() => execFileSync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command', command,
+    ], { encoding: 'utf-8' })).not.toThrow();
+  });
+});

--- a/tests/doctor-runner.test.ts
+++ b/tests/doctor-runner.test.ts
@@ -79,19 +79,20 @@ describe('runDoctor', () => {
   it('errors when --deep is requested without --agent and no state', async () => {
     const dir = makeTmp('runner-deep-no-agent-');
     writeFileSync(join(dir, 'host.json'), JSON.stringify({ version: '2.0' }));
-    const { report } = await runDoctor(defaultOpts(dir, { deep: true, acceptDeepRisk: true }));
+    const { report, exitCode } = await runDoctor(defaultOpts(dir, { deep: true, acceptDeepRisk: true }));
 
     // Tier 1 should still run; Tier 2 should be skipped with explanation
     expect(report.tiers.builtin.ran).toBe(true);
     expect(report.tiers.ai.ran).toBe(false);
     expect(report.tiers.ai.agent).toBeUndefined();
     expect(report.tiers.ai.error).toMatch(/agent/i);
+    expect(exitCode).toBe(1);
   });
 
   it('refuses to run --deep without acceptDeepRisk acknowledgement', async () => {
     const dir = makeTmp('runner-deep-no-accept-');
     writeFileSync(join(dir, 'host.json'), JSON.stringify({ version: '2.0' }));
-    const { report } = await runDoctor(defaultOpts(dir, {
+    const { report, exitCode } = await runDoctor(defaultOpts(dir, {
       deep: true,
       agent: 'github-copilot',
       acceptDeepRisk: false,
@@ -100,6 +101,7 @@ describe('runDoctor', () => {
     expect(report.tiers.builtin.ran).toBe(true);
     expect(report.tiers.ai.ran).toBe(false);
     expect(report.tiers.ai.error).toMatch(/--accept-deep-risk|untrusted|elevated/i);
+    expect(exitCode).toBe(1);
   });
 
   it('refuses --deep when GITHUB_EVENT_NAME=pull_request (contributor PR context)', async () => {
@@ -238,6 +240,25 @@ describe('formatReport', () => {
     const md = formatReport(report, 'markdown');
     expect(md).toContain('# Azure Functions Doctor Report');
     expect(md).toContain('| Status | Check | Message |');
+  });
+
+  it('markdown format includes AI model provenance and errors', async () => {
+    const dir = makeTmp('fmt-md-ai-');
+    writeFileSync(join(dir, 'host.json'), JSON.stringify({ version: '2.0' }));
+    const { report } = await runDoctor(defaultOpts(dir));
+    report.tiers.ai = {
+      ran: true,
+      checks: [],
+      agent: 'github-copilot',
+      requestedModel: 'gpt-5.6-sol',
+      error: 'Agent rejected the requested model.',
+    };
+
+    const markdown = formatReport(report, 'markdown');
+
+    expect(markdown).toContain('github-copilot');
+    expect(markdown).toContain('gpt-5.6-sol');
+    expect(markdown).toContain('Agent rejected the requested model.');
   });
 
   it('html format has valid structure and embedded styles', async () => {

--- a/tests/doctor-validation-report.test.ts
+++ b/tests/doctor-validation-report.test.ts
@@ -12,6 +12,7 @@ interface Finding {
   title: string;
   message: string;
   severity?: string;
+  line?: unknown;
 }
 
 function makeTmp(prefix: string): string {
@@ -28,6 +29,8 @@ function writeResult(root: string, fixture: string, findings: Finding[], options
   readonly ran?: boolean;
   readonly requestedModel?: string;
   readonly cachedFindings?: Finding[];
+  readonly error?: string;
+  readonly effectiveModel?: string;
 }): void {
   const fixtureDir = join(root, fixture);
   mkdirSync(fixtureDir, { recursive: true });
@@ -45,7 +48,8 @@ function writeResult(root: string, fixture: string, findings: Finding[], options
         ran: options?.ran ?? true,
         agent: 'github-copilot',
         requestedModel: options?.requestedModel ?? 'gpt-5.6-sol',
-        effectiveModel: options?.requestedModel ?? 'gpt-5.6-sol',
+        ...(options?.effectiveModel ? { effectiveModel: options.effectiveModel } : {}),
+        ...(options?.error ? { error: options.error } : {}),
         durationMs: 1000,
         checks,
       },
@@ -147,6 +151,34 @@ describe('doctor deep validation report', () => {
     expect(stdout).toContain('Extras: 2');
   });
 
+  it('does not treat retry or telemetry substrings as try error-handling evidence', () => {
+    const root = makeTmp('doctor-validation-boundary-');
+    writeResult(root, 'node-deep-client-reuse', [{
+      id: 'retry-telemetry',
+      title: 'Add retry telemetry',
+      message: 'Use a retry policy and improve telemetry for the registry entry.',
+    }]);
+
+    const { stdout } = runReport(root);
+
+    expect(stdout).toContain('0/3 expected findings matched');
+    expect(stdout).toContain('Extras: 1');
+  });
+
+  it('matches intentional keyword stems without matching inside unrelated words', () => {
+    const root = makeTmp('doctor-validation-stems-');
+    writeResult(root, 'node-deep-eventhub-no-idempotency', [{
+      id: 'missing-idempotency',
+      title: 'Payment is not idempotent',
+      message: 'No idempotency key protects the payment charge from replay duplicates.',
+    }]);
+
+    const { stdout } = runReport(root);
+
+    expect(stdout).toContain('1/3 expected findings matched');
+    expect(stdout).toContain('Extras: 0');
+  });
+
   it('is independent of expectation order and includes Go expectations', () => {
     const root = makeTmp('doctor-validation-go-');
     writeResult(root, 'go-deep-toolchain-and-runtime', [{
@@ -160,6 +192,31 @@ describe('doctor deep validation report', () => {
     expect(stdout).toContain('2/5 expected findings matched');
     expect(html).toContain('[GO-003]');
     expect(html).toContain('[GO-004]');
+  });
+
+  it('selects the same best candidate regardless of AI finding order', () => {
+    const firstRoot = makeTmp('doctor-validation-order-a-');
+    const secondRoot = makeTmp('doctor-validation-order-b-');
+    const findings = [
+      {
+        id: 'a-blocking',
+        title: 'A deterministic candidate',
+        message: 'GetAsync().Result blocks async work and risks deadlock.',
+      },
+      {
+        id: 'z-blocking',
+        title: 'Z deterministic candidate',
+        message: 'GetAsync().Result blocks async work and risks deadlock.',
+      },
+    ];
+    writeResult(firstRoot, 'csharp-deep-blocking-async', findings);
+    writeResult(secondRoot, 'csharp-deep-blocking-async', [...findings].reverse());
+
+    const first = runReport(firstRoot).html;
+    const second = runReport(secondRoot).html;
+
+    expect(first).toContain('→ matched: <strong>A deterministic candidate</strong>');
+    expect(second).toContain('→ matched: <strong>A deterministic candidate</strong>');
   });
 
   it('invalidates nested fixture workspaces', () => {
@@ -194,6 +251,19 @@ describe('doctor deep validation report', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toContain('deep analysis did not run');
     expect(result.stdout).toContain('cached AI findings conflict');
+    expect(result.stdout).toContain('across 0/2 valid fixtures');
+  });
+
+  it('invalidates a fixture when the AI tier reports an error', () => {
+    const root = makeTmp('doctor-validation-ai-error-');
+    writeResult(root, 'node-deep-client-reuse', [], {
+      error: 'Agent rejected unsupported model.',
+    });
+
+    const result = runInvalidReport(root);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('Agent rejected unsupported model.');
   });
 
   it('shows model provenance in the report', () => {
@@ -204,6 +274,23 @@ describe('doctor deep validation report', () => {
 
     expect(html).toContain('gpt-5.6-sol');
     expect(html).toContain('Requested model');
-    expect(html).toContain('Effective model');
+    expect(html).not.toContain('Effective model');
+  });
+
+  it('escapes agent-controlled severity and line values in HTML', () => {
+    const root = makeTmp('doctor-validation-escape-');
+    writeResult(root, 'node-deep-client-reuse', [{
+      id: 'floating-promise',
+      title: 'Promise is not awaited',
+      message: 'The items.create promise is fire-and-forget.',
+      severity: 'high"><script>alert(1)</script>',
+      line: '1"><script>alert(2)</script>',
+    }]);
+
+    const { html } = runReport(root);
+
+    expect(html.toLowerCase()).not.toContain('<script>');
+    expect(html).not.toContain('sev-high"');
+    expect(html).toContain('&lt;script&gt;');
   });
 });

--- a/tests/doctor-validation-report.test.ts
+++ b/tests/doctor-validation-report.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+const TEMP_DIRS: string[] = [];
+const REPORT_SCRIPT = join(import.meta.dirname, '..', 'scripts', 'doctor-validation-report.mjs');
+
+interface Finding {
+  id: string;
+  title: string;
+  message: string;
+  severity?: string;
+}
+
+function makeTmp(prefix: string): string {
+  const dir = createTempDir(prefix);
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of TEMP_DIRS) removeDir(dir);
+});
+
+function writeResult(root: string, fixture: string, findings: Finding[], options?: {
+  readonly ran?: boolean;
+  readonly requestedModel?: string;
+  readonly cachedFindings?: Finding[];
+}): void {
+  const fixtureDir = join(root, fixture);
+  mkdirSync(fixtureDir, { recursive: true });
+  const checks = findings.map(finding => ({
+    category: 'code',
+    severity: finding.severity ?? 'high',
+    status: 'fail',
+    ...finding,
+  }));
+  writeFileSync(join(fixtureDir, 'doctor-result.json'), JSON.stringify({
+    language: 'node',
+    summary: { status: 'fail' },
+    tiers: {
+      ai: {
+        ran: options?.ran ?? true,
+        agent: 'github-copilot',
+        requestedModel: options?.requestedModel ?? 'gpt-5.6-sol',
+        effectiveModel: options?.requestedModel ?? 'gpt-5.6-sol',
+        durationMs: 1000,
+        checks,
+      },
+    },
+  }));
+  if (options?.cachedFindings) {
+    const cacheDir = join(fixtureDir, '.azure-functions-doctor');
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, 'doctor-ai-findings.json'), JSON.stringify(
+      options.cachedFindings.map(finding => ({
+        category: 'code',
+        severity: finding.severity ?? 'high',
+        status: 'fail',
+        ...finding,
+      })),
+    ));
+  }
+}
+
+function runReport(root: string): { stdout: string; html: string } {
+  const output = join(root, 'report.html');
+  const stdout = execFileSync(process.execPath, [
+    REPORT_SCRIPT,
+    '--fixtures-dir', root,
+    '--output', output,
+  ], { encoding: 'utf-8' });
+  return { stdout, html: readFileSync(output, 'utf-8') };
+}
+
+function runInvalidReport(root: string): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync(process.execPath, [REPORT_SCRIPT, '--fixtures-dir', root], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (error: unknown) {
+    const result = error as { stdout?: Buffer | string; stderr?: Buffer | string; status?: number };
+    return {
+      stdout: result.stdout?.toString() ?? '',
+      stderr: result.stderr?.toString() ?? '',
+      exitCode: result.status ?? 1,
+    };
+  }
+}
+
+describe('doctor deep validation report', () => {
+  it('keeps the machine-readable expectation catalog aligned with deep fixture documentation', () => {
+    const output = execFileSync(process.execPath, [REPORT_SCRIPT, '--list-expectations'], { encoding: 'utf-8' });
+    const catalog = JSON.parse(output) as Record<string, string[]>;
+    const fixtureRoot = join(import.meta.dirname, 'fixtures', 'doctor-bad-apps');
+    const documented = readFileSync(join(fixtureRoot, 'expected-results.md'), 'utf-8');
+    const fixtureNames = readdirSync(fixtureRoot, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name)
+      .filter(name => name.includes('-deep-') || name.includes('-supply-chain-'))
+      .filter(name => !name.endsWith('-unpinned-deps'));
+
+    expect(Object.keys(catalog).sort()).toEqual(fixtureNames.sort());
+    for (const fixture of Object.keys(catalog)) {
+      expect(documented).toContain(`**\`${fixture}\`**`);
+      expect(catalog[fixture].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('lets one finding satisfy multiple explicitly covered expectations without becoming extra', () => {
+    const root = makeTmp('doctor-validation-many-');
+    writeResult(root, 'csharp-deep-blocking-async', [{
+      id: 'blocked-async',
+      title: 'Asynchronous HTTP calls are blocked synchronously',
+      message: 'GetAsync().Result and PostAsync().Wait() block async work and risk deadlocks.',
+    }]);
+
+    const { stdout, html } = runReport(root);
+
+    expect(stdout).toContain('2/5 expected findings matched');
+    expect(stdout).toContain('Extras: 0');
+    expect(html).toContain('matched 2 expectations');
+    expect(html).toContain('.result');
+    expect(html).toContain('wait()');
+  });
+
+  it('rejects generic client-reuse and request-validation false matches', () => {
+    const root = makeTmp('doctor-validation-false-');
+    writeResult(root, 'node-deep-secrets-obfuscated', [{
+      id: 'client-reuse',
+      title: 'BlobServiceClient created per invocation',
+      message: 'Move the client to module scope for reuse.',
+    }]);
+    writeResult(root, 'node-deep-output-binding-errors', [{
+      id: 'request-validation',
+      title: 'Request validation missing',
+      message: 'Validate input before returning success from the handler.',
+    }]);
+
+    const { stdout } = runReport(root);
+
+    expect(stdout).toContain('0/4 expected findings matched');
+    expect(stdout).toContain('Extras: 2');
+  });
+
+  it('is independent of expectation order and includes Go expectations', () => {
+    const root = makeTmp('doctor-validation-go-');
+    writeResult(root, 'go-deep-toolchain-and-runtime', [{
+      id: 'go-runtime',
+      title: 'Go worker runtime and client lifecycle issues',
+      message: 'FUNCTIONS_WORKER_RUNTIME must be native; construct http.Client at package scope, not inside the hello handler.',
+    }]);
+
+    const { stdout, html } = runReport(root);
+
+    expect(stdout).toContain('2/5 expected findings matched');
+    expect(html).toContain('[GO-003]');
+    expect(html).toContain('[GO-004]');
+  });
+
+  it('invalidates nested fixture workspaces', () => {
+    const root = makeTmp('doctor-validation-nested-');
+    writeResult(root, 'node-deep-client-reuse', []);
+    mkdirSync(join(root, 'node-deep-client-reuse', 'node-deep-client-reuse'), { recursive: true });
+
+    const result = runInvalidReport(root);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('INVALID');
+    expect(result.stdout).toContain('nested fixture directory');
+  });
+
+  it('invalidates reports where deep analysis did not run or cached findings conflict', () => {
+    const root = makeTmp('doctor-validation-stale-');
+    writeResult(root, 'node-deep-client-reuse', [], { ran: false });
+    writeResult(root, 'python-deep-blocking-sync', [{
+      id: 'sync-http',
+      title: 'Synchronous HTTP',
+      message: 'requests.get blocks the worker.',
+    }], {
+      cachedFindings: [{
+        id: 'different',
+        title: 'Different cache',
+        message: 'Stale.',
+      }],
+    });
+
+    const result = runInvalidReport(root);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('deep analysis did not run');
+    expect(result.stdout).toContain('cached AI findings conflict');
+  });
+
+  it('shows model provenance in the report', () => {
+    const root = makeTmp('doctor-validation-model-');
+    writeResult(root, 'node-deep-client-reuse', [], { requestedModel: 'gpt-5.6-sol' });
+
+    const { html } = runReport(root);
+
+    expect(html).toContain('gpt-5.6-sol');
+    expect(html).toContain('Requested model');
+    expect(html).toContain('Effective model');
+  });
+});

--- a/tests/fixtures/doctor-bad-apps/README.md
+++ b/tests/fixtures/doctor-bad-apps/README.md
@@ -19,6 +19,7 @@ node bin/azure-functions-skills.js doctor `
   --dir tests\fixtures\doctor-bad-apps\<fixture-name> `
   --deep --accept-deep-risk `
   --agent github-copilot `
+  --model gpt-5.6-sol `
   --format json --output <fixture-name>-result.json
 ```
 
@@ -63,6 +64,7 @@ Use `expected-results.md` for expected findings. Tier 1 findings are strict; Tie
 | `csharp-clean` | C# .NET | Healthy isolated model project |
 | `java-clean` | Java | Healthy Maven project |
 | `powershell-clean` | PowerShell | Healthy managed-deps project |
+| `go-clean` | Go | Healthy native-worker project |
 
 ### Deep / semantic fixtures (multi-language — require LLM analysis)
 
@@ -84,6 +86,7 @@ Use `expected-results.md` for expected findings. Tier 1 findings are strict; Tie
 | `java-deep-client-reuse` | Java | Missing extension bundle | JV-001, JV-002, JV-003, CQ-005, CQ-007 — Old plugin/Java 11, client per invocation, no idempotency, empty catch |
 | `powershell-deep-install-module` | PowerShell | — | PS-002, PS-003, CQ-002 — Heavy profile, Install-Module in handler, $env/$global persistence |
 | `powershell-deep-managed-deps` | PowerShell | Deprecated AzureWebJobsDashboard | PS-001, CQ-002, CQ-007 — managedDependency without requirements.psd1, $global cache anti-pattern |
+| `go-deep-toolchain-and-runtime` | Go | Old toolchain, pseudo-version worker pin, wrong runtime | GO-001..GO-004, SC-002 — panic escape, client lifecycle, worker configuration, anonymous auth |
 
 ### Supply-chain fixtures (Tier 1 + Tier 2)
 
@@ -112,6 +115,10 @@ node <repo-root>/scripts/doctor-validation-report.mjs --fixtures-dir .
 Start-Process .\ai-validation-report.html
 ```
 
-The script uses a curated keyword map for each fixture and reports overall recall (%), per-fixture matched / missed / extra findings, and AI durations. Self-contained HTML, no external dependencies.
+The script uses a machine-readable expectation catalog and scored many-to-many
+matching. It reports expected-item recall, associated and extra AI findings,
+match evidence, model provenance, and workspace integrity errors. A finding is
+extra only when it has no valid expectation match. Reports are advisory because
+LLM output is non-deterministic and model-dependent.
 
 > **Why not delegate this to an LLM agent?** An earlier version of this README contained a "let a coding agent produce the report" prompt. That pattern was withdrawn because every fixture under this directory is intentionally adversarial test content (some files are designed to look like real prompt-injection / supply-chain payloads). Pointing a general-purpose agent at the fixtures directory and asking it to *read* and *interpret* their JSON output is itself a prompt-injection surface. Use the deterministic Node.js script above instead.


### PR DESCRIPTION
## Summary

- replace greedy one-to-one deep finding assignment with deterministic many-to-many match edges
- use boundary-aware signal matching, tighten weak rules, add Go and missing supply-chain expectations, and explain required signals/alternative candidates
- classify extras only when they have no valid expectation edge
- invalidate nested, missing, non-deep, errored, malformed, or stale fixture results while excluding invalid fixtures from aggregate recall
- delete stale AI findings before every agent run and fail when an agent does not produce the requested report
- reject fixture setup into an existing destination and derive `-DeepOnly` fixtures from the canonical machine-readable expectation catalog
- add `doctor --model`, forward it through Copilot/Claude/Codex and generated `run-all.ps1`, validate its CLI usage, and record requested model provenance
- surface AI execution errors and model provenance across text, Markdown, JSON, and HTML
- add focused regression coverage for matching boundaries, ordering, workspace integrity, stale output, model forwarding, and HTML safety

## Validation

- `npm run check`
  - lint, typecheck, security lint, skill validation, plugin payload verification, tests, and build passed
  - 286 tests passed
- trusted real deep run: `csharp-deep-blocking-async` with GitHub Copilot CLI and `gpt-5.6-sol`
  - 4 AI findings covered all 5 expectations
  - main scorer on the same result: 4/5 (80%)
  - updated scorer after self-review: 5/5 (100%), 0 extras, 1/1 valid fixture
  - requested model persisted as `gpt-5.6-sol`
- `doctor-e2e-setup.ps1 -DeepOnly` selected all 22 catalog fixtures, including Go and supply-chain fixtures, and excluded the deterministic-only supply-chain fixture

## Self-review

Reviewed twice with Claude Opus 5. Follow-up fixes addressed overly broad substring matches, keyword-stem matching, stale report reuse, silent agent failures, deterministic candidate ordering, invalid-fixture denominator handling, Markdown provenance, HTML escaping, and duplicated fixture discovery. The duplication audit found no reusable stable-JSON or agent-command implementation; the remaining `escapeHtml` copies predate this change and are intentionally separate because the validation report is a standalone script.

Fixes #225