### PR TITLE
fix: correct official pipeline resource name

### DIFF
--- a/azure-pipelines/partner-drop-upload.yml
+++ b/azure-pipelines/partner-drop-upload.yml
@@ -14,7 +14,7 @@ resources:
     pipelines:
         - pipeline: officialBuild
           project: internal
-          source: functions-skills.official
+          source: azure-functions-skills.official
           branch: main
 
 variables:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -24,7 +24,7 @@ resources:
     pipelines:
         - pipeline: officialBuild
           project: internal
-          source: functions-skills.official
+          source: azure-functions-skills.official
           branch: main
 
 variables:


### PR DESCRIPTION
## Summary

- update the release pipeline to reference the actual `azure-functions-skills.official` pipeline definition
- apply the same correction to the partner drop upload pipeline

## Context

The previous `functions-skills.official` resource name could not be resolved when manually queuing the release pipeline, even though official build `297306` completed successfully and produced the `drop` artifact.

## Testing

- `npm test -- tests/telemetry-release.test.ts`