### PR TITLE
fix: update vulnerable Java fixture dependencies

### DIFF
--- a/tests/fixtures/doctor-bad-apps/java-deep-client-reuse/pom.xml
+++ b/tests/fixtures/doctor-bad-apps/java-deep-client-reuse/pom.xml
@@ -50,4 +50,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.136.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.18.8</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
## Summary

- import Netty BOM `4.1.136.Final` to address the vulnerabilities reported by internal mirror PRs [1725](https://dev.azure.com/azfunc/internal/_git/azure.azure-functions-skills/pullrequest/1725) and [1726](https://dev.azure.com/azfunc/internal/_git/azure.azure-functions-skills/pullrequest/1726)
- import Jackson BOM `2.18.8` to address the vulnerability reported by internal mirror PR [1729](https://dev.azure.com/azfunc/internal/_git/azure.azure-functions-skills/pullrequest/1729)
- keep each dependency family version-aligned instead of applying the mirror's individual transitive dependency overrides

Public Dependabot has no matching Maven alert or PR. Existing public Dependabot PRs #214 and #226 cover unrelated npm development dependencies.

## Validation

- `npm test` (265 tests)
- `npm run build`
- Maven fixture compile and dependency resolution using Maven 3.9 / Java 11
  - all Netty modules resolve to `4.1.136.Final`
  - all Jackson modules resolve to `2.18.8`

`npm run check` reaches `verify:plugin-payload`, which reports pre-existing generated payload drift unrelated to this fixture-only change.