### PR TITLE
ci: add Azure DevOps Dependabot configuration

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,4 @@
+# Mirrored repository. We use dependabot via GitHub, not Azure DevOps.
+version: 2
+enable-security-updates: false
+enable-campaigned-updates: false


### PR DESCRIPTION
## Summary

- add the Azure DevOps Dependabot configuration for this mirrored repository
- disable Azure DevOps security and campaigned updates because GitHub manages Dependabot
