### PR TITLE
feat: reduce template skill token usage

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
@@ -14,6 +14,13 @@ Guide the user through creating a new Azure Functions project or adding a functi
 
 Ensure `func` (Azure Functions Core Tools v4) is installed. If not, suggest running **azure-functions-setup** first.
 
+Template discovery and application use the manifest-backed CLI released in
+`@azure/functions-skills@0.0.6-preview`. Invoke it with:
+
+```bash
+npx -y @azure/functions-skills@0.0.6-preview
+```
+
 ## Workflow
 
 ### Step 0 — Check for Go
@@ -22,34 +29,15 @@ If the user asks for **Go** (or Golang), use **Path C** below. Neither the Azure
 
 For every other language, continue with Step 1.
 
-### Step 1 — Detect Azure MCP tools
+### Step 1 — Gather requirements and best practices
 
-Check whether the following Azure MCP tools are available in your current tool list:
-
-- `functions_language_list` — list supported languages and runtime versions
-- `functions_project_get` — scaffold project-level files
-- `functions_template_get` — list templates (language only) or get a specific template (language + template)
-
-These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) and return officially maintained templates across C#, Python, TypeScript, JavaScript, Java and PowerShell.
-
-Also check for the best practices tool:
+Check for the best practices tool:
 
 - `get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions`
 
-- **If available** → proceed with **Path A (MCP primary)**.
-- **If not available** → proceed with **Path B (composition algorithm fallback)**.
+If available, call it before generating code:
 
----
-
-### Path A — MCP primary (recommended)
-
-Use the Azure MCP Server as the **authoritative source of truth** for Azure Functions templates. Do **not** write function code from scratch when these tools are available.
-
-#### A.1 Gather requirements & best practices
-
-If `get_azure_bestpractices` is available, call it first:
-
-```
+```text
 Tool: get_azure_bestpractices
 resource: azurefunctions
 action: code-generation
@@ -60,21 +48,31 @@ Apply the returned guidelines (programming models, extension bundles version, au
 Ask the user (or detect from context):
 
 - **Language**: `csharp` | `python` | `typescript` | `javascript` | `java` | `powershell`
-- **Trigger / template**: let the MCP list decide (step A.3)
+- **Trigger / template**: let the CLI list decide (Path A.1)
 - **Project name**: directory name
 - **Runtime version** (optional): e.g. Node.js `22`, Python `3.11`, Java `21`
 
-#### A.2 Discover supported languages
+Resolve the target directory to an absolute path. Pass it with `--dir` on every apply command so files never land in the wrong workspace.
 
-Call `functions_language_list`. Returns supported languages with runtime versions, programming models, and prerequisites. Use this to confirm the user's language choice is supported and to suggest a default runtime version.
+---
 
-#### A.3 Browse available templates
+### Path A — Manifest-backed CLI (recommended)
 
-Call `functions_template_get` with only the `language` parameter (omit `template`). This returns the list of available templates for the chosen language with descriptions. Present the templates to the user and let them pick.
+The Azure Functions Skills CLI writes official templates directly to disk. This keeps template source files out of the LLM transcript. Do **not** call `functions_template_get`, fetch repository trees, download raw template files, or reproduce template contents manually while this path works.
 
-Do **not** invent or guess template identifiers such as `HttpTrigger`. Azure MCP template IDs are versioned, language-specific strings returned by the template list. For example, the TypeScript HTTP trigger template is currently returned as `http-trigger-typescript-azd`.
+#### A.1 Browse available templates
 
-When the user asks for a common trigger name, map it to one of the template IDs returned by the MCP list before calling the template-get operation. Examples:
+List matching template metadata:
+
+```bash
+npx -y @azure/functions-skills@0.0.6-preview template list --language <language>
+```
+
+Add `--resource <resource>` or `--iac <iac>` when the user supplied those constraints. Use `--json` only when structured metadata is needed for filtering; the default text list consumes fewer tokens. Neither format contains the full template payload. Use the result to confirm language support, available runtime choices, and the exact template ID. Present relevant matches and let the user choose when intent is ambiguous.
+
+Do **not** invent or guess template identifiers such as `HttpTrigger`. Template IDs are versioned, language-specific strings returned by `template list`. For example, the TypeScript HTTP trigger template is currently returned as `http-trigger-typescript-azd`.
+
+When the user asks for a common trigger name, map it to one of the IDs returned by the list. Examples:
 
 | User intent | Language | Prefer a returned template ID like |
 | --- | --- | --- |
@@ -83,36 +81,41 @@ When the user asks for a common trigger name, map it to one of the template IDs 
 | Blob trigger | `typescript` | `blob-eventgrid-trigger-typescript-azd` |
 | Queue / Service Bus trigger | `typescript` | `servicebus-trigger-typescript-azd` |
 
-If a template-get call fails with "template not found", immediately recover by calling `functions_template_get` again with only `language`, then select the closest returned template ID instead of retrying the failed alias.
+If apply reports "template not found", immediately run `template list` again with the same language and filters, then select the closest returned ID instead of retrying a guessed alias.
 
-#### A.4 Initialize the project
+#### A.2 Apply a new project
 
-Call `functions_project_get`:
+For a new project, apply the chosen template directly into the absolute target directory:
 
-```
-Tool: functions_project_get
-language: <chosen language, e.g. typescript>
-```
-
-Returns project-level files (`host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, `tsconfig.json`, etc.). Write these into the target directory.
-
-#### A.5 Add the function
-
-Call `functions_template_get` with both `language` and `template`:
-
-```
-Tool: functions_template_get
-language: <chosen language, e.g. typescript>
-template: <chosen returned template ID, e.g. http-trigger-typescript-azd>
-runtime-version: <optional, e.g. 22>
-output: <optional, "New" (default) or "Add" for existing projects>
+```bash
+npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode new --dir <absolute-target-directory>
 ```
 
-Returns the full function source code plus any required app settings and additional package dependencies. Write the returned file(s) into the project and merge any extra settings into `local.settings.json` and any extra packages into the dependency manifest.
+When the user selected a runtime version, also pass `--runtime-version <version>`. Do not add `--force` unless the user explicitly approves overwriting conflicts.
 
-> ⚠️ **Large template output**: Some templates (especially `*-azd` variants that include infrastructure files) can produce very large output (100KB+). If the tool output is truncated or saved to a temporary file, read the file, parse the JSON `files` array, and write each file individually. After writing files, run `npm install` (or the equivalent package manager command) to generate lock files rather than relying on lock files from the template output.
+The command downloads and writes the template locally, performs runtime placeholder substitution, and prints only a concise file summary. Do not read every generated file back into the conversation. Inspect only files needed for user-requested customization or verification.
 
-#### A.6 Verify
+Tailor the generated project to the user's requested trigger and business logic. Remove unrelated demo functions or sample data that the selected repository template included.
+
+#### A.3 Add to an existing project
+
+When `host.json` already exists, apply the selected template in add mode:
+
+```bash
+npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode add --dir <absolute-existing-project-directory>
+```
+
+Add `--runtime-version <version>` when selected. Add mode preserves root project files and existing conflicts by default. Never use `--force` without explicit confirmation.
+
+Review the concise apply summary. When dependency or settings files such as `package.json`, `requirements.txt`, or `local.settings.json` are skipped, apply the same template with `--mode new` into an isolated temporary directory. Compare only the skipped dependency/settings files, merge required entries into the existing project, then delete the temporary directory. This keeps template source local while ensuring the added trigger has every required package and setting.
+
+Keep only the requested function and its supporting code. Remove repository-level documentation, licenses, changelogs, and unrelated demo files that the apply summary shows as newly added to the existing project; never remove files that existed before the command.
+
+If the CLI rejects a nested full-project template in add mode, run `template list` again and choose an add-compatible template. If none exists, use Path B rather than forcing or reinitializing the project.
+
+#### A.4 Install dependencies and verify
+
+Run the appropriate dependency restore in the target directory (`npm install`, `pip install -r requirements.txt`, `dotnet restore`, or `mvn package` as applicable). Generate lock files through the package manager rather than asking the model to recreate them.
 
 For TypeScript and other compiled-language projects, build first:
 
@@ -140,50 +143,23 @@ After the host reports the function endpoints/listeners:
 
 ### Path B — Composition algorithm fallback
 
-Use this path **only when the Azure MCP tools are not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
+Use this path only after the CLI command produces an actual error and retrying discovery cannot resolve it. Do not treat a long-running download as failure without waiting for the command result.
 
-> ℹ️ Azure MCP tools were not found; using the manifest-based fallback path. Enabling the Azure MCP Server unlocks dynamic template discovery and composition. Run `azure-functions-setup` to configure it.
+When falling back, show this notice to the user verbatim (translate to the user's language if needed):
+
+> ℹ️ The manifest-backed template CLI could not complete, so I am using a higher-token fallback path. I will keep template content handling local where possible.
 
 #### B.1 Fallback algorithm
 
-Follow this manifest-based fallback algorithm:
+Prefer the first available fallback:
 
-```
-1. FETCH MANIFEST
-   GET https://cdn.functions.azure.com/public/templates-manifest/manifest.json
-   If fetch fails → fall back to:
-     https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Template-Manifest/manifest.json
-   If both fail → fall back to known-good Azure-Samples/functions-quickstart-* repos
-   If all fail → report error and ask user to retry later
+1. If Azure MCP `functions_template_get` is available, use it only for the selected template after CLI failure. Write returned files directly and avoid echoing their contents in the final response.
+2. Otherwise fetch the public manifest, select the exact entry, and download its repository/folder locally with a ZIP download or shallow clone.
+3. For a new project, use the selected template as the base. For an existing project, copy only the required function/binding files and merge dependencies/settings without replacing user-owned files.
+4. For requests that combine multiple triggers or bindings, use one project template as the base, extract only the additional binding patterns, and merge required IaC resources, RBAC roles, app settings, and dependencies.
+5. If all sources fail, report the exact errors and ask the user to retry later.
 
-2. FILTER TEMPLATES
-   Filter by: language, resource, iac
-
-3. CHECK SINGLE-TEMPLATE MATCH
-   If one template covers ALL requirements → use it alone
-
-4. SELECT TEMPLATES
-   - Trigger template (REQUIRED) — base project with IaC
-   - Binding templates (OPTIONAL) — extract patterns only
-
-5. DOWNLOAD TEMPLATES
-   For each template:
-   - If folderPath == "." → ZIP download + unzip
-   - If folderPath != "." → fetch tree + raw github url file downloads
-   - Fallback: git clone --depth 1
-
-6. COMPOSE
-   - Use trigger template as BASE
-   - EXTRACT binding patterns from binding templates
-   - MERGE IaC resources, RBAC roles and settings
-   - ADD user's custom business logic
-
-7. TRIM unused demo code (keep AzureWebJobsStorage)
-
-8. WRITE all files
-
-9. DEPLOY: azd up --no-prompt
-```
+Do not deploy automatically as part of creation. Deployment remains the responsibility of **azure-functions-deploy**.
 
 #### B.2 Quick code reference
 
@@ -217,8 +193,8 @@ Tell the user up front that **Go support on Azure Functions is in public preview
 
 If `host.json` already exists, do **not** re-initialize. Instead:
 
-- **MCP path**: call `functions_template_get` with the same language as the existing project and specify the desired template name. Write the returned file.
-- **Fallback path**: fetch the manifest, filter for the desired template by language and resource, download the template source, and merge the function files into the existing project.
+- **CLI path**: run `template list` for the existing language, then `template apply` with the exact returned ID, `--mode add`, and the absolute project directory.
+- **Fallback path**: only after an actual CLI error, retrieve the selected template through Azure MCP or the manifest and merge function files, dependencies, and settings without replacing user-owned files.
 - **Go path**: `func new` is not supported for Go. Edit `main.go`, add another `app.*` registration and, for an extension trigger, the blank import. Do not run `func init` or `go mod init` again, and do not create `function.json`. See [references/go-project.md](references/go-project.md).
 
 ## After Creation

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
@@ -14,11 +14,12 @@ Guide the user through creating a new Azure Functions project or adding a functi
 
 Ensure `func` (Azure Functions Core Tools v4) is installed. If not, suggest running **azure-functions-setup** first.
 
-Template discovery and application use the manifest-backed CLI released in
-`@azure/functions-skills@0.0.6-preview`. Invoke it with:
+Template discovery and application use the manifest-backed Azure Functions
+Skills CLI. Request the `latest` dist-tag explicitly so `npx` does not reuse
+an older locally installed package:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview
+npx -y @azure/functions-skills@latest
 ```
 
 ## Workflow
@@ -65,7 +66,7 @@ The Azure Functions Skills CLI writes official templates directly to disk. This 
 List matching template metadata:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview template list --language <language>
+npx -y @azure/functions-skills@latest template list --language <language>
 ```
 
 Add `--resource <resource>` or `--iac <iac>` when the user supplied those constraints. Use `--json` only when structured metadata is needed for filtering; the default text list consumes fewer tokens. Neither format contains the full template payload. Use the result to confirm language support, available runtime choices, and the exact template ID. Present relevant matches and let the user choose when intent is ambiguous.
@@ -88,7 +89,7 @@ If apply reports "template not found", immediately run `template list` again wit
 For a new project, apply the chosen template directly into the absolute target directory:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode new --dir <absolute-target-directory>
+npx -y @azure/functions-skills@latest template apply --language <language> --template <returned-template-id> --mode new --dir <absolute-target-directory>
 ```
 
 When the user selected a runtime version, also pass `--runtime-version <version>`. Do not add `--force` unless the user explicitly approves overwriting conflicts.
@@ -102,7 +103,7 @@ Tailor the generated project to the user's requested trigger and business logic.
 When `host.json` already exists, apply the selected template in add mode:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode add --dir <absolute-existing-project-directory>
+npx -y @azure/functions-skills@latest template apply --language <language> --template <returned-template-id> --mode add --dir <absolute-existing-project-directory>
 ```
 
 Add `--runtime-version <version>` when selected. Add mode preserves root project files and existing conflicts by default. Never use `--force` without explicit confirmation.
@@ -147,17 +148,19 @@ Use this path only after the CLI command produces an actual error and retrying d
 
 When falling back, show this notice to the user verbatim (translate to the user's language if needed):
 
-> ℹ️ The manifest-backed template CLI could not complete, so I am using a higher-token fallback path. I will keep template content handling local where possible.
+> ℹ️ The manifest-backed template CLI could not complete, so I am using the public template manifest directly. I will keep template content handling local.
 
 #### B.1 Fallback algorithm
 
-Prefer the first available fallback:
+Prefer the direct manifest path before Azure MCP because the MCP template tool depends on the same manifest:
 
-1. If Azure MCP `functions_template_get` is available, use it only for the selected template after CLI failure. Write returned files directly and avoid echoing their contents in the final response.
-2. Otherwise fetch the public manifest, select the exact entry, and download its repository/folder locally with a ZIP download or shallow clone.
-3. For a new project, use the selected template as the base. For an existing project, copy only the required function/binding files and merge dependencies/settings without replacing user-owned files.
-4. For requests that combine multiple triggers or bindings, use one project template as the base, extract only the additional binding patterns, and merge required IaC resources, RBAC roles, app settings, and dependencies.
-5. If all sources fail, report the exact errors and ask the user to retry later.
+1. Fetch `https://cdn.functions.azure.com/public/templates-manifest/manifest.json`.
+2. If the CDN manifest fails, fetch its raw GitHub mirror at `https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json`.
+3. Select the exact template entry and download its `repositoryUrl` / `folderPath` locally with a ZIP download or shallow clone.
+4. For a new project, use the selected template as the base. For an existing project, copy only the required function/binding files and merge dependencies/settings without replacing user-owned files.
+5. For requests that combine multiple triggers or bindings, use one project template as the base, extract only the additional binding patterns, and merge required IaC resources, RBAC roles, app settings, and dependencies.
+6. Only if direct manifest/repository retrieval fails and Azure MCP `functions_template_get` is available, use it for the selected template. Write returned files directly and avoid echoing their contents in the final response.
+7. If all sources fail, report the exact errors and ask the user to retry later.
 
 Do not deploy automatically as part of creation. Deployment remains the responsibility of **azure-functions-deploy**.
 

--- a/.github/workflows/skill-evaluation-offline.yml
+++ b/.github/workflows/skill-evaluation-offline.yml
@@ -103,7 +103,7 @@ jobs:
         run: npx -y @azure/mcp@latest server --help >/dev/null
 
       - name: Pre-warm Azure Functions Skills CLI cache
-        run: npx -y @azure/functions-skills@0.0.6-preview --version >/dev/null
+        run: npx -y @azure/functions-skills@latest --version >/dev/null
 
       - name: Validate eval specs (vally lint)
         env:

--- a/.github/workflows/skill-evaluation-offline.yml
+++ b/.github/workflows/skill-evaluation-offline.yml
@@ -102,8 +102,18 @@ jobs:
         # and avoids races where the agent answers before the MCP server is ready.
         run: npx -y @azure/mcp@latest server --help >/dev/null
 
+      - name: Pre-warm Azure Functions Skills CLI cache
+        run: npx -y @azure/functions-skills@0.0.6-preview --version >/dev/null
+
       - name: Validate eval specs (vally lint)
-        run: npx vally lint --eval-spec evals
+        env:
+          EVAL_SPEC: ${{ inputs.eval_spec }}
+        run: |
+          if [ -n "${EVAL_SPEC}" ]; then
+            npx vally lint --eval-spec "${EVAL_SPEC}"
+          else
+            npx vally lint --eval-spec evals
+          fi
 
       - name: Run vally eval
         # Token is scoped to this step only (least privilege). The @github/copilot-sdk
@@ -111,6 +121,7 @@ jobs:
         # COPILOT_CLI_TOKEN secret is mapped onto that variable name here.
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           SUITE: ${{ inputs.suite || 'full' }}
           EVAL_SPEC: ${{ inputs.eval_spec }}
           MODEL: ${{ inputs.model }}

--- a/evals/azure-functions-create/eval.yaml
+++ b/evals/azure-functions-create/eval.yaml
@@ -6,9 +6,11 @@ description: |
     - Routing (skill-invocation) for typical "create a function" prompts
       across TypeScript HTTP, Python timer, Go HTTP, and existing-project
       flows.
-    - Response-quality checks that the skill follows Path A (Azure MCP)
-      when available, does not fabricate template IDs, and includes
-      proper local end-to-end verification.
+    - Response-quality checks that the skill uses the manifest-backed
+      Azure Functions Skills CLI, does not fabricate template IDs, keeps
+      template contents out of the transcript, and includes proper local
+      end-to-end verification.
+    - Executable CLI scaffolding checks for both new and existing projects.
     - Go (Path C): Go has no Azure MCP template and no manifest entry,
       so the skill must scaffold with Core Tools or the worker SDK, use
       FUNCTIONS_WORKER_RUNTIME=native, use the lower-case module path,
@@ -18,21 +20,17 @@ description: |
     - "Do not re-initialize an existing project" guardrail.
 
   Environment:
-    - Each stimulus attaches the Azure MCP server (`@azure/mcp`) via
-      stdio, scoped to the `functions` namespace. All three Functions
-      tools (`functions_language_list`, `functions_project_get`,
-      `functions_template_get`) are readOnly and require no Azure
-      credentials, so this works in plain CI.
+    - Some stimuli attach the Azure MCP server (`@azure/mcp`) to prove
+      that the skill still prefers the lower-token CLI path when the
+      legacy template-content tool is available.
     - Cold start is slow because `npx -y @azure/mcp@latest` downloads
       the package on first run. Subsequent runs are fast thanks to npm
       cache; CI can pre-warm via `npm install -g @azure/mcp@latest` or
       `npx -y @azure/mcp@latest server --help`.
 
   Notes:
-    - Built-in graders only (skill-invocation / output-contains /
-      output-matches / output-not-matches / completed). We rely on
-      Vally's standard `copilot-sdk` executor; no custom executor tags
-      such as earlyTerminate are used.
+    - Built-in graders only. We rely on Vally's standard `copilot-sdk`
+      executor; no custom executor tags such as earlyTerminate are used.
     - Global graders (`completed`, `no_runtime_failure`) are duplicated
       into each stimulus per evaluate#125. See ../_base/common-graders.yaml.
 
@@ -49,15 +47,16 @@ config:
 scoring:
   threshold: 0.8
   weights:
-    skill-invocation: 2.0
-    tool-calls: 2.0
-    run-command: 2.0
-    file-exists: 1.0
-    file-not-exists: 1.5
-    output-contains: 0.5
-    output-matches: 1.0
-    output-not-matches: 1.5
-    completed: 1.0
+    skill-invocation: 0.15
+    tool-calls: 0.15
+    run-command: 0.15
+    file-exists: 0.075
+    file-not-exists: 0.11
+    file-matches: 0.075
+    output-contains: 0.04
+    output-matches: 0.075
+    output-not-matches: 0.10
+    completed: 0.075
 
 stimuli:
   # ─────────────────────────────────────────────────────────────────
@@ -172,7 +171,7 @@ stimuli:
   # Response quality (tier: full)
   # ─────────────────────────────────────────────────────────────────
 
-  - name: "Quality — uses Azure MCP path when scaffolding TypeScript HTTP"
+  - name: "Quality — uses template CLI when scaffolding TypeScript HTTP"
     prompt: |
       Create a TypeScript Azure Functions project with an HTTP trigger named "hello".
       Walk me through the scaffolding step by step before writing files.
@@ -200,18 +199,29 @@ stimuli:
         config:
           required:
             - azure-functions-create
-      # MCP-first guidance must be mentioned (tool names or "Azure MCP")
+      # The low-token CLI path must be described.
       - type: output-matches
         config:
-          pattern: "(?i)functions_(template|project|language)_(get|list)|Azure MCP"
-      # Must reference a properly-suffixed MCP template ID, not a bare alias
+          pattern: "(?i)(?:@azure/functions-skills(?:@[^\\s]+)?|azure-functions-skills)\\s+template\\s+(?:list|apply)"
+      # Must reference a properly-suffixed manifest template ID, not a bare alias.
       - type: output-matches
         config:
           pattern: "http-trigger-typescript(-azd)?"
+      - type: output-matches
+        config:
+          pattern: "(?i)--mode\\s+new"
+      # Template contents must not be requested through MCP.
+      - type: tool-calls
+        config:
+          disallowed:
+            - name: "functions_template_get"
       # Must NOT invent the bare ".NET-style" alias as the actual template ID
       - type: output-not-matches
         config:
           pattern: "(?<![\\w-])HttpTrigger(?![\\w-])"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)\\bisPerson\\b"
       # Must propose `func start` based verification
       - type: output-contains
         config:
@@ -305,8 +315,194 @@ stimuli:
       # Should reference the "add to existing project" path
       - type: output-matches
         config:
-          pattern: "(?i)existing project|functions_template_get|add (a |the |new )?(function|trigger)"
+          pattern: "(?i)--mode\\s+add|existing project|add (a |the |new )?(function|trigger)"
+      - type: output-matches
+        config:
+          pattern: "(?i)(?:@azure/functions-skills(?:@[^\\s]+)?|azure-functions-skills)\\s+template\\s+apply"
+      - type: tool-calls
+        config:
+          disallowed:
+            - name: "functions_template_get"
       # Globals
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  # ─────────────────────────────────────────────────────────────────
+  # Executable template CLI E2E
+  # ─────────────────────────────────────────────────────────────────
+
+  - name: "Execution — template CLI scaffolds a new TypeScript project"
+    prompt: |
+      Create a new TypeScript Azure Functions project with an HTTP trigger
+      directly in the current directory. Actually discover the template and
+      apply it, then install dependencies and build the project. Do not only
+      describe commands: run them and report whether the build succeeded.
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: full
+      cost: llm
+      area: e2e-scaffold
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
+    constraints:
+      max_turns: 30
+      max_duration: "15m"
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      - name: template_list_ran
+        type: tool-calls
+        config:
+          required:
+            - name: "^(bash|powershell|run)$"
+              command: "(?i)(?:@azure/functions-skills(?:@[^\\s]+)?|azure-functions-skills)\\s+template\\s+list\\b[^\\n|;&]*--language\\s+['\"]?typescript\\b"
+      - name: template_apply_new_ran
+        type: tool-calls
+        config:
+          required:
+            - name: "^(bash|powershell|run)$"
+              command: "(?i)(?:@azure/functions-skills(?:@[^\\s]+)?|azure-functions-skills)\\s+template\\s+apply\\b(?=[^\\n|;&]*--template\\s+['\"]?http-trigger-typescript-azd['\"]?)(?=[^\\n|;&]*--mode\\s+new\\b)"
+      - type: tool-calls
+        config:
+          disallowed:
+            - name: "functions_template_get"
+      - name: new_project_host_written
+        type: file-exists
+        config:
+          path: host.json
+      - name: new_project_function_written
+        type: file-exists
+        config:
+          path: src/functions/httpGetFunction.ts
+      - name: new_project_compiles
+        type: run-command
+        config:
+          command: npm
+          args: ["run", "build"]
+          expected_exit_code: 0
+          timeout: "5m"
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|crashed|panic:"
+
+  - name: "Execution — template CLI adds to an existing TypeScript project"
+    prompt: |
+      This directory already contains an Azure Functions TypeScript project.
+      Add the official TypeScript HTTP trigger template to it without
+      re-initializing the project or replacing user-owned files. Actually run
+      template discovery and application in add mode, install dependencies,
+      and build the resulting project.
+    tags:
+      type: integration
+      skill: azure-functions-create
+      tier: full
+      cost: llm
+      area: e2e-scaffold
+    environment:
+      skills:
+        - ../../templates/skills/azure-functions-create
+        - ../../templates/skills/azure-functions-common
+        - ../../templates/skills/azure-functions-setup
+      mcpServers:
+        azure:
+          type: stdio
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start", "--namespace", "functions"]
+          timeout: "120s"
+      files:
+        - src: fixtures/existing-project/host.json
+          dest: host.json
+        - src: fixtures/existing-project/package.json
+          dest: package.json
+        - src: fixtures/existing-project/tsconfig.json
+          dest: tsconfig.json
+        - src: fixtures/existing-project/user-owned.txt
+          dest: user-owned.txt
+    constraints:
+      max_turns: 30
+      max_duration: "15m"
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-functions-create
+      - name: template_list_for_add_ran
+        type: tool-calls
+        config:
+          required:
+            - name: "^(bash|powershell|run)$"
+              command: "(?i)(?:@azure/functions-skills(?:@[^\\s]+)?|azure-functions-skills)\\s+template\\s+list\\b[^\\n|;&]*--language\\s+['\"]?typescript\\b"
+      - name: template_apply_add_ran
+        type: tool-calls
+        config:
+          required:
+            - name: "^(bash|powershell|run)$"
+              command: "(?i)(?:@azure/functions-skills(?:@[^\\s]+)?|azure-functions-skills)\\s+template\\s+apply\\b(?=[^\\n|;&]*--template\\s+['\"]?http-trigger-typescript-azd['\"]?)(?=[^\\n|;&]*--mode\\s+add\\b)"
+      - type: tool-calls
+        config:
+          disallowed:
+            - name: "functions_template_get"
+            - name: "^(bash|powershell|run)$"
+              command: "(?i)\\bfunc\\s+init\\b"
+            - name: "^(bash|powershell|run)$"
+              command: "(?i)(?:@azure/functions-skills(?:@[^\\s]+)?|azure-functions-skills)\\s+template\\s+apply\\b[^\\n|;&]*--force\\b"
+      - name: existing_host_preserved
+        type: file-matches
+        config:
+          path: host.json
+          pattern: "\"version\"\\s*:\\s*\"2\\.0\""
+      - name: user_file_preserved
+        type: file-matches
+        config:
+          path: user-owned.txt
+          pattern: "^user-owned\\s*$"
+      - name: existing_package_preserved
+        type: file-matches
+        config:
+          path: package.json
+          pattern: "\"name\"\\s*:\\s*\"existing-functions-project\""
+      - name: existing_project_not_reinitialized
+        type: file-not-exists
+        config:
+          path: azure.yaml
+      - name: existing_infra_not_added
+        type: file-not-exists
+        config:
+          path: infra/main.bicep
+      - name: template_license_not_added
+        type: file-not-exists
+        config:
+          path: LICENSE.md
+      - name: unrelated_demo_function_not_added
+        type: file-not-exists
+        config:
+          path: src/functions/httpPostBodyFunction.ts
+      - name: added_function_written
+        type: file-exists
+        config:
+          path: src/functions/httpGetFunction.ts
+      - name: existing_project_compiles
+        type: run-command
+        config:
+          command: npm
+          args: ["run", "build"]
+          expected_exit_code: 0
+          timeout: "5m"
       - type: completed
       - type: output-not-matches
         config:

--- a/evals/azure-functions-create/fixtures/existing-project/tsconfig.json
+++ b/evals/azure-functions-create/fixtures/existing-project/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "target": "ES2022",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": ".",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/evals/azure-functions-create/fixtures/existing-project/user-owned.txt
+++ b/evals/azure-functions-create/fixtures/existing-project/user-owned.txt
@@ -1,0 +1,1 @@
+user-owned

--- a/reports/e2e/current/report.html
+++ b/reports/e2e/current/report.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Azure Functions Skills E2E Report — 20260820-0821</title>
+<title>Azure Functions Skills E2E Report — 20260820-2243</title>
 <style>
 :root { color-scheme: light dark; --bd:#d0d7de; --mut:#57606a; --ok:#1a7f37; --bad:#cf222e; --bg:#ffffff; --panel:#f6f8fa; --fg:#1f2328; }
 @media (prefers-color-scheme: dark) { :root { --bd:#30363d; --mut:#8b949e; --ok:#3fb950; --bad:#f85149; --bg:#0d1117; --panel:#161b22; --fg:#e6edf3; } }
@@ -41,16 +41,16 @@ footer { margin-top:32px; color:var(--mut); font-size:0.8rem; border-top:1px sol
 </head>
 <body>
 <h1>Azure Functions Skills — Local Install/Update E2E Report</h1>
-<p class="muted">Run <code>20260820-0821</code> &middot; generated 2026-08-20T08:27:32.0552852Z</p>
+<p class="muted">Run <code>20260820-2243</code> &middot; generated 2026-08-20T22:48:10.5957603Z</p>
 
 <table class="grid">
 <tbody>
-<tr><th>Run ID</th><td><code>20260820-0821</code></td><th>Package version</th><td><code>0.0.6-preview</code></td></tr>
-<tr><th>Platform</th><td>windows (PowerShell 7, Node v24.18.1)</td><th>Git commit</th><td><code>b71d1a4</code></td></tr>
-<tr><th>Run started (UTC)</th><td><code>2026-08-20T08:23:16.9055034Z</code></td><th>Run completed (UTC)</th><td><code>2026-08-20T08:27:20.8740110Z</code></td></tr>
-<tr><th>Report generated (UTC)</th><td colspan="3"><code>2026-08-20T08:27:32.0552852Z</code></td></tr>
+<tr><th>Run ID</th><td><code>20260820-2243</code></td><th>Package version</th><td><code>0.0.6-preview</code></td></tr>
+<tr><th>Platform</th><td>windows (PowerShell 7, Node v24.18.1)</td><th>Git commit</th><td><code>5354651</code></td></tr>
+<tr><th>Run started (UTC)</th><td><code>2026-08-20T22:43:43.2446013Z</code></td><th>Run completed (UTC)</th><td><code>2026-08-20T22:47:44.0045661Z</code></td></tr>
+<tr><th>Report generated (UTC)</th><td colspan="3"><code>2026-08-20T22:48:10.5957603Z</code></td></tr>
 <tr><th>Command source</th><td colspan="3"><code>.github/skills/azure-functions-e2e-tests/references/commands.md</code></td></tr>
-<tr><th>Workspace root</th><td colspan="3"><code>reports/e2e/20260820-0821/workspaces/&lt;test-case-id&gt;</code></td></tr>
+<tr><th>Workspace root</th><td colspan="3"><code>reports/e2e/20260820-2243/workspaces/&lt;test-case-id&gt;</code></td></tr>
 <tr><th>Execution model</th><td colspan="3">Each numbered command ran individually, in order, in its own PowerShell process with cwd = repository root. POSIX shell syntax was translated to PowerShell only (per commands.md); every body uses <code>$ErrorActionPreference = 'Stop'</code> with a trap so any failed step exits non-zero, matching <code>&amp;&amp;</code> chain semantics. No commands were batched, simplified, or supplemented.</td></tr>
 </tbody>
 </table>
@@ -82,20 +82,20 @@ footer { margin-top:32px; color:var(--mut); font-size:0.8rem; border-top:1px sol
 <details class="case" open>
 <summary><span class="badge ok">PASS</span> <strong>PREFLIGHT</strong> <span class="muted">agent=- · mode=local · 2 commands</span></summary>
 <div class="casebody">
-<p class="kv"><strong>Started:</strong> 2026-08-20T08:23:16.9055034Z &middot; <strong>Completed:</strong> 2026-08-20T08:23:24.8581559Z</p>
+<p class="kv"><strong>Started:</strong> 2026-08-20T22:43:43.2446013Z &middot; <strong>Completed:</strong> 2026-08-20T22:43:50.1982234Z</p>
 <p class="analysis">CLI reports version 0.0.6-preview and help lists install --local and update --local with no chat or setup command.</p>
 
 <h4>Command evidence</h4>
 <details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>PF-1</code> <span class="muted">$CLI --version</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:16.9055034Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:43:43.2446013Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -130,13 +130,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>PF-2</code> <span class="muted">$CLI --help</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:24.1875098Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:43:49.4661107Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -184,7 +184,7 @@ Plugin installation is managed by the host coding agent, not this package.</pre>
 <details class="case" open>
 <summary><span class="badge ok">PASS</span> <strong>TC-S1-GHCP-LOCAL</strong> <span class="muted">agent=ghcp · mode=local · 5 commands</span></summary>
 <div class="casebody">
-<p class="kv"><strong>Started:</strong> 2026-08-20T08:23:30.3149941Z &middot; <strong>Completed:</strong> 2026-08-20T08:23:57.8967418Z</p>
+<p class="kv"><strong>Started:</strong> 2026-08-20T22:43:55.7870693Z &middot; <strong>Completed:</strong> 2026-08-20T22:44:23.2843236Z</p>
 <p class="analysis">Fresh local install produced 88 files limited to .github/skills, .mcp.json, and .github/hooks telemetry assets. No legacy state, generated AGENTS.md, agent definitions, or welcome hook.</p>
 <h4>File verification</h4>
 <table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
@@ -201,13 +201,13 @@ Plugin installation is managed by the host coding agent, not this package.</pre>
 <details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1GL-1</code> <span class="muted">mkdir -p $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:30.3149941Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:43:55.7870693Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -230,7 +230,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL'
 New-Item -ItemType Directory -Force -Path $WS | Out-Null
 exit 0
 </pre>
@@ -243,13 +243,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1GL-2</code> <span class="muted">$CLI install --local --agent ghcp --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:36.1068826Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:01.6082937Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -272,7 +272,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL'
 &amp; $CLI[0] $CLI[1] install --local --agent ghcp --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -287,13 +287,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1GL-3</code> <span class="muted">find $WS -type f | sort</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:44.4796374Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:10.1639807Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -316,7 +316,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL'
 $files = [string[]](Get-ChildItem -LiteralPath $WS -Recurse -File -Force | ForEach-Object { $_.FullName })
 $cmp = [System.Comparison[string]]{ param([string]$x, [string]$y)
     $bx = [Text.Encoding]::UTF8.GetBytes($x); $by = [Text.Encoding]::UTF8.GetBytes($y)
@@ -330,107 +330,107 @@ exit 0
 </pre>
 <p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\telemetry.config.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-setup\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.mcp.json</pre>
+<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\telemetry.config.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-setup\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL\.mcp.json</pre>
 <p class="kv"><strong>stderr:</strong></p>
 <pre>(empty)</pre>
 </div>
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1GL-4</code> <span class="muted">test -f $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.mcp.json &amp;&amp; test -f $WS/.github/hooks/azure-functions-telemetry.json &amp;&amp; test -f $WS/.github/hooks/scripts/track-telemetry.sh</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:50.6265338Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:16.4131614Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -453,7 +453,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL'
 foreach ($rel in @('.github\skills\azure-functions-help\SKILL.md', '.mcp.json', '.github\hooks\azure-functions-telemetry.json', '.github\hooks\scripts\track-telemetry.sh')) {
     $p = Join-Path $WS $rel
     if (-not (Test-Path -LiteralPath $p -PathType Leaf)) { Fail "test -f failed: $p" }
@@ -473,13 +473,13 @@ ok file: .github\hooks\scripts\track-telemetry.sh</pre>
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1GL-5</code> <span class="muted">test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.github/agents &amp;&amp; test ! -e $WS/.github/hooks/welcome-setup.json</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:57.2753855Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:22.6533461Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -502,7 +502,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-GHCP-LOCAL'
 foreach ($rel in @('.azure-functions-skills', 'AGENTS.md', '.github\agents', '.github\hooks\welcome-setup.json')) {
     $p = Join-Path $WS $rel
     if (Test-Path -LiteralPath $p) { Fail "test ! -e failed: $p" }
@@ -525,7 +525,7 @@ ok absent: .github\hooks\welcome-setup.json</pre>
 <details class="case" open>
 <summary><span class="badge ok">PASS</span> <strong>TC-S1-CLAUDE-LOCAL</strong> <span class="muted">agent=claude · mode=local · 5 commands</span></summary>
 <div class="casebody">
-<p class="kv"><strong>Started:</strong> 2026-08-20T08:24:03.1760831Z &middot; <strong>Completed:</strong> 2026-08-20T08:24:30.9768775Z</p>
+<p class="kv"><strong>Started:</strong> 2026-08-20T22:44:28.9663822Z &middot; <strong>Completed:</strong> 2026-08-20T22:44:56.8362551Z</p>
 <p class="analysis">Fresh local install produced 88 files limited to .claude/skills, .claude/settings.json, and .claude/hooks telemetry assets. No legacy state, CLAUDE.md, or agent definitions.</p>
 <h4>File verification</h4>
 <table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
@@ -541,13 +541,13 @@ ok absent: .github\hooks\welcome-setup.json</pre>
 <details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1CL-1</code> <span class="muted">mkdir -p $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:03.1760831Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:28.9663822Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -570,7 +570,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL'
 New-Item -ItemType Directory -Force -Path $WS | Out-Null
 exit 0
 </pre>
@@ -583,13 +583,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1CL-2</code> <span class="muted">$CLI install --local --agent claude --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:09.9961934Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:35.1911249Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -612,7 +612,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL'
 &amp; $CLI[0] $CLI[1] install --local --agent claude --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -627,13 +627,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1CL-3</code> <span class="muted">find $WS -type f | sort</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:18.4280343Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:44.1756934Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -656,7 +656,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL'
 $files = [string[]](Get-ChildItem -LiteralPath $WS -Recurse -File -Force | ForEach-Object { $_.FullName })
 $cmp = [System.Comparison[string]]{ param([string]$x, [string]$y)
     $bx = [Text.Encoding]::UTF8.GetBytes($x); $by = [Text.Encoding]::UTF8.GetBytes($y)
@@ -670,107 +670,107 @@ exit 0
 </pre>
 <p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-setup\SKILL.md</pre>
+<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-setup\SKILL.md</pre>
 <p class="kv"><strong>stderr:</strong></p>
 <pre>(empty)</pre>
 </div>
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1CL-4</code> <span class="muted">test -f $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.claude/settings.json &amp;&amp; test -f $WS/.claude/hooks/hooks.json &amp;&amp; test -f $WS/.claude/hooks/scripts/track-telemetry.sh</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:24.4592320Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:50.0499823Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -793,7 +793,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL'
 foreach ($rel in @('.claude\skills\azure-functions-help\SKILL.md', '.claude\settings.json', '.claude\hooks\hooks.json', '.claude\hooks\scripts\track-telemetry.sh')) {
     $p = Join-Path $WS $rel
     if (-not (Test-Path -LiteralPath $p -PathType Leaf)) { Fail "test -f failed: $p" }
@@ -813,13 +813,13 @@ ok file: .claude\hooks\scripts\track-telemetry.sh</pre>
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1CL-5</code> <span class="muted">test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/CLAUDE.md &amp;&amp; test ! -e $WS/.claude/agents</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:30.3135672Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:44:56.1923985Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -842,7 +842,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CLAUDE-LOCAL'
 foreach ($rel in @('.azure-functions-skills', 'CLAUDE.md', '.claude\agents')) {
     $p = Join-Path $WS $rel
     if (Test-Path -LiteralPath $p) { Fail "test ! -e failed: $p" }
@@ -864,7 +864,7 @@ ok absent: .claude\agents</pre>
 <details class="case" open>
 <summary><span class="badge ok">PASS</span> <strong>TC-S1-CODEX-LOCAL</strong> <span class="muted">agent=codex · mode=local · 5 commands</span></summary>
 <div class="casebody">
-<p class="kv"><strong>Started:</strong> 2026-08-20T08:24:36.1613139Z &middot; <strong>Completed:</strong> 2026-08-20T08:25:02.6163780Z</p>
+<p class="kv"><strong>Started:</strong> 2026-08-20T22:45:01.9867816Z &middot; <strong>Completed:</strong> 2026-08-20T22:45:28.3347210Z</p>
 <p class="analysis">Fresh local install produced 88 files limited to .agents/skills, .codex/config.toml, and .codex/hooks telemetry assets. No legacy state, AGENTS.md, or agent definitions.</p>
 <h4>File verification</h4>
 <table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
@@ -880,13 +880,13 @@ ok absent: .claude\agents</pre>
 <details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1XL-1</code> <span class="muted">mkdir -p $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:36.1613139Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:01.9867816Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -909,7 +909,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL'
 New-Item -ItemType Directory -Force -Path $WS | Out-Null
 exit 0
 </pre>
@@ -922,13 +922,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1XL-2</code> <span class="muted">$CLI install --local --agent codex --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:41.8675874Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:08.1185075Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -951,7 +951,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL'
 &amp; $CLI[0] $CLI[1] install --local --agent codex --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -966,13 +966,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1XL-3</code> <span class="muted">find $WS -type f | sort</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:50.2954812Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:16.1562532Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -995,7 +995,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL'
 $files = [string[]](Get-ChildItem -LiteralPath $WS -Recurse -File -Force | ForEach-Object { $_.FullName })
 $cmp = [System.Comparison[string]]{ param([string]$x, [string]$y)
     $bx = [Text.Encoding]::UTF8.GetBytes($x); $by = [Text.Encoding]::UTF8.GetBytes($y)
@@ -1009,107 +1009,107 @@ exit 0
 </pre>
 <p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-setup\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\telemetry.config.json</pre>
+<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-setup\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\telemetry.config.json</pre>
 <p class="kv"><strong>stderr:</strong></p>
 <pre>(empty)</pre>
 </div>
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1XL-4</code> <span class="muted">test -f $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.codex/config.toml &amp;&amp; test -f $WS/.codex/hooks.json &amp;&amp; test -f $WS/.codex/hooks/scripts/track-telemetry.sh</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:56.1746354Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:21.8181309Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1132,7 +1132,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL'
 foreach ($rel in @('.agents\skills\azure-functions-help\SKILL.md', '.codex\config.toml', '.codex\hooks.json', '.codex\hooks\scripts\track-telemetry.sh')) {
     $p = Join-Path $WS $rel
     if (-not (Test-Path -LiteralPath $p -PathType Leaf)) { Fail "test -f failed: $p" }
@@ -1152,13 +1152,13 @@ ok file: .codex\hooks\scripts\track-telemetry.sh</pre>
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S1XL-5</code> <span class="muted">test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.agents/agents</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:01.9627641Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:27.6586720Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1181,7 +1181,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S1-CODEX-LOCAL'
 foreach ($rel in @('.azure-functions-skills', 'AGENTS.md', '.agents\agents')) {
     $p = Join-Path $WS $rel
     if (Test-Path -LiteralPath $p) { Fail "test ! -e failed: $p" }
@@ -1203,7 +1203,7 @@ ok absent: .agents\agents</pre>
 <details class="case" open>
 <summary><span class="badge ok">PASS</span> <strong>TC-S2-GHCP-LOCAL</strong> <span class="muted">agent=ghcp · mode=local · 7 commands</span></summary>
 <div class="casebody">
-<p class="kv"><strong>Started:</strong> 2026-08-20T08:25:07.8445768Z &middot; <strong>Completed:</strong> 2026-08-20T08:25:47.7913704Z</p>
+<p class="kv"><strong>Started:</strong> 2026-08-20T22:45:33.4090541Z &middot; <strong>Completed:</strong> 2026-08-20T22:46:13.4563745Z</p>
 <p class="analysis">Update replaced the stale bundled skill, preserved the user-owned skill, hook script, and custom MCP server, merged the azure MCP server, migrated the legacy telemetry opt-out into .github/hooks/telemetry.config.json, and removed legacy state, the legacy agent file, and the managed AGENTS.md block.</p>
 <h4>File verification</h4>
 <table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
@@ -1220,13 +1220,13 @@ ok absent: .agents\agents</pre>
 <details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2GL-1</code> <span class="muted">mkdir -p $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:07.8445768Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:33.4090541Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1249,7 +1249,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-GHCP-LOCAL'
 New-Item -ItemType Directory -Force -Path $WS | Out-Null
 exit 0
 </pre>
@@ -1262,13 +1262,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2GL-2</code> <span class="muted">$CLI install --local --agent ghcp --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:13.7063450Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:39.2984807Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1291,7 +1291,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-GHCP-LOCAL'
 &amp; $CLI[0] $CLI[1] install --local --agent ghcp --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -1306,13 +1306,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2GL-3</code> <span class="muted">printf 'stale bundled\n' &gt; $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.github/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/skills/azure-functions-internal-runbook/SKILL.md</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:21.6130873Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:47.3714272Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1335,7 +1335,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-GHCP-LOCAL'
 [IO.File]::WriteAllText((Join-Path $WS '.github\skills\azure-functions-help\SKILL.md'), "stale bundled`n")
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.github\skills\azure-functions-internal-runbook') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.github\skills\azure-functions-internal-runbook\SKILL.md'), "user-owned`n")
@@ -1350,13 +1350,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2GL-4</code> <span class="muted">mkdir -p $WS/.github/hooks/scripts &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/hooks/scripts/custom-hook.sh &amp;&amp; printf '{"inputs":[{"id":"subscription"}],"mcpServers":{"custom":{"command":"custom-server","args":[]}}}\n' &gt; $WS/.mcp.json</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:27.3983623Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:53.0433325Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1379,7 +1379,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-GHCP-LOCAL'
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.github\hooks\scripts') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.github\hooks\scripts\custom-hook.sh'), "user-owned`n")
 [IO.File]::WriteAllText((Join-Path $WS '.mcp.json'), '{"inputs":[{"id":"subscription"}],"mcpServers":{"custom":{"command":"custom-server","args":[]}}}' + "`n")
@@ -1394,13 +1394,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2GL-5</code> <span class="muted">mkdir -p $WS/.azure-functions-skills $WS/.github/agents &amp;&amp; printf '{"telemetry":{"enabled":false}}\n' &gt; $WS/.azure-functions-skills/state.local.json &amp;&amp; printf 'legacy\n' &gt; $WS/.github/agents/functions-copilot.agent.md &amp;&amp; printf 'customer\n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;\nlegacy routing\n&lt;!-- azure-functions-skills:end --&gt;\n' &gt; $WS/AGENTS.md</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:33.2270152Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:45:59.0334081Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1423,7 +1423,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-GHCP-LOCAL'
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.azure-functions-skills'), (Join-Path $WS '.github\agents') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.azure-functions-skills\state.local.json'), '{"telemetry":{"enabled":false}}' + "`n")
 [IO.File]::WriteAllText((Join-Path $WS '.github\agents\functions-copilot.agent.md'), "legacy`n")
@@ -1439,13 +1439,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2GL-6</code> <span class="muted">$CLI update --local --agent ghcp --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:39.0706181Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:04.8116157Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1468,7 +1468,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-GHCP-LOCAL'
 &amp; $CLI[0] $CLI[1] update --local --agent ghcp --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -1483,13 +1483,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2GL-7</code> <span class="muted">test -f $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; test "$(cat $WS/.github/skills/azure-functions-internal-runbook/SKILL.md)" = "user-owned" &amp;&amp; test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/.github/agents/functions-copilot.agent.md &amp;&amp; test "$(cat $WS/AGENTS.md)" = "customer" &amp;&amp; test "$(cat $WS/.github/hooks/scripts/custom-hook.sh)" = "user-owned" &amp;&amp; node -e "const fs=require('fs');const m=JSON.parse(fs.readFileSync('$WS/.mcp.json'));const t=JSON.parse(fs.readFileSync('$WS/.github/hooks/telemetry.config.json'));if(m.mcpServers.custom.command!=='custom-server'||m.mcpServers.azure.command!=='npx'||t.enabled!==false)process.exit(1)"</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:46.9813639Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:12.6360588Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1512,7 +1512,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-GHCP-LOCAL'
 $fwd = $WS -replace '\\', '/'
 if (-not (Test-Path -LiteralPath (Join-Path $WS '.github\skills\azure-functions-help\SKILL.md') -PathType Leaf)) { Fail 'missing refreshed bundled skill' }
 if ((GrepQ (Join-Path $WS '.github\skills\azure-functions-help\SKILL.md') 'stale bundled') -eq 0) { Fail 'stale bundled content survived' }
@@ -1539,7 +1539,7 @@ exit 0
 <details class="case" open>
 <summary><span class="badge ok">PASS</span> <strong>TC-S2-CLAUDE-LOCAL</strong> <span class="muted">agent=claude · mode=local · 7 commands</span></summary>
 <div class="casebody">
-<p class="kv"><strong>Started:</strong> 2026-08-20T08:25:53.2890642Z &middot; <strong>Completed:</strong> 2026-08-20T08:26:34.4165309Z</p>
+<p class="kv"><strong>Started:</strong> 2026-08-20T22:46:19.1141427Z &middot; <strong>Completed:</strong> 2026-08-20T22:46:59.8670320Z</p>
 <p class="analysis">Update replaced the stale bundled skill, preserved user-owned skill, hook, permissions, and custom MCP server, kept both custom and telemetry hooks in settings.json, migrated the telemetry opt-out, and removed legacy state and the managed CLAUDE.md block.</p>
 <h4>File verification</h4>
 <table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
@@ -1555,13 +1555,13 @@ exit 0
 <details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2CL-1</code> <span class="muted">mkdir -p $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:53.2890642Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:19.1141427Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1584,7 +1584,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CLAUDE-LOCAL'
 New-Item -ItemType Directory -Force -Path $WS | Out-Null
 exit 0
 </pre>
@@ -1597,13 +1597,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2CL-2</code> <span class="muted">$CLI install --local --agent claude --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:59.0792394Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:25.2675577Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1626,7 +1626,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CLAUDE-LOCAL'
 &amp; $CLI[0] $CLI[1] install --local --agent claude --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -1641,13 +1641,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2CL-3</code> <span class="muted">printf 'stale bundled\n' &gt; $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.claude/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.claude/skills/azure-functions-internal-runbook/SKILL.md</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:07.2316711Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:33.6554819Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1670,7 +1670,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CLAUDE-LOCAL'
 [IO.File]::WriteAllText((Join-Path $WS '.claude\skills\azure-functions-help\SKILL.md'), "stale bundled`n")
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.claude\skills\azure-functions-internal-runbook') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.claude\skills\azure-functions-internal-runbook\SKILL.md'), "user-owned`n")
@@ -1685,13 +1685,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2CL-4</code> <span class="muted">mkdir -p $WS/.claude/hooks &amp;&amp; printf 'user-owned\n' &gt; $WS/.claude/hooks/custom-hook.json &amp;&amp; printf '{"permissions":{"allow":["Read"]},"mcpServers":{"custom":{"command":"custom-server","args":[]}},"hooks":{"PostToolUse":[{"hooks":[{"type":"command","command":"custom-hook"}]}]}}\n' &gt; $WS/.claude/settings.json</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:13.0812090Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:39.2696446Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1714,7 +1714,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CLAUDE-LOCAL'
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.claude\hooks') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.claude\hooks\custom-hook.json'), "user-owned`n")
 [IO.File]::WriteAllText((Join-Path $WS '.claude\settings.json'), '{"permissions":{"allow":["Read"]},"mcpServers":{"custom":{"command":"custom-server","args":[]}},"hooks":{"PostToolUse":[{"hooks":[{"type":"command","command":"custom-hook"}]}]}}' + "`n")
@@ -1729,13 +1729,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2CL-5</code> <span class="muted">mkdir -p $WS/.azure-functions-skills &amp;&amp; printf '{"telemetry":{"enabled":false}}\n' &gt; $WS/.azure-functions-skills/state.local.json &amp;&amp; printf 'customer\n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;\nlegacy routing\n&lt;!-- azure-functions-skills:end --&gt;\n' &gt; $WS/CLAUDE.md</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:19.3699323Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:45.1434819Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1758,7 +1758,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CLAUDE-LOCAL'
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.azure-functions-skills') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.azure-functions-skills\state.local.json'), '{"telemetry":{"enabled":false}}' + "`n")
 [IO.File]::WriteAllText((Join-Path $WS 'CLAUDE.md'), "customer`n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;`nlegacy routing`n&lt;!-- azure-functions-skills:end --&gt;`n")
@@ -1773,13 +1773,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2CL-6</code> <span class="muted">$CLI update --local --agent claude --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:25.3924073Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:50.8058192Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1802,7 +1802,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CLAUDE-LOCAL'
 &amp; $CLI[0] $CLI[1] update --local --agent claude --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -1817,13 +1817,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2CL-7</code> <span class="muted">test -f $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; test "$(cat $WS/.claude/skills/azure-functions-internal-runbook/SKILL.md)" = "user-owned" &amp;&amp; test ! -e $WS/.azure-functions-skills &amp;&amp; test "$(cat $WS/CLAUDE.md)" = "customer" &amp;&amp; test "$(cat $WS/.claude/hooks/custom-hook.json)" = "user-owned" &amp;&amp; node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync('$WS/.claude/settings.json'));const t=JSON.parse(fs.readFileSync('$WS/.claude/hooks/telemetry.config.json'));if(s.permissions.allow[0]!=='Read'||s.mcpServers.custom.command!=='custom-server'||s.mcpServers.azure.command!=='npx'||!JSON.stringify(s.hooks).includes('custom-hook')||!JSON.stringify(s.hooks).includes('track-telemetry.sh')||t.enabled!==false)process.exit(1)"</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:33.6446561Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:46:59.0583536Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1846,7 +1846,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CLAUDE-LOCAL'
 $fwd = $WS -replace '\\', '/'
 if (-not (Test-Path -LiteralPath (Join-Path $WS '.claude\skills\azure-functions-help\SKILL.md') -PathType Leaf)) { Fail 'missing refreshed bundled skill' }
 if ((GrepQ (Join-Path $WS '.claude\skills\azure-functions-help\SKILL.md') 'stale bundled') -eq 0) { Fail 'stale bundled content survived' }
@@ -1872,7 +1872,7 @@ exit 0
 <details class="case" open>
 <summary><span class="badge ok">PASS</span> <strong>TC-S2-CODEX-LOCAL</strong> <span class="muted">agent=codex · mode=local · 7 commands</span></summary>
 <div class="casebody">
-<p class="kv"><strong>Started:</strong> 2026-08-20T08:26:40.1437731Z &middot; <strong>Completed:</strong> 2026-08-20T08:27:20.8740110Z</p>
+<p class="kv"><strong>Started:</strong> 2026-08-20T22:47:04.9918233Z &middot; <strong>Completed:</strong> 2026-08-20T22:47:44.0045661Z</p>
 <p class="analysis">Update replaced the stale bundled skill, preserved user-owned skill, hook, custom TOML model and MCP server, refreshed the azure MCP server to npx while dropping old-azure, kept custom and telemetry hooks, migrated the telemetry opt-out, and removed legacy state and the managed AGENTS.md block.</p>
 <h4>File verification</h4>
 <table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
@@ -1888,13 +1888,13 @@ exit 0
 <details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2XL-1</code> <span class="muted">mkdir -p $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:40.1437731Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:47:04.9918233Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1917,7 +1917,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CODEX-LOCAL'
 New-Item -ItemType Directory -Force -Path $WS | Out-Null
 exit 0
 </pre>
@@ -1930,13 +1930,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2XL-2</code> <span class="muted">$CLI install --local --agent codex --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:46.2193115Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:47:10.4714283Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -1959,7 +1959,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CODEX-LOCAL'
 &amp; $CLI[0] $CLI[1] install --local --agent codex --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -1974,13 +1974,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2XL-3</code> <span class="muted">printf 'stale bundled\n' &gt; $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.agents/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.agents/skills/azure-functions-internal-runbook/SKILL.md</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:54.1442578Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:47:18.1530011Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -2003,7 +2003,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CODEX-LOCAL'
 [IO.File]::WriteAllText((Join-Path $WS '.agents\skills\azure-functions-help\SKILL.md'), "stale bundled`n")
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.agents\skills\azure-functions-internal-runbook') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.agents\skills\azure-functions-internal-runbook\SKILL.md'), "user-owned`n")
@@ -2018,13 +2018,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2XL-4</code> <span class="muted">mkdir -p $WS/.codex/hooks &amp;&amp; printf 'user-owned\n' &gt; $WS/.codex/hooks/custom-hook.json &amp;&amp; printf '{"hooks":{"PostToolUse":[{"type":"command","command":"custom-hook"}]}}\n' &gt; $WS/.codex/hooks.json &amp;&amp; printf 'model = "gpt-test"\n\n[mcp_servers.custom]\ncommand = "custom-server"\n\n[mcp_servers.azure]\ncommand = "old-azure"\n' &gt; $WS/.codex/config.toml</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:00.0878895Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:47:23.7971766Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -2047,7 +2047,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CODEX-LOCAL'
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.codex\hooks') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.codex\hooks\custom-hook.json'), "user-owned`n")
 [IO.File]::WriteAllText((Join-Path $WS '.codex\hooks.json'), '{"hooks":{"PostToolUse":[{"type":"command","command":"custom-hook"}]}}' + "`n")
@@ -2064,13 +2064,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2XL-5</code> <span class="muted">mkdir -p $WS/.azure-functions-skills &amp;&amp; printf '{"telemetry":{"enabled":false}}\n' &gt; $WS/.azure-functions-skills/state.local.json &amp;&amp; printf 'customer\n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;\nlegacy routing\n&lt;!-- azure-functions-skills:end --&gt;\n' &gt; $WS/AGENTS.md</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:05.9275845Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:47:29.6123007Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -2093,7 +2093,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CODEX-LOCAL'
 New-Item -ItemType Directory -Force -Path (Join-Path $WS '.azure-functions-skills') | Out-Null
 [IO.File]::WriteAllText((Join-Path $WS '.azure-functions-skills\state.local.json'), '{"telemetry":{"enabled":false}}' + "`n")
 [IO.File]::WriteAllText((Join-Path $WS 'AGENTS.md'), "customer`n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;`nlegacy routing`n&lt;!-- azure-functions-skills:end --&gt;`n")
@@ -2108,13 +2108,13 @@ exit 0
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2XL-6</code> <span class="muted">$CLI update --local --agent codex --dir $WS</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:11.8133899Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:47:35.2662057Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -2137,7 +2137,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CODEX-LOCAL'
 &amp; $CLI[0] $CLI[1] update --local --agent codex --dir $WS
 exit $LASTEXITCODE
 </pre>
@@ -2152,13 +2152,13 @@ exit $LASTEXITCODE
 </details><details class="cmd">
 <summary><span class="badge ok">exit 0</span> <code>S2XL-7</code> <span class="muted">test -f $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; test "$(cat $WS/.agents/skills/azure-functions-internal-runbook/SKILL.md)" = "user-owned" &amp;&amp; test ! -e $WS/.azure-functions-skills &amp;&amp; test "$(cat $WS/AGENTS.md)" = "customer" &amp;&amp; test "$(cat $WS/.codex/hooks/custom-hook.json)" = "user-owned" &amp;&amp; grep -q 'model = "gpt-test"' $WS/.codex/config.toml &amp;&amp; grep -q '\[mcp_servers.custom\]' $WS/.codex/config.toml &amp;&amp; grep -q 'command = "npx"' $WS/.codex/config.toml &amp;&amp; ! grep -q 'old-azure' $WS/.codex/config.toml &amp;&amp; node -e "const fs=require('fs');const h=JSON.parse(fs.readFileSync('$WS/.codex/hooks.json'));const t=JSON.parse(fs.readFileSync('$WS/.codex/hooks/telemetry.config.json'));if(!JSON.stringify(h.hooks).includes('custom-hook')||!JSON.stringify(h.hooks).includes('track-telemetry.sh')||t.enabled!==false)process.exit(1)"</span></summary>
 <div class="cmdbody">
-<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:20.0387496Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T22:47:43.1726883Z &middot; <strong>exit code:</strong> 0</p>
 <p class="kv"><strong>executed (PowerShell translation):</strong></p>
 <pre>$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
 $REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
-$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243'
 $CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
 function CatBytes([string]$p) {
     $b = [IO.File]::ReadAllBytes($p)
@@ -2181,7 +2181,7 @@ function GrepQ([string]$p, [string]$pattern) {
     return 1
 }
 function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
-$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-2243\workspaces\TC-S2-CODEX-LOCAL'
 $fwd = $WS -replace '\\', '/'
 $toml = Join-Path $WS '.codex\config.toml'
 if (-not (Test-Path -LiteralPath (Join-Path $WS '.agents\skills\azure-functions-help\SKILL.md') -PathType Leaf)) { Fail 'missing refreshed bundled skill' }
@@ -2215,10 +2215,10 @@ exit 0
 
 <h2>Machine-checkable counters</h2>
 <pre>{
-  "runId": "20260820-0821",
+  "runId": "20260820-2243",
   "packageVersion": "0.0.6-preview",
   "platform": "windows",
-  "gitCommit": "b71d1a4",
+  "gitCommit": "5354651",
   "expectedCommandCount": 38,
   "actualCommandCount": 38,
   "missingCommandIds": [],
@@ -2247,40 +2247,36 @@ exit 0
 <h2>Cross-Check Results</h2>
 <div id="crosscheck">
 <table>
-<tr><th>Reviewer model</th><td>gpt-5.6-sol (self-reported: GPT-5.4) &mdash; premium-model rubber-duck agent, read-only</td></tr>
-<tr><th>Cross-check completed (UTC)</th><td>2026-08-20T08:32:20Z</td></tr>
-<tr><th>Verified commands</th><td>38/38</td></tr>
-<tr><th>Missing commands</th><td>none</td></tr>
-<tr><th>Workarounds detected</th><td>none</td></tr>
-<tr><th>Verdict overrides</th><td>none</td></tr>
-<tr><th>Overall result</th><td><span class="badge pass">VALID</span></td></tr>
+<tr><th>Reviewer model</th><td>gpt-5.6-sol (self-reported: GPT-5.4), premium rubber-duck agent, reasoning effort: high</td></tr>
+<tr><th>Verified command count</th><td>38 / 38</td></tr>
+<tr><th>missingCommandIds</th><td><code>[]</code></td></tr>
+<tr><th>workaroundsDetected</th><td><code>[]</code></td></tr>
+<tr><th>verdictOverrides</th><td><code>[]</code></td></tr>
+<tr><th>Overall result</th><td><span class="pass">VALID</span></td></tr>
 </table>
 
 <h3>Reviewer findings</h3>
 <table>
-<tr><th>#</th><th>Area</th><th>Severity</th><th>Finding</th></tr>
-<tr><td>1</td><td>A &mdash; coverage</td><td>non-blocking</td><td>Expected/actual evidence/checklist counts are 38/38; no missing or duplicate IDs.</td></tr>
-<tr><td>2</td><td>B &mdash; ordering</td><td>non-blocking</td><td>Timestamps prove individual, exact-order execution with no overlaps.</td></tr>
-<tr><td>3</td><td>C &mdash; no batching</td><td>non-blocking</td><td>All bodies match the prescribed commands; no batching or supplementation. PF-1's first harness attempt launched no process and produced no evidence; the infrastructure retry does not compromise validity.</td></tr>
-<tr><td>4</td><td>D &mdash; verbatim text</td><td>non-blocking</td><td>Every evidence <code>command</code> exactly matches <code>commands.md</code>.</td></tr>
-<tr><td>5</td><td>E &mdash; translation fidelity</td><td>non-blocking</td><td>Byte comparisons, case-sensitive grep, negation/error semantics, and UTF-8 byte sorting are faithful.</td></tr>
-<tr><td>6</td><td>F &mdash; failure propagation</td><td>non-blocking</td><td>Traps and explicit native exit checks correctly propagate failures.</td></tr>
-<tr><td>7</td><td>G &mdash; verdicts</td><td>non-blocking</td><td>All exits are zero; all six PASS verdicts and criteria are supported.</td></tr>
-<tr><td>8</td><td>H &mdash; report schema</td><td>non-blocking</td><td>Required report sections, 38 command details, six file-verification sections, counters, and cross-check placeholder exist.</td></tr>
-<tr><td>9</td><td>I &mdash; isolation / leaks</td><td>non-blocking</td><td>Absolute isolated workspaces were used. Git status matches the disclosed baseline; no root installation or run leaks found.</td></tr>
-<tr><td>10</td><td>J &mdash; freshness of assets under test</td><td>non-blocking</td><td>Raw hashes differ only because <code>generateSkillMd</code> regenerates frontmatter and trims the final LF. Normalized canonical bodies match exactly in all six workspaces and include the current 0.0.6-preview CLI changes.</td></tr>
+<tr><th>Check</th><th>Result</th><th>Evidence</th></tr>
+<tr><td>A — Every command ID has evidence and a checked checklist entry</td><td class="pass">PASS</td><td>38/38 IDs have evidence and checked entries (checklist.md:10-65; commands.md:129-142). Missing: none.</td></tr>
+<tr><td>B — No skipped, batched, simplified, or workaround commands</td><td class="pass">PASS</td><td>All evidence command strings match commands.md; executed snapshots match all 38 bodies. No batching/workarounds. Translation plumbing in gen-cmds.ps1:14-40.</td></tr>
+<tr><td>C — Execution order matches commands.md exactly</td><td class="pass">PASS</td><td>Timestamps strictly sequential from PF-1 through S2XL-7, without overlap.</td></tr>
+<tr><td>D — Faithful byte-exact POSIX translation semantics</td><td class="pass">PASS</td><td>Failure propagation, byte comparison, grep status inversion, UTF-8 byte sort, LF seeds, file tests, mkdir, and native exit propagation are faithful for every exercised input (gen-cmds.ps1:20-40, 81-92, 160-289).</td></tr>
+<tr><td>E — Verdicts match exit codes and pass criteria</td><td class="pass">PASS</td><td>All exit codes 0; independent checks confirmed all six case criteria. Report analysis matches commands.md:35,51,65,79,127.</td></tr>
+<tr><td>F — report.html contains all required schema sections</td><td class="pass">PASS</td><td>Required header, cards, matrix, seven collapsible evidence groups containing 38 commands, file analysis, issues, counters, criteria, and cross-check section exist (report.html:43-81, 2213-2248).</td></tr>
+<tr><td>G — Isolation held; no leaks outside the gitignored report tree</td><td class="pass">PASS</td><td>Every install/update body uses an absolute workspace path. Git status matches baseline, and no post-start writes occurred outside reports\e2e\.</td></tr>
+<tr><td>H — Checklist contains all 38 IDs and was maintained</td><td class="pass">PASS</td><td>38 checked; zero pending or failed (checklist.md:10-65).</td></tr>
+<tr><td>I — No discrepancy between report claims and evidence</td><td class="pass">PASS</td><td>No report/evidence verdict, output, command, cwd, or timestamp discrepancies.</td></tr>
+<tr><td>J — Freshness: installed skill matches current canonical template</td><td class="warn">NON-BLOCKING FINDING</td><td>Source hash CAB245…E1A, mtime 22:26:28Z, predating the run. All six installed substantive bodies match current canonical content. Exact bodies contain one additional leading blank line and the canonical trailing LF is trimmed; both originate from <code>generateSkillMd</code> (src/build/build-target.ts:244-248). Cosmetic only.</td></tr>
+<tr><td>K — Change under test: @latest and reordered Path B</td><td class="pass">PASS</td><td>Every workspace has four <code>@latest</code> references, zero pinned numeric references, and indexes cdn=156, raw=157, mcp=161; ordering is correct (templates/skills/azure-functions-create/SKILL.md:156-164).</td></tr>
 </table>
 
-<h3>Cross-check scope</h3>
-<p class="muted">The reviewer was given read-only access to <code>SKILL.md</code>, <code>references/commands.md</code>, <code>references/report-schema.md</code>, this run's <code>checklist.md</code>, <code>report.html</code>, all 38 <code>evidence/*.json</code> files, all 38 translated command bodies under <code>_harness/cmds/</code>, and the harness scripts, and verified checklist items A&ndash;J (coverage, ordering, no batching/skipping/workarounds, verbatim command text, POSIX&rarr;PowerShell translation fidelity, failure propagation, verdict support, report-schema conformance, workspace isolation / git leak assessment, and freshness of the assets actually exercised).</p>
-
-<h3>Disclosed harness event</h3>
-<p class="muted">The first invocation of <code>exec.ps1 -Id PF-1</code> aborted before launching any command process because the harness output directory <code>_harness/out/</code> did not yet exist in the freshly created run directory. No product command process was started and no evidence file was written. After creating the directory, PF-1 was invoked again and executed normally. This was disclosed to the cross-check reviewer, who judged it a harness infrastructure defect that does not compromise evidence validity (finding&nbsp;3). No product command was retried after a real failure.</p>
-
-<h3>Why this run exists</h3>
-<p class="muted">Run <code>20260820-0800</code> passed cross-check as VALID. Afterwards the canonical create skill (<code>templates/skills/azure-functions-create/SKILL.md</code>), the generated plugin payload under <code>.github/plugins/azure-functions-skills/</code>, the eval spec (<code>evals/azure-functions-create/eval.yaml</code>), and a GitHub workflow changed. This run is a complete fresh re-execution of the same six-case, 38-command matrix against that current final workspace state, with a new run ID, a new pre-execution checklist, new evidence, a new report, and a fresh premium-model cross-check. Earlier runs <code>20260819-2337</code>, <code>20260819-2353</code>, <code>20260820-0000</code>, <code>20260820-0715</code>, <code>20260820-0730</code>, and <code>20260820-0745</code> were declared INVALID for POSIX-translation-fidelity defects and were superseded.</p>
+<h3>Run history and remediation context</h3>
+<p class="muted">This is run 11. Ten prior runs exist under <code>reports/e2e/</code>. Six were declared INVALID by prior reviewers for POSIX-translation-fidelity defects, each remediated cumulatively in the harness: (1) non-propagating <code>$ErrorActionPreference = 'Continue'</code> plus unconditional <code>exit 0</code>, paraphrased command text, missing timestamps; (2) <code>Select-String -SimpleMatch</code> without <code>-CaseSensitive</code>; (3) a <code>cat</code> helper that normalized CRLF to LF; (4) culture-aware <code>-ne</code> comparison and <code>-SimpleMatch</code> on the <code>[mcp_servers.custom]</code> pattern; (5) culture-aware <code>Sort-Object</code> for POSIX <code>sort</code>; (6) culture-aware <code>-cne</code>, a decoding/BOM-stripping <code>cat</code> helper, UTF-16-ordered <code>[StringComparer]::Ordinal</code>, and a negated <code>grep</code> that terminated on read errors instead of inverting exit 2 to success. Run <code>20260820-2219</code> was INVALID for a non-harness reason: the canonical create-skill template was rewritten concurrently during that run, producing a mid-edit snapshot.</p>
+<p class="muted">Freshness protocol applied to this run: the newest write across <code>templates/</code>, <code>src/</code>, <code>.github/plugins/</code>, and <code>.github/workflows/</code> was 2026-08-20T22:26:37.899Z; <code>lib/</code> was rebuilt at 22:27:18.110Z (not stale); the run started at 22:43Z, roughly 17 minutes after the last source write. The SHA-256 of <code>templates/skills/azure-functions-create/SKILL.md</code> was <code>CAB2459B54D69985B7AEB5DFBAE2AD894624C821ABA8FD98A86DEA013FDAAE1A</code> both before and after all 38 commands, with an unchanged mtime of 22:26:28.232Z, confirming no source mutation during execution.</p>
+<p class="muted">All ten earlier runs (<code>20260819-2337</code> through <code>20260820-2232</code>) are superseded by this run.</p>
 </div>
 
-<footer>Generated by the <code>azure-functions-e2e-tests</code> skill. Evidence JSON: <code>reports/e2e/20260820-0821/evidence/</code> &middot; Checklist: <code>reports/e2e/20260820-0821/checklist.md</code></footer>
+<footer>Generated by the <code>azure-functions-e2e-tests</code> skill. Evidence JSON: <code>reports/e2e/20260820-2243/evidence/</code> &middot; Checklist: <code>reports/e2e/20260820-2243/checklist.md</code></footer>
 </body>
 </html>

--- a/reports/e2e/current/report.html
+++ b/reports/e2e/current/report.html
@@ -3,82 +3,168 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Azure Functions Skills E2E Report — 20260810-132424</title>
+<title>Azure Functions Skills E2E Report — 20260820-0821</title>
 <style>
-  :root { --ok:#1a7f37; --bad:#cf222e; --warn:#9a6700; --bg:#f6f8fa; --bd:#d0d7de; --fg:#1f2328; }
-  * { box-sizing: border-box; }
-  body { font-family: -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; color:var(--fg); margin:0; padding:0 1rem 4rem; line-height:1.5; }
-  header { padding:1.5rem 0 1rem; border-bottom:1px solid var(--bd); }
-  h1 { margin:0 0 .25rem; font-size:1.5rem; }
-  .meta { color:#57606a; font-size:.9rem; }
-  .meta code { background:var(--bg); padding:.05rem .3rem; border-radius:4px; }
-  .cards { display:flex; flex-wrap:wrap; gap:.75rem; margin:1rem 0; }
-  .card { border:1px solid var(--bd); border-radius:8px; padding:.75rem 1rem; min-width:120px; background:#fff; }
-  .card .n { font-size:1.6rem; font-weight:700; }
-  .card.pass .n { color:var(--ok); } .card.fail .n { color:var(--bad); } .card.blocked .n { color:var(--warn); }
-  table.tbl { border-collapse:collapse; width:100%; margin:.5rem 0 1.5rem; }
-  table.tbl th, table.tbl td { border:1px solid var(--bd); padding:.4rem .6rem; text-align:left; font-size:.9rem; vertical-align:top; }
-  table.tbl th { background:var(--bg); }
-  .status { font-weight:700; text-transform:uppercase; font-size:.75rem; padding:.1rem .45rem; border-radius:999px; }
-  .status.pass { color:#fff; background:var(--ok); } .status.fail { color:#fff; background:var(--bad); }
-  .status.blocked { color:#fff; background:var(--warn); } .status.incomplete { color:#fff; background:#8250df; }
-  section.case { border:1px solid var(--bd); border-radius:8px; padding:1rem 1.25rem; margin:1rem 0; background:#fff; }
-  section.case h3 { margin-top:0; }
-  .analysis { color:#57606a; }
-  details.cmd { border:1px solid var(--bd); border-radius:6px; margin:.4rem 0; background:var(--bg); }
-  details.cmd summary { cursor:pointer; padding:.5rem .75rem; display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; }
-  details.cmd summary code { font-size:.82rem; }
-  .cid { font-weight:700; font-family:monospace; }
-  .badge { font-size:.72rem; font-weight:700; padding:.05rem .4rem; border-radius:999px; color:#fff; }
-  .badge.ok { background:var(--ok); } .badge.bad { background:var(--bad); } .badge.warn { background:var(--warn); }
-  details.cmd .kv, details.cmd .io { padding:0 .75rem; }
-  .io-h { font-size:.75rem; text-transform:uppercase; color:#57606a; margin-top:.4rem; }
-  pre { background:#0d1117; color:#e6edf3; padding:.6rem .8rem; border-radius:6px; overflow:auto; font-size:.8rem; max-height:420px; }
-  td.ok, .ok { color:var(--ok); font-weight:600; } td.bad, .bad { color:var(--bad); font-weight:600; }
-  .counters pre { background:var(--bg); color:var(--fg); border:1px solid var(--bd); }
-  a { color:#0969da; }
-  @media print { details.cmd[open] summary { } pre { max-height:none; } details { break-inside: avoid; } }
+:root { color-scheme: light dark; --bd:#d0d7de; --mut:#57606a; --ok:#1a7f37; --bad:#cf222e; --bg:#ffffff; --panel:#f6f8fa; --fg:#1f2328; }
+@media (prefers-color-scheme: dark) { :root { --bd:#30363d; --mut:#8b949e; --ok:#3fb950; --bad:#f85149; --bg:#0d1117; --panel:#161b22; --fg:#e6edf3; } }
+* { box-sizing: border-box; }
+body { margin:0; padding:24px; font:15px/1.55 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; background:var(--bg); color:var(--fg); }
+h1 { font-size:1.6rem; margin:0 0 4px; }
+h2 { font-size:1.2rem; margin:32px 0 10px; border-bottom:1px solid var(--bd); padding-bottom:6px; }
+h4 { margin:16px 0 6px; font-size:0.95rem; }
+code { font-family:ui-monospace,SFMono-Regular,Consolas,monospace; font-size:0.86em; }
+pre { background:var(--panel); border:1px solid var(--bd); border-radius:6px; padding:10px; overflow:auto; max-height:420px; white-space:pre-wrap; word-break:break-word; font-size:0.8rem; }
+.muted, .note { color:var(--mut); }
+.note { font-size:0.8rem; }
+.cards { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:12px; margin:16px 0; }
+.card { border:1px solid var(--bd); border-radius:8px; padding:12px 14px; background:var(--panel); }
+.card .n { font-size:1.7rem; font-weight:700; }
+.card .l { color:var(--mut); font-size:0.78rem; text-transform:uppercase; letter-spacing:.04em; }
+table.grid { border-collapse:collapse; width:100%; margin:8px 0 16px; }
+table.grid th, table.grid td { border:1px solid var(--bd); padding:6px 9px; text-align:left; font-size:0.87rem; vertical-align:top; }
+table.grid th { background:var(--panel); }
+.badge { display:inline-block; padding:1px 8px; border-radius:999px; font-size:0.74rem; font-weight:700; color:#fff; }
+.badge.ok { background:var(--ok); }
+.badge.bad { background:var(--bad); }
+details.case { border:1px solid var(--bd); border-radius:8px; margin:10px 0; background:var(--panel); }
+details.case > summary { padding:10px 12px; cursor:pointer; font-size:0.95rem; }
+.casebody { padding:0 14px 14px; }
+details.cmd { border:1px solid var(--bd); border-radius:6px; margin:6px 0; background:var(--bg); }
+details.cmd > summary { padding:7px 10px; cursor:pointer; font-size:0.85rem; }
+.cmdbody { padding:0 12px 12px; }
+.kv { font-size:0.82rem; margin:8px 0 4px; }
+.analysis { background:var(--bg); border-left:3px solid var(--ok); padding:8px 12px; border-radius:0 6px 6px 0; font-size:0.88rem; }
+.ok-text { color:var(--ok); font-weight:600; }
+footer { margin-top:32px; color:var(--mut); font-size:0.8rem; border-top:1px solid var(--bd); padding-top:10px; }
+@media print { body { padding:0; } details { break-inside:avoid; } details > summary { list-style:none; } details[open] .cmdbody, .casebody { display:block; } pre { max-height:none; } }
 </style>
 </head>
 <body>
-<header>
-  <h1>Azure Functions Skills — Local E2E Report</h1>
-  <div class="meta">
-    Run ID <code>20260810-132424</code> &middot; Generated <code>2026-08-10T20:34:35.094Z</code><br>
-    Package version <code>0.0.6-preview</code> &middot; Platform <code>windows</code> &middot; Git commit <code>0bd094698feb680a684c41905b971ec43fd7eb4c</code>
-  </div>
-</header>
+<h1>Azure Functions Skills — Local Install/Update E2E Report</h1>
+<p class="muted">Run <code>20260820-0821</code> &middot; generated 2026-08-20T08:27:32.0552852Z</p>
 
-<section>
-  <h2>Summary</h2>
-  <div class="cards">
-    <div class="card pass"><div class="n">6</div><div>Pass</div></div>
-    <div class="card fail"><div class="n">0</div><div>Fail</div></div>
-    <div class="card blocked"><div class="n">0</div><div>Blocked</div></div>
-    <div class="card"><div class="n">38/38</div><div>Commands (actual/expected)</div></div>
-    <div class="card"><div class="n">6</div><div>Test cases</div></div>
-  </div>
-</section>
+<table class="grid">
+<tbody>
+<tr><th>Run ID</th><td><code>20260820-0821</code></td><th>Package version</th><td><code>0.0.6-preview</code></td></tr>
+<tr><th>Platform</th><td>windows (PowerShell 7, Node v24.18.1)</td><th>Git commit</th><td><code>b71d1a4</code></td></tr>
+<tr><th>Run started (UTC)</th><td><code>2026-08-20T08:23:16.9055034Z</code></td><th>Run completed (UTC)</th><td><code>2026-08-20T08:27:20.8740110Z</code></td></tr>
+<tr><th>Report generated (UTC)</th><td colspan="3"><code>2026-08-20T08:27:32.0552852Z</code></td></tr>
+<tr><th>Command source</th><td colspan="3"><code>.github/skills/azure-functions-e2e-tests/references/commands.md</code></td></tr>
+<tr><th>Workspace root</th><td colspan="3"><code>reports/e2e/20260820-0821/workspaces/&lt;test-case-id&gt;</code></td></tr>
+<tr><th>Execution model</th><td colspan="3">Each numbered command ran individually, in order, in its own PowerShell process with cwd = repository root. POSIX shell syntax was translated to PowerShell only (per commands.md); every body uses <code>$ErrorActionPreference = 'Stop'</code> with a trap so any failed step exits non-zero, matching <code>&amp;&amp;</code> chain semantics. No commands were batched, simplified, or supplemented.</td></tr>
+</tbody>
+</table>
 
-<section>
-  <h2>Preflight</h2>
-  <p>Status: <span class="status pass">pass</span> &middot;
-     <code>install --local</code> listed: <span class="ok">true</span> &middot;
-     <code>update --local</code> listed: <span class="ok">true</span> &middot;
-     no <code>chat</code>: <span class="ok">true</span> &middot;
-     no <code>setup</code>: <span class="ok">true</span></p>
+<h2>Summary</h2>
+<div class="cards">
+<div class="card"><div class="n">6</div><div class="l">Test cases</div></div>
+<div class="card"><div class="n" style="color:var(--ok)">6</div><div class="l">Pass</div></div>
+<div class="card"><div class="n" style="color:var(--bad)">0</div><div class="l">Fail</div></div>
+<div class="card"><div class="n">0</div><div class="l">Blocked</div></div>
+<div class="card"><div class="n">38</div><div class="l">Expected commands</div></div>
+<div class="card"><div class="n">38</div><div class="l">Executed commands</div></div>
+</div>
 
-  <details class="cmd">
-    <summary><span class="cid">PF-1</span> <span class="badge ok">exit 0</span> <code>$CLI --version</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>0.0.6-preview
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">PF-2</span> <span class="badge ok">exit 0</span> <code>$CLI --help</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>@azure/functions-skills — Azure Functions skills for coding agents
+<h2>Test matrix</h2>
+<table class="grid">
+<thead><tr><th>Test case</th><th>Agent</th><th>Install mode</th><th>Scenario</th><th>Commands</th><th>Status</th></tr></thead>
+<tbody>
+<tr><td><code>TC-S1-GHCP-LOCAL</code></td><td>ghcp</td><td>local</td><td>fresh-install</td><td>5</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>TC-S1-CLAUDE-LOCAL</code></td><td>claude</td><td>local</td><td>fresh-install</td><td>5</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>TC-S1-CODEX-LOCAL</code></td><td>codex</td><td>local</td><td>fresh-install</td><td>5</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>TC-S2-GHCP-LOCAL</code></td><td>ghcp</td><td>local</td><td>update-and-legacy-cleanup</td><td>7</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>TC-S2-CLAUDE-LOCAL</code></td><td>claude</td><td>local</td><td>update-and-legacy-cleanup</td><td>7</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>TC-S2-CODEX-LOCAL</code></td><td>codex</td><td>local</td><td>update-and-legacy-cleanup</td><td>7</td><td><span class='badge ok'>PASS</span></td></tr>
+</tbody>
+</table>
+
+<h2>Evidence</h2>
+<details class="case" open>
+<summary><span class="badge ok">PASS</span> <strong>PREFLIGHT</strong> <span class="muted">agent=- · mode=local · 2 commands</span></summary>
+<div class="casebody">
+<p class="kv"><strong>Started:</strong> 2026-08-20T08:23:16.9055034Z &middot; <strong>Completed:</strong> 2026-08-20T08:23:24.8581559Z</p>
+<p class="analysis">CLI reports version 0.0.6-preview and help lists install --local and update --local with no chat or setup command.</p>
+
+<h4>Command evidence</h4>
+<details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>PF-1</code> <span class="muted">$CLI --version</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:16.9055034Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+&amp; $CLI[0] $CLI[1] --version
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>0.0.6-preview</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>PF-2</code> <span class="muted">$CLI --help</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:24.1875098Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+&amp; $CLI[0] $CLI[1] --help
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>@azure/functions-skills — Azure Functions skills for coding agents
 
 Commands:
   install --local   Copy skills, MCP, and telemetry hooks into a workspace
@@ -88,743 +174,2113 @@ Commands:
   template apply    Apply an Azure Functions template
   build             Build local and plugin artifacts
 
-Plugin installation is managed by the host coding agent, not this package.
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-</section>
+Plugin installation is managed by the host coding agent, not this package.</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details>
+</div>
+</details>
+<details class="case" open>
+<summary><span class="badge ok">PASS</span> <strong>TC-S1-GHCP-LOCAL</strong> <span class="muted">agent=ghcp · mode=local · 5 commands</span></summary>
+<div class="casebody">
+<p class="kv"><strong>Started:</strong> 2026-08-20T08:23:30.3149941Z &middot; <strong>Completed:</strong> 2026-08-20T08:23:57.8967418Z</p>
+<p class="analysis">Fresh local install produced 88 files limited to .github/skills, .mcp.json, and .github/hooks telemetry assets. No legacy state, generated AGENTS.md, agent definitions, or welcome hook.</p>
+<h4>File verification</h4>
+<table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>.github\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.mcp.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\hooks\azure-functions-telemetry.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\hooks\scripts\track-telemetry.sh</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.azure-functions-skills</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>AGENTS.md</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\agents</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\hooks\welcome-setup.json</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+</tbody></table>
+<h4>Command evidence</h4>
+<details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1GL-1</code> <span class="muted">mkdir -p $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:30.3149941Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+New-Item -ItemType Directory -Force -Path $WS | Out-Null
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-<section>
-  <h2>Test matrix</h2>
-  <table class="tbl"><thead><tr><th>Test case</th><th>Agent</th><th>Scenario</th><th>Status</th></tr></thead>
-  <tbody>
-  <tr>
-    <td><a href="#TC-S1-GHCP-LOCAL">TC-S1-GHCP-LOCAL</a></td>
-    <td>ghcp</td>
-    <td>fresh-install</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S1-CLAUDE-LOCAL">TC-S1-CLAUDE-LOCAL</a></td>
-    <td>claude</td>
-    <td>fresh-install</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S1-CODEX-LOCAL">TC-S1-CODEX-LOCAL</a></td>
-    <td>codex</td>
-    <td>fresh-install</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S2-GHCP-LOCAL">TC-S2-GHCP-LOCAL</a></td>
-    <td>ghcp</td>
-    <td>update-ownership</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S2-CLAUDE-LOCAL">TC-S2-CLAUDE-LOCAL</a></td>
-    <td>claude</td>
-    <td>update-ownership</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S2-CODEX-LOCAL">TC-S2-CODEX-LOCAL</a></td>
-    <td>codex</td>
-    <td>update-ownership</td>
-    <td class="status pass">pass</td>
-  </tr></tbody></table>
-</section>
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1GL-2</code> <span class="muted">$CLI install --local --agent ghcp --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:36.1068826Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+&amp; $CLI[0] $CLI[1] install --local --agent ghcp --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-<section>
-  <h2>Per-case evidence</h2>
-
-  <section class="case" id="TC-S1-GHCP-LOCAL">
-    <h3>TC-S1-GHCP-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Fresh GHCP local install produced skills, MCP, and telemetry hooks only; no legacy or agent-definition artifacts.</p>
-    <h4>Commands</h4>
-
-  <details class="cmd">
-    <summary><span class="cid">S1GL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent ghcp --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+<pre>Azure Functions Skills locally installed.
   Agents: ghcp
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-3</span> <span class="badge ok">exit 0</span> <code>find $WS -type f | sort</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\telemetry.config.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-setup\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.mcp.json
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-4</span> <span class="badge ok">exit 0</span> <code>test -f $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.mcp.json &amp;&amp; test -f $WS/.github/hooks/azure-functions-telemetry.json &amp;&amp; test -f $WS/.github/hooks/scripts/track-telemetry.sh</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-5</span> <span class="badge ok">exit 0</span> <code>test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.github/agents &amp;&amp; test ! -e $WS/.github/hooks/welcome-setup.json</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.github/skills/azure-functions-help/SKILL.md</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.mcp.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/azure-functions-telemetry.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/scripts/track-telemetry.sh</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/agents</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/welcome-setup.json</code></td><td>absent</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S1-CLAUDE-LOCAL">
-    <h3>TC-S1-CLAUDE-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Fresh Claude local install produced skills, settings/MCP, and telemetry hooks only; no legacy or agent-definition artifacts.</p>
-    <h4>Commands</h4>
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1GL-3</code> <span class="muted">find $WS -type f | sort</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:44.4796374Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+$files = [string[]](Get-ChildItem -LiteralPath $WS -Recurse -File -Force | ForEach-Object { $_.FullName })
+$cmp = [System.Comparison[string]]{ param([string]$x, [string]$y)
+    $bx = [Text.Encoding]::UTF8.GetBytes($x); $by = [Text.Encoding]::UTF8.GetBytes($y)
+    $n = [Math]::Min($bx.Length, $by.Length)
+    for ($i = 0; $i -lt $n; $i++) { if ($bx[$i] -ne $by[$i]) { return ([int]$bx[$i] - [int]$by[$i]) } }
+    return ($bx.Length - $by.Length)
+}
+[Array]::Sort($files, $cmp)
+$files
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-  <details class="cmd">
-    <summary><span class="cid">S1CL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent claude --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\telemetry.config.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-setup\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL\.mcp.json</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1GL-4</code> <span class="muted">test -f $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.mcp.json &amp;&amp; test -f $WS/.github/hooks/azure-functions-telemetry.json &amp;&amp; test -f $WS/.github/hooks/scripts/track-telemetry.sh</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:50.6265338Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+foreach ($rel in @('.github\skills\azure-functions-help\SKILL.md', '.mcp.json', '.github\hooks\azure-functions-telemetry.json', '.github\hooks\scripts\track-telemetry.sh')) {
+    $p = Join-Path $WS $rel
+    if (-not (Test-Path -LiteralPath $p -PathType Leaf)) { Fail "test -f failed: $p" }
+    Write-Output "ok file: $rel"
+}
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>ok file: .github\skills\azure-functions-help\SKILL.md
+ok file: .mcp.json
+ok file: .github\hooks\azure-functions-telemetry.json
+ok file: .github\hooks\scripts\track-telemetry.sh</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1GL-5</code> <span class="muted">test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.github/agents &amp;&amp; test ! -e $WS/.github/hooks/welcome-setup.json</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:23:57.2753855Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-GHCP-LOCAL'
+foreach ($rel in @('.azure-functions-skills', 'AGENTS.md', '.github\agents', '.github\hooks\welcome-setup.json')) {
+    $p = Join-Path $WS $rel
+    if (Test-Path -LiteralPath $p) { Fail "test ! -e failed: $p" }
+    Write-Output "ok absent: $rel"
+}
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>ok absent: .azure-functions-skills
+ok absent: AGENTS.md
+ok absent: .github\agents
+ok absent: .github\hooks\welcome-setup.json</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details>
+</div>
+</details>
+<details class="case" open>
+<summary><span class="badge ok">PASS</span> <strong>TC-S1-CLAUDE-LOCAL</strong> <span class="muted">agent=claude · mode=local · 5 commands</span></summary>
+<div class="casebody">
+<p class="kv"><strong>Started:</strong> 2026-08-20T08:24:03.1760831Z &middot; <strong>Completed:</strong> 2026-08-20T08:24:30.9768775Z</p>
+<p class="analysis">Fresh local install produced 88 files limited to .claude/skills, .claude/settings.json, and .claude/hooks telemetry assets. No legacy state, CLAUDE.md, or agent definitions.</p>
+<h4>File verification</h4>
+<table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>.claude\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\settings.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\hooks\hooks.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\hooks\scripts\track-telemetry.sh</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.azure-functions-skills</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>CLAUDE.md</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\agents</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+</tbody></table>
+<h4>Command evidence</h4>
+<details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1CL-1</code> <span class="muted">mkdir -p $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:03.1760831Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+New-Item -ItemType Directory -Force -Path $WS | Out-Null
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1CL-2</code> <span class="muted">$CLI install --local --agent claude --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:09.9961934Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+&amp; $CLI[0] $CLI[1] install --local --agent claude --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally installed.
   Agents: claude
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-3</span> <span class="badge ok">exit 0</span> <code>find $WS -type f | sort</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-setup\SKILL.md
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-4</span> <span class="badge ok">exit 0</span> <code>test -f $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.claude/settings.json &amp;&amp; test -f $WS/.claude/hooks/hooks.json &amp;&amp; test -f $WS/.claude/hooks/scripts/track-telemetry.sh</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-5</span> <span class="badge ok">exit 0</span> <code>test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/CLAUDE.md &amp;&amp; test ! -e $WS/.claude/agents</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.claude/skills/azure-functions-help/SKILL.md</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/settings.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/hooks/hooks.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/hooks/scripts/track-telemetry.sh</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>CLAUDE.md</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/agents</code></td><td>absent</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S1-CODEX-LOCAL">
-    <h3>TC-S1-CODEX-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Fresh Codex local install produced skills, config/MCP, and telemetry hooks only; no legacy or agent-definition artifacts.</p>
-    <h4>Commands</h4>
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1CL-3</code> <span class="muted">find $WS -type f | sort</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:18.4280343Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+$files = [string[]](Get-ChildItem -LiteralPath $WS -Recurse -File -Force | ForEach-Object { $_.FullName })
+$cmp = [System.Comparison[string]]{ param([string]$x, [string]$y)
+    $bx = [Text.Encoding]::UTF8.GetBytes($x); $by = [Text.Encoding]::UTF8.GetBytes($y)
+    $n = [Math]::Min($bx.Length, $by.Length)
+    for ($i = 0; $i -lt $n; $i++) { if ($bx[$i] -ne $by[$i]) { return ([int]$bx[$i] - [int]$by[$i]) } }
+    return ($bx.Length - $by.Length)
+}
+[Array]::Sort($files, $cmp)
+$files
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-  <details class="cmd">
-    <summary><span class="cid">S1XL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent codex --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-setup\SKILL.md</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1CL-4</code> <span class="muted">test -f $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.claude/settings.json &amp;&amp; test -f $WS/.claude/hooks/hooks.json &amp;&amp; test -f $WS/.claude/hooks/scripts/track-telemetry.sh</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:24.4592320Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+foreach ($rel in @('.claude\skills\azure-functions-help\SKILL.md', '.claude\settings.json', '.claude\hooks\hooks.json', '.claude\hooks\scripts\track-telemetry.sh')) {
+    $p = Join-Path $WS $rel
+    if (-not (Test-Path -LiteralPath $p -PathType Leaf)) { Fail "test -f failed: $p" }
+    Write-Output "ok file: $rel"
+}
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>ok file: .claude\skills\azure-functions-help\SKILL.md
+ok file: .claude\settings.json
+ok file: .claude\hooks\hooks.json
+ok file: .claude\hooks\scripts\track-telemetry.sh</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1CL-5</code> <span class="muted">test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/CLAUDE.md &amp;&amp; test ! -e $WS/.claude/agents</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:30.3135672Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CLAUDE-LOCAL'
+foreach ($rel in @('.azure-functions-skills', 'CLAUDE.md', '.claude\agents')) {
+    $p = Join-Path $WS $rel
+    if (Test-Path -LiteralPath $p) { Fail "test ! -e failed: $p" }
+    Write-Output "ok absent: $rel"
+}
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>ok absent: .azure-functions-skills
+ok absent: CLAUDE.md
+ok absent: .claude\agents</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details>
+</div>
+</details>
+<details class="case" open>
+<summary><span class="badge ok">PASS</span> <strong>TC-S1-CODEX-LOCAL</strong> <span class="muted">agent=codex · mode=local · 5 commands</span></summary>
+<div class="casebody">
+<p class="kv"><strong>Started:</strong> 2026-08-20T08:24:36.1613139Z &middot; <strong>Completed:</strong> 2026-08-20T08:25:02.6163780Z</p>
+<p class="analysis">Fresh local install produced 88 files limited to .agents/skills, .codex/config.toml, and .codex/hooks telemetry assets. No legacy state, AGENTS.md, or agent definitions.</p>
+<h4>File verification</h4>
+<table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>.agents\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.codex\config.toml</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.codex\hooks.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.codex\hooks\scripts\track-telemetry.sh</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.azure-functions-skills</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>AGENTS.md</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.agents\agents</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+</tbody></table>
+<h4>Command evidence</h4>
+<details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1XL-1</code> <span class="muted">mkdir -p $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:36.1613139Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+New-Item -ItemType Directory -Force -Path $WS | Out-Null
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1XL-2</code> <span class="muted">$CLI install --local --agent codex --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:41.8675874Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+&amp; $CLI[0] $CLI[1] install --local --agent codex --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally installed.
   Agents: codex
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-3</span> <span class="badge ok">exit 0</span> <code>find $WS -type f | sort</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-setup\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\telemetry.config.json
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-4</span> <span class="badge ok">exit 0</span> <code>test -f $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.codex/config.toml &amp;&amp; test -f $WS/.codex/hooks.json &amp;&amp; test -f $WS/.codex/hooks/scripts/track-telemetry.sh</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-5</span> <span class="badge ok">exit 0</span> <code>test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.agents/agents</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.agents/skills/azure-functions-help/SKILL.md</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/hooks.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/hooks/scripts/track-telemetry.sh</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.agents/agents</code></td><td>absent</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S2-GHCP-LOCAL">
-    <h3>TC-S2-GHCP-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">GHCP update refreshed the bundled skill, preserved user-owned skill/hook/MCP entries, migrated telemetry opt-out into telemetry.config.json, and removed legacy state plus managed instruction block.</p>
-    <h4>Commands</h4>
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1XL-3</code> <span class="muted">find $WS -type f | sort</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:50.2954812Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+$files = [string[]](Get-ChildItem -LiteralPath $WS -Recurse -File -Force | ForEach-Object { $_.FullName })
+$cmp = [System.Comparison[string]]{ param([string]$x, [string]$y)
+    $bx = [Text.Encoding]::UTF8.GetBytes($x); $by = [Text.Encoding]::UTF8.GetBytes($y)
+    $n = [Math]::Min($bx.Length, $by.Length)
+    for ($i = 0; $i -lt $n; $i++) { if ($bx[$i] -ne $by[$i]) { return ([int]$bx[$i] - [int]$by[$i]) } }
+    return ($bx.Length - $by.Length)
+}
+[Array]::Sort($files, $cmp)
+$files
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-  <details class="cmd">
-    <summary><span class="cid">S2GL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent ghcp --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+<pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-setup\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\telemetry.config.json</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1XL-4</code> <span class="muted">test -f $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.codex/config.toml &amp;&amp; test -f $WS/.codex/hooks.json &amp;&amp; test -f $WS/.codex/hooks/scripts/track-telemetry.sh</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:24:56.1746354Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+foreach ($rel in @('.agents\skills\azure-functions-help\SKILL.md', '.codex\config.toml', '.codex\hooks.json', '.codex\hooks\scripts\track-telemetry.sh')) {
+    $p = Join-Path $WS $rel
+    if (-not (Test-Path -LiteralPath $p -PathType Leaf)) { Fail "test -f failed: $p" }
+    Write-Output "ok file: $rel"
+}
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>ok file: .agents\skills\azure-functions-help\SKILL.md
+ok file: .codex\config.toml
+ok file: .codex\hooks.json
+ok file: .codex\hooks\scripts\track-telemetry.sh</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S1XL-5</code> <span class="muted">test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.agents/agents</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:01.9627641Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S1-CODEX-LOCAL'
+foreach ($rel in @('.azure-functions-skills', 'AGENTS.md', '.agents\agents')) {
+    $p = Join-Path $WS $rel
+    if (Test-Path -LiteralPath $p) { Fail "test ! -e failed: $p" }
+    Write-Output "ok absent: $rel"
+}
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>ok absent: .azure-functions-skills
+ok absent: AGENTS.md
+ok absent: .agents\agents</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details>
+</div>
+</details>
+<details class="case" open>
+<summary><span class="badge ok">PASS</span> <strong>TC-S2-GHCP-LOCAL</strong> <span class="muted">agent=ghcp · mode=local · 7 commands</span></summary>
+<div class="casebody">
+<p class="kv"><strong>Started:</strong> 2026-08-20T08:25:07.8445768Z &middot; <strong>Completed:</strong> 2026-08-20T08:25:47.7913704Z</p>
+<p class="analysis">Update replaced the stale bundled skill, preserved the user-owned skill, hook script, and custom MCP server, merged the azure MCP server, migrated the legacy telemetry opt-out into .github/hooks/telemetry.config.json, and removed legacy state, the legacy agent file, and the managed AGENTS.md block.</p>
+<h4>File verification</h4>
+<table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>.github\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\skills\azure-functions-internal-runbook\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\hooks\scripts\custom-hook.sh</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\hooks\telemetry.config.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.mcp.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>AGENTS.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.azure-functions-skills</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.github\agents\functions-copilot.agent.md</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+</tbody></table>
+<h4>Command evidence</h4>
+<details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2GL-1</code> <span class="muted">mkdir -p $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:07.8445768Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+New-Item -ItemType Directory -Force -Path $WS | Out-Null
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2GL-2</code> <span class="muted">$CLI install --local --agent ghcp --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:13.7063450Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+&amp; $CLI[0] $CLI[1] install --local --agent ghcp --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally installed.
   Agents: ghcp
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-3</span> <span class="badge ok">exit 0</span> <code>printf 'stale bundled\n' &gt; $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.github/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/skills/azure-functions-internal-runbook/SKILL.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-4</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS/.github/hooks/scripts &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/hooks/scripts/custom-hook.sh &amp;&amp; printf '{...custom mcp...}\n' &gt; $WS/.mcp.json</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-5</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS/.azure-functions-skills $WS/.github/agents &amp;&amp; printf '{opt-out}' &gt; state.local.json &amp;&amp; printf 'legacy' &gt; functions-copilot.agent.md &amp;&amp; printf 'customer + managed block' &gt; $WS/AGENTS.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-6</span> <span class="badge ok">exit 0</span> <code>$CLI update --local --agent ghcp --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2GL-3</code> <span class="muted">printf 'stale bundled\n' &gt; $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.github/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/skills/azure-functions-internal-runbook/SKILL.md</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:21.6130873Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+[IO.File]::WriteAllText((Join-Path $WS '.github\skills\azure-functions-help\SKILL.md'), "stale bundled`n")
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.github\skills\azure-functions-internal-runbook') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.github\skills\azure-functions-internal-runbook\SKILL.md'), "user-owned`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2GL-4</code> <span class="muted">mkdir -p $WS/.github/hooks/scripts &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/hooks/scripts/custom-hook.sh &amp;&amp; printf '{"inputs":[{"id":"subscription"}],"mcpServers":{"custom":{"command":"custom-server","args":[]}}}\n' &gt; $WS/.mcp.json</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:27.3983623Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.github\hooks\scripts') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.github\hooks\scripts\custom-hook.sh'), "user-owned`n")
+[IO.File]::WriteAllText((Join-Path $WS '.mcp.json'), '{"inputs":[{"id":"subscription"}],"mcpServers":{"custom":{"command":"custom-server","args":[]}}}' + "`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2GL-5</code> <span class="muted">mkdir -p $WS/.azure-functions-skills $WS/.github/agents &amp;&amp; printf '{"telemetry":{"enabled":false}}\n' &gt; $WS/.azure-functions-skills/state.local.json &amp;&amp; printf 'legacy\n' &gt; $WS/.github/agents/functions-copilot.agent.md &amp;&amp; printf 'customer\n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;\nlegacy routing\n&lt;!-- azure-functions-skills:end --&gt;\n' &gt; $WS/AGENTS.md</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:33.2270152Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.azure-functions-skills'), (Join-Path $WS '.github\agents') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.azure-functions-skills\state.local.json'), '{"telemetry":{"enabled":false}}' + "`n")
+[IO.File]::WriteAllText((Join-Path $WS '.github\agents\functions-copilot.agent.md'), "legacy`n")
+[IO.File]::WriteAllText((Join-Path $WS 'AGENTS.md'), "customer`n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;`nlegacy routing`n&lt;!-- azure-functions-skills:end --&gt;`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2GL-6</code> <span class="muted">$CLI update --local --agent ghcp --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:39.0706181Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+&amp; $CLI[0] $CLI[1] update --local --agent ghcp --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally updated.
   Agents: ghcp
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-7</span> <span class="badge ok">exit 0</span> <code>test -f help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' &amp;&amp; cat runbook == user-owned &amp;&amp; test ! -e .azure-functions-skills &amp;&amp; test ! -e .github/agents/functions-copilot.agent.md &amp;&amp; cat AGENTS.md == customer &amp;&amp; cat custom-hook.sh == user-owned &amp;&amp; node -e (mcp.custom=custom-server, mcp.azure=npx, telemetry.enabled=false)</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.github/skills/azure-functions-help/SKILL.md</code></td><td>refreshed (no &quot;stale bundled&quot;)</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/skills/azure-functions-internal-runbook/SKILL.md</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/scripts/custom-hook.sh</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/agents/functions-copilot.agent.md</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>managed block stripped (== customer)</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S2-CLAUDE-LOCAL">
-    <h3>TC-S2-CLAUDE-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Claude update refreshed the bundled skill, preserved user settings (allow, custom MCP, custom hook), injected the telemetry hook, migrated opt-out, and removed legacy state plus managed block.</p>
-    <h4>Commands</h4>
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2GL-7</code> <span class="muted">test -f $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; test "$(cat $WS/.github/skills/azure-functions-internal-runbook/SKILL.md)" = "user-owned" &amp;&amp; test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/.github/agents/functions-copilot.agent.md &amp;&amp; test "$(cat $WS/AGENTS.md)" = "customer" &amp;&amp; test "$(cat $WS/.github/hooks/scripts/custom-hook.sh)" = "user-owned" &amp;&amp; node -e "const fs=require('fs');const m=JSON.parse(fs.readFileSync('$WS/.mcp.json'));const t=JSON.parse(fs.readFileSync('$WS/.github/hooks/telemetry.config.json'));if(m.mcpServers.custom.command!=='custom-server'||m.mcpServers.azure.command!=='npx'||t.enabled!==false)process.exit(1)"</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:46.9813639Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-GHCP-LOCAL'
+$fwd = $WS -replace '\\', '/'
+if (-not (Test-Path -LiteralPath (Join-Path $WS '.github\skills\azure-functions-help\SKILL.md') -PathType Leaf)) { Fail 'missing refreshed bundled skill' }
+if ((GrepQ (Join-Path $WS '.github\skills\azure-functions-help\SKILL.md') 'stale bundled') -eq 0) { Fail 'stale bundled content survived' }
+if (-not (TestStrEq (Join-Path $WS '.github\skills\azure-functions-internal-runbook\SKILL.md') 'user-owned')) { Fail 'user-owned skill not preserved' }
+if (Test-Path -LiteralPath (Join-Path $WS '.azure-functions-skills')) { Fail 'legacy state survived' }
+if (Test-Path -LiteralPath (Join-Path $WS '.github\agents\functions-copilot.agent.md')) { Fail 'legacy agent survived' }
+if (-not (TestStrEq (Join-Path $WS 'AGENTS.md') 'customer')) { Fail 'managed AGENTS.md block not removed' }
+if (-not (TestStrEq (Join-Path $WS '.github\hooks\scripts\custom-hook.sh') 'user-owned')) { Fail 'user hook script not preserved' }
+$js = "const fs=require('fs');const m=JSON.parse(fs.readFileSync('$fwd/.mcp.json'));const t=JSON.parse(fs.readFileSync('$fwd/.github/hooks/telemetry.config.json'));if(m.mcpServers.custom.command!=='custom-server'||m.mcpServers.azure.command!=='npx'||t.enabled!==false)process.exit(1)"
+node -e $js
+if ($LASTEXITCODE -ne 0) { Fail "node assertion failed with exit $LASTEXITCODE" }
+Write-Output 'all S2GL-7 assertions passed'
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-  <details class="cmd">
-    <summary><span class="cid">S2CL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent claude --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+<pre>all S2GL-7 assertions passed</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details>
+</div>
+</details>
+<details class="case" open>
+<summary><span class="badge ok">PASS</span> <strong>TC-S2-CLAUDE-LOCAL</strong> <span class="muted">agent=claude · mode=local · 7 commands</span></summary>
+<div class="casebody">
+<p class="kv"><strong>Started:</strong> 2026-08-20T08:25:53.2890642Z &middot; <strong>Completed:</strong> 2026-08-20T08:26:34.4165309Z</p>
+<p class="analysis">Update replaced the stale bundled skill, preserved user-owned skill, hook, permissions, and custom MCP server, kept both custom and telemetry hooks in settings.json, migrated the telemetry opt-out, and removed legacy state and the managed CLAUDE.md block.</p>
+<h4>File verification</h4>
+<table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>.claude\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\skills\azure-functions-internal-runbook\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\hooks\custom-hook.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\hooks\telemetry.config.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.claude\settings.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>CLAUDE.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.azure-functions-skills</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+</tbody></table>
+<h4>Command evidence</h4>
+<details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2CL-1</code> <span class="muted">mkdir -p $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:53.2890642Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+New-Item -ItemType Directory -Force -Path $WS | Out-Null
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2CL-2</code> <span class="muted">$CLI install --local --agent claude --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:25:59.0792394Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+&amp; $CLI[0] $CLI[1] install --local --agent claude --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally installed.
   Agents: claude
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-3</span> <span class="badge ok">exit 0</span> <code>printf 'stale bundled\n' &gt; help/SKILL.md &amp;&amp; mkdir -p runbook &amp;&amp; printf 'user-owned\n' &gt; runbook/SKILL.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-4</span> <span class="badge ok">exit 0</span> <code>mkdir -p .claude/hooks &amp;&amp; printf 'user-owned\n' &gt; custom-hook.json &amp;&amp; printf '{custom settings}' &gt; .claude/settings.json</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-5</span> <span class="badge ok">exit 0</span> <code>mkdir -p .azure-functions-skills &amp;&amp; printf '{opt-out}' &gt; state.local.json &amp;&amp; printf 'customer + managed block' &gt; $WS/CLAUDE.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-6</span> <span class="badge ok">exit 0</span> <code>$CLI update --local --agent claude --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2CL-3</code> <span class="muted">printf 'stale bundled\n' &gt; $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.claude/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.claude/skills/azure-functions-internal-runbook/SKILL.md</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:07.2316711Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+[IO.File]::WriteAllText((Join-Path $WS '.claude\skills\azure-functions-help\SKILL.md'), "stale bundled`n")
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.claude\skills\azure-functions-internal-runbook') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.claude\skills\azure-functions-internal-runbook\SKILL.md'), "user-owned`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2CL-4</code> <span class="muted">mkdir -p $WS/.claude/hooks &amp;&amp; printf 'user-owned\n' &gt; $WS/.claude/hooks/custom-hook.json &amp;&amp; printf '{"permissions":{"allow":["Read"]},"mcpServers":{"custom":{"command":"custom-server","args":[]}},"hooks":{"PostToolUse":[{"hooks":[{"type":"command","command":"custom-hook"}]}]}}\n' &gt; $WS/.claude/settings.json</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:13.0812090Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.claude\hooks') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.claude\hooks\custom-hook.json'), "user-owned`n")
+[IO.File]::WriteAllText((Join-Path $WS '.claude\settings.json'), '{"permissions":{"allow":["Read"]},"mcpServers":{"custom":{"command":"custom-server","args":[]}},"hooks":{"PostToolUse":[{"hooks":[{"type":"command","command":"custom-hook"}]}]}}' + "`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2CL-5</code> <span class="muted">mkdir -p $WS/.azure-functions-skills &amp;&amp; printf '{"telemetry":{"enabled":false}}\n' &gt; $WS/.azure-functions-skills/state.local.json &amp;&amp; printf 'customer\n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;\nlegacy routing\n&lt;!-- azure-functions-skills:end --&gt;\n' &gt; $WS/CLAUDE.md</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:19.3699323Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.azure-functions-skills') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.azure-functions-skills\state.local.json'), '{"telemetry":{"enabled":false}}' + "`n")
+[IO.File]::WriteAllText((Join-Path $WS 'CLAUDE.md'), "customer`n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;`nlegacy routing`n&lt;!-- azure-functions-skills:end --&gt;`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2CL-6</code> <span class="muted">$CLI update --local --agent claude --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:25.3924073Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+&amp; $CLI[0] $CLI[1] update --local --agent claude --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally updated.
   Agents: claude
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-7</span> <span class="badge ok">exit 0</span> <code>test -f help/SKILL.md &amp;&amp; ! grep 'stale bundled' &amp;&amp; cat runbook == user-owned &amp;&amp; test ! -e .azure-functions-skills &amp;&amp; cat CLAUDE.md == customer &amp;&amp; cat custom-hook.json == user-owned &amp;&amp; node -e (allow[0]=Read, mcp.custom=custom-server, mcp.azure=npx, hooks include custom-hook + track-telemetry.sh, telemetry.enabled=false)</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.claude/skills/azure-functions-help/SKILL.md</code></td><td>refreshed (no &quot;stale bundled&quot;)</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/skills/azure-functions-internal-runbook/SKILL.md</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/hooks/custom-hook.json</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>CLAUDE.md</code></td><td>managed block stripped (== customer)</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S2-CODEX-LOCAL">
-    <h3>TC-S2-CODEX-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Codex update refreshed the bundled skill, preserved user runbook/hook, merged config.toml (kept gpt-test model and custom server, replaced azure server with npx removing old-azure), injected telemetry hook, migrated opt-out, and removed legacy state plus managed block.</p>
-    <h4>Commands</h4>
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2CL-7</code> <span class="muted">test -f $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; test "$(cat $WS/.claude/skills/azure-functions-internal-runbook/SKILL.md)" = "user-owned" &amp;&amp; test ! -e $WS/.azure-functions-skills &amp;&amp; test "$(cat $WS/CLAUDE.md)" = "customer" &amp;&amp; test "$(cat $WS/.claude/hooks/custom-hook.json)" = "user-owned" &amp;&amp; node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync('$WS/.claude/settings.json'));const t=JSON.parse(fs.readFileSync('$WS/.claude/hooks/telemetry.config.json'));if(s.permissions.allow[0]!=='Read'||s.mcpServers.custom.command!=='custom-server'||s.mcpServers.azure.command!=='npx'||!JSON.stringify(s.hooks).includes('custom-hook')||!JSON.stringify(s.hooks).includes('track-telemetry.sh')||t.enabled!==false)process.exit(1)"</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:33.6446561Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CLAUDE-LOCAL'
+$fwd = $WS -replace '\\', '/'
+if (-not (Test-Path -LiteralPath (Join-Path $WS '.claude\skills\azure-functions-help\SKILL.md') -PathType Leaf)) { Fail 'missing refreshed bundled skill' }
+if ((GrepQ (Join-Path $WS '.claude\skills\azure-functions-help\SKILL.md') 'stale bundled') -eq 0) { Fail 'stale bundled content survived' }
+if (-not (TestStrEq (Join-Path $WS '.claude\skills\azure-functions-internal-runbook\SKILL.md') 'user-owned')) { Fail 'user-owned skill not preserved' }
+if (Test-Path -LiteralPath (Join-Path $WS '.azure-functions-skills')) { Fail 'legacy state survived' }
+if (-not (TestStrEq (Join-Path $WS 'CLAUDE.md') 'customer')) { Fail 'managed CLAUDE.md block not removed' }
+if (-not (TestStrEq (Join-Path $WS '.claude\hooks\custom-hook.json') 'user-owned')) { Fail 'user hook not preserved' }
+$js = "const fs=require('fs');const s=JSON.parse(fs.readFileSync('$fwd/.claude/settings.json'));const t=JSON.parse(fs.readFileSync('$fwd/.claude/hooks/telemetry.config.json'));if(s.permissions.allow[0]!=='Read'||s.mcpServers.custom.command!=='custom-server'||s.mcpServers.azure.command!=='npx'||!JSON.stringify(s.hooks).includes('custom-hook')||!JSON.stringify(s.hooks).includes('track-telemetry.sh')||t.enabled!==false)process.exit(1)"
+node -e $js
+if ($LASTEXITCODE -ne 0) { Fail "node assertion failed with exit $LASTEXITCODE" }
+Write-Output 'all S2CL-7 assertions passed'
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-  <details class="cmd">
-    <summary><span class="cid">S2XL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent codex --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+<pre>all S2CL-7 assertions passed</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details>
+</div>
+</details>
+<details class="case" open>
+<summary><span class="badge ok">PASS</span> <strong>TC-S2-CODEX-LOCAL</strong> <span class="muted">agent=codex · mode=local · 7 commands</span></summary>
+<div class="casebody">
+<p class="kv"><strong>Started:</strong> 2026-08-20T08:26:40.1437731Z &middot; <strong>Completed:</strong> 2026-08-20T08:27:20.8740110Z</p>
+<p class="analysis">Update replaced the stale bundled skill, preserved user-owned skill, hook, custom TOML model and MCP server, refreshed the azure MCP server to npx while dropping old-azure, kept custom and telemetry hooks, migrated the telemetry opt-out, and removed legacy state and the managed AGENTS.md block.</p>
+<h4>File verification</h4>
+<table class="grid"><thead><tr><th>Path (workspace relative)</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>.agents\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.agents\skills\azure-functions-internal-runbook\SKILL.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.codex\hooks\custom-hook.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.codex\hooks\telemetry.config.json</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.codex\config.toml</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>AGENTS.md</code></td><td>exists</td><td>exists</td><td><span class='badge ok'>PASS</span></td></tr>
+<tr><td><code>.azure-functions-skills</code></td><td>absent</td><td>absent</td><td><span class='badge ok'>PASS</span></td></tr>
+</tbody></table>
+<h4>Command evidence</h4>
+<details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2XL-1</code> <span class="muted">mkdir -p $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:40.1437731Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+New-Item -ItemType Directory -Force -Path $WS | Out-Null
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2XL-2</code> <span class="muted">$CLI install --local --agent codex --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:46.2193115Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+&amp; $CLI[0] $CLI[1] install --local --agent codex --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally installed.
   Agents: codex
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-3</span> <span class="badge ok">exit 0</span> <code>printf 'stale bundled\n' &gt; help/SKILL.md &amp;&amp; mkdir -p runbook &amp;&amp; printf 'user-owned\n' &gt; runbook/SKILL.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-4</span> <span class="badge ok">exit 0</span> <code>mkdir -p .codex/hooks &amp;&amp; printf 'user-owned\n' &gt; custom-hook.json &amp;&amp; printf '{custom hooks.json}' &gt; .codex/hooks.json &amp;&amp; printf 'model=gpt-test + custom + azure=old-azure' &gt; .codex/config.toml</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-5</span> <span class="badge ok">exit 0</span> <code>mkdir -p .azure-functions-skills &amp;&amp; printf '{opt-out}' &gt; state.local.json &amp;&amp; printf 'customer + managed block' &gt; $WS/AGENTS.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-6</span> <span class="badge ok">exit 0</span> <code>$CLI update --local --agent codex --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2XL-3</code> <span class="muted">printf 'stale bundled\n' &gt; $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.agents/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.agents/skills/azure-functions-internal-runbook/SKILL.md</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:26:54.1442578Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+[IO.File]::WriteAllText((Join-Path $WS '.agents\skills\azure-functions-help\SKILL.md'), "stale bundled`n")
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.agents\skills\azure-functions-internal-runbook') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.agents\skills\azure-functions-internal-runbook\SKILL.md'), "user-owned`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2XL-4</code> <span class="muted">mkdir -p $WS/.codex/hooks &amp;&amp; printf 'user-owned\n' &gt; $WS/.codex/hooks/custom-hook.json &amp;&amp; printf '{"hooks":{"PostToolUse":[{"type":"command","command":"custom-hook"}]}}\n' &gt; $WS/.codex/hooks.json &amp;&amp; printf 'model = "gpt-test"\n\n[mcp_servers.custom]\ncommand = "custom-server"\n\n[mcp_servers.azure]\ncommand = "old-azure"\n' &gt; $WS/.codex/config.toml</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:00.0878895Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.codex\hooks') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.codex\hooks\custom-hook.json'), "user-owned`n")
+[IO.File]::WriteAllText((Join-Path $WS '.codex\hooks.json'), '{"hooks":{"PostToolUse":[{"type":"command","command":"custom-hook"}]}}' + "`n")
+$toml = 'model = "gpt-test"' + "`n`n" + '[mcp_servers.custom]' + "`n" + 'command = "custom-server"' + "`n`n" + '[mcp_servers.azure]' + "`n" + 'command = "old-azure"' + "`n"
+[IO.File]::WriteAllText((Join-Path $WS '.codex\config.toml'), $toml)
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2XL-5</code> <span class="muted">mkdir -p $WS/.azure-functions-skills &amp;&amp; printf '{"telemetry":{"enabled":false}}\n' &gt; $WS/.azure-functions-skills/state.local.json &amp;&amp; printf 'customer\n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;\nlegacy routing\n&lt;!-- azure-functions-skills:end --&gt;\n' &gt; $WS/AGENTS.md</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:05.9275845Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+New-Item -ItemType Directory -Force -Path (Join-Path $WS '.azure-functions-skills') | Out-Null
+[IO.File]::WriteAllText((Join-Path $WS '.azure-functions-skills\state.local.json'), '{"telemetry":{"enabled":false}}' + "`n")
+[IO.File]::WriteAllText((Join-Path $WS 'AGENTS.md'), "customer`n&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;`nlegacy routing`n&lt;!-- azure-functions-skills:end --&gt;`n")
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>(empty)</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2XL-6</code> <span class="muted">$CLI update --local --agent codex --dir $WS</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:11.8133899Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+&amp; $CLI[0] $CLI[1] update --local --agent codex --dir $WS
+exit $LASTEXITCODE
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
+
+<pre>Azure Functions Skills locally updated.
   Agents: codex
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-7</span> <span class="badge ok">exit 0</span> <code>test -f help/SKILL.md &amp;&amp; ! grep 'stale bundled' &amp;&amp; cat runbook == user-owned &amp;&amp; test ! -e .azure-functions-skills &amp;&amp; cat AGENTS.md == customer &amp;&amp; cat custom-hook.json == user-owned &amp;&amp; grep 'model = &quot;gpt-test&quot;' &amp;&amp; grep '[mcp_servers.custom]' &amp;&amp; grep 'command = &quot;npx&quot;' &amp;&amp; ! grep 'old-azure' &amp;&amp; node -e (hooks include custom-hook + track-telemetry.sh, telemetry.enabled=false)</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.agents/skills/azure-functions-help/SKILL.md</code></td><td>refreshed (no &quot;stale bundled&quot;)</td><td class="ok">pass</td></tr>
-    <tr><td><code>.agents/skills/azure-functions-internal-runbook/SKILL.md</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/hooks/custom-hook.json</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml (model)</code></td><td>model = &quot;gpt-test&quot; preserved</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml (custom server)</code></td><td>[mcp_servers.custom] preserved</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml (azure server)</code></td><td>command = &quot;npx&quot;, no old-azure</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>managed block stripped (== customer)</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-</section>
+  Files written: 88</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details><details class="cmd">
+<summary><span class="badge ok">exit 0</span> <code>S2XL-7</code> <span class="muted">test -f $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; test "$(cat $WS/.agents/skills/azure-functions-internal-runbook/SKILL.md)" = "user-owned" &amp;&amp; test ! -e $WS/.azure-functions-skills &amp;&amp; test "$(cat $WS/AGENTS.md)" = "customer" &amp;&amp; test "$(cat $WS/.codex/hooks/custom-hook.json)" = "user-owned" &amp;&amp; grep -q 'model = "gpt-test"' $WS/.codex/config.toml &amp;&amp; grep -q '\[mcp_servers.custom\]' $WS/.codex/config.toml &amp;&amp; grep -q 'command = "npx"' $WS/.codex/config.toml &amp;&amp; ! grep -q 'old-azure' $WS/.codex/config.toml &amp;&amp; node -e "const fs=require('fs');const h=JSON.parse(fs.readFileSync('$WS/.codex/hooks.json'));const t=JSON.parse(fs.readFileSync('$WS/.codex/hooks/telemetry.config.json'));if(!JSON.stringify(h.hooks).includes('custom-hook')||!JSON.stringify(h.hooks).includes('track-telemetry.sh')||t.enabled!==false)process.exit(1)"</span></summary>
+<div class="cmdbody">
+<p class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick</code> &middot; <strong>timestamp:</strong> 2026-08-20T08:27:20.0387496Z &middot; <strong>exit code:</strong> 0</p>
+<p class="kv"><strong>executed (PowerShell translation):</strong></p>
+<pre>$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+trap { [Console]::Error.WriteLine($_.Exception.Message); exit 1 }
+$REPO = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick'
+$RUN  = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821'
+$CLI  = @('node', (Join-Path $REPO 'bin\azure-functions-skills.js'))
+function CatBytes([string]$p) {
+    $b = [IO.File]::ReadAllBytes($p)
+    $n = $b.Length
+    while ($n -gt 0 -and $b[$n - 1] -eq 10) { $n-- }
+    $r = New-Object byte[] $n
+    [Array]::Copy($b, $r, $n)
+    return ,$r
+}
+function TestStrEq([string]$p, [string]$expected) {
+    $a = CatBytes $p
+    $e = [Text.Encoding]::UTF8.GetBytes($expected)
+    if ($a.Length -ne $e.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $e[$i]) { return $false } }
+    return $true
+}
+function GrepQ([string]$p, [string]$pattern) {
+    try { $b = [IO.File]::ReadAllBytes($p) } catch { return 2 }
+    foreach ($line in ([Text.Encoding]::Latin1.GetString($b)).Split([char]10)) { if ([regex]::IsMatch($line, $pattern)) { return 0 } }
+    return 1
+}
+function Fail([string]$m) { [Console]::Error.WriteLine($m); exit 1 }
+$WS = 'Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-sturdy-fishstick\reports\e2e\20260820-0821\workspaces\TC-S2-CODEX-LOCAL'
+$fwd = $WS -replace '\\', '/'
+$toml = Join-Path $WS '.codex\config.toml'
+if (-not (Test-Path -LiteralPath (Join-Path $WS '.agents\skills\azure-functions-help\SKILL.md') -PathType Leaf)) { Fail 'missing refreshed bundled skill' }
+if ((GrepQ (Join-Path $WS '.agents\skills\azure-functions-help\SKILL.md') 'stale bundled') -eq 0) { Fail 'stale bundled content survived' }
+if (-not (TestStrEq (Join-Path $WS '.agents\skills\azure-functions-internal-runbook\SKILL.md') 'user-owned')) { Fail 'user-owned skill not preserved' }
+if (Test-Path -LiteralPath (Join-Path $WS '.azure-functions-skills')) { Fail 'legacy state survived' }
+if (-not (TestStrEq (Join-Path $WS 'AGENTS.md') 'customer')) { Fail 'managed AGENTS.md block not removed' }
+if (-not (TestStrEq (Join-Path $WS '.codex\hooks\custom-hook.json') 'user-owned')) { Fail 'user hook not preserved' }
+if ((GrepQ $toml 'model = "gpt-test"') -ne 0) { Fail 'user model setting lost' }
+if ((GrepQ $toml '\[mcp_servers.custom\]') -ne 0) { Fail 'custom mcp server lost' }
+if ((GrepQ $toml 'command = "npx"') -ne 0) { Fail 'azure mcp server not refreshed' }
+if ((GrepQ $toml 'old-azure') -eq 0) { Fail 'stale azure mcp command survived' }
+$js = "const fs=require('fs');const h=JSON.parse(fs.readFileSync('$fwd/.codex/hooks.json'));const t=JSON.parse(fs.readFileSync('$fwd/.codex/hooks/telemetry.config.json'));if(!JSON.stringify(h.hooks).includes('custom-hook')||!JSON.stringify(h.hooks).includes('track-telemetry.sh')||t.enabled!==false)process.exit(1)"
+node -e $js
+if ($LASTEXITCODE -ne 0) { Fail "node assertion failed with exit $LASTEXITCODE" }
+Write-Output 'all S2XL-7 assertions passed'
+exit 0
+</pre>
+<p class="kv"><strong>stdout (first 200 lines):</strong></p>
 
-<section>
-  <h2>Issues found</h2>
-  <p class="ok">No issues found. All 38 commands exited 0 and all file checks passed.</p>
-</section>
+<pre>all S2XL-7 assertions passed</pre>
+<p class="kv"><strong>stderr:</strong></p>
+<pre>(empty)</pre>
+</div>
+</details>
+</div>
+</details>
 
-<section class="counters">
-  <h2>Machine-checkable counters</h2>
-  <pre id="counters-json">{
-  &quot;runId&quot;: &quot;20260810-132424&quot;,
-  &quot;packageVersion&quot;: &quot;0.0.6-preview&quot;,
-  &quot;platform&quot;: &quot;windows&quot;,
-  &quot;gitCommit&quot;: &quot;0bd094698feb680a684c41905b971ec43fd7eb4c&quot;,
-  &quot;expectedCommandCount&quot;: 38,
-  &quot;actualCommandCount&quot;: 38,
-  &quot;missingCommandIds&quot;: [],
-  &quot;testCases&quot;: {
-    &quot;total&quot;: 6,
-    &quot;pass&quot;: 6,
-    &quot;fail&quot;: 0,
-    &quot;blocked&quot;: 0,
-    &quot;unsupported&quot;: 0
+<h2>Issues found</h2>
+<p class='ok-text'>No issues found. All 38 commands exited 0 and all file verifications passed.</p>
+
+<h2>Machine-checkable counters</h2>
+<pre>{
+  "runId": "20260820-0821",
+  "packageVersion": "0.0.6-preview",
+  "platform": "windows",
+  "gitCommit": "b71d1a4",
+  "expectedCommandCount": 38,
+  "actualCommandCount": 38,
+  "missingCommandIds": [],
+  "testCases": {
+    "total": 6,
+    "pass": 6,
+    "fail": 0,
+    "blocked": 0,
+    "unsupported": 0
   }
 }</pre>
-  <p>expectedCommandCount = <strong>38</strong> &middot; actualCommandCount = <strong>38</strong> &middot; missingCommandIds = <strong>(none)</strong></p>
-  <script type="application/json" id="e2e-counters">{"runId":"20260810-132424","packageVersion":"0.0.6-preview","platform":"windows","gitCommit":"0bd094698feb680a684c41905b971ec43fd7eb4c","expectedCommandCount":38,"actualCommandCount":38,"missingCommandIds":[],"testCases":{"total":6,"pass":6,"fail":0,"blocked":0,"unsupported":0}}</script>
-</section>
 
-<section>
-  <h2>Cross-Check Results</h2>
-  <p><strong>Overall: VALID</strong></p>
-  <table class="tbl"><tbody>
-    <tr><th>Reviewer model</th><td>claude-opus-4.8</td></tr>
-    <tr><th>Verified command count</th><td>38/38</td></tr>
-    <tr><th>Missing command IDs</th><td>none</td></tr>
-    <tr><th>Workarounds / extra / batched / reordered commands</th><td>none</td></tr>
-    <tr><th>Verdict overrides</th><td>none</td></tr>
-  </tbody></table>
-  <p>The reviewer compared <code>commands.md</code>, <code>checklist.md</code>, and this report: every command ID has evidence, no commands were skipped, batched, simplified, or supplemented with workarounds, and every verdict matches its command exit code and pass criteria.</p>
-  <p><strong>Non-blocking note:</strong> Several Scenario-2 seed and verify command strings are paraphrased in the per-case report summaries. This does not affect the run: the command IDs, the raw stdout/stderr/exit evidence under <code>raw/</code>, and the authoritative <code>commands.md</code> preserve full traceability of the exact commands executed.</p>
-</section>
+<h2>Pass criteria analysis</h2>
+<table class="grid">
+<thead><tr><th>Criterion (commands.md)</th><th>Result</th></tr></thead>
+<tbody>
+<tr><td>PF-2 lists <code>install --local</code> and <code>update --local</code>, and does not list <code>chat</code> or <code>setup</code></td><td><span class="badge ok">MET</span></td></tr>
+<tr><td>Scenario 1: every command exits 0 and the file list contains only skills, MCP, and telemetry surfaces</td><td><span class="badge ok">MET</span></td></tr>
+<tr><td>Scenario 1: no <code>.azure-functions-skills</code>, generated AGENTS/CLAUDE instructions, agent definitions, or welcome hooks</td><td><span class="badge ok">MET</span></td></tr>
+<tr><td>Scenario 2: all seven commands per case exit 0</td><td><span class="badge ok">MET</span></td></tr>
+<tr><td>Scenario 2: bundled skill refreshed, user assets preserved, telemetry opt-out migrated, legacy state and managed instruction block removed</td><td><span class="badge ok">MET</span></td></tr>
+<tr><td>Repository <code>git status --short</code> shows no leaked files from the run</td><td><span class="badge ok">MET</span></td></tr>
+</tbody>
+</table>
 
+<h2>Cross-Check Results</h2>
+<div id="crosscheck">
+<table>
+<tr><th>Reviewer model</th><td>gpt-5.6-sol (self-reported: GPT-5.4) &mdash; premium-model rubber-duck agent, read-only</td></tr>
+<tr><th>Cross-check completed (UTC)</th><td>2026-08-20T08:32:20Z</td></tr>
+<tr><th>Verified commands</th><td>38/38</td></tr>
+<tr><th>Missing commands</th><td>none</td></tr>
+<tr><th>Workarounds detected</th><td>none</td></tr>
+<tr><th>Verdict overrides</th><td>none</td></tr>
+<tr><th>Overall result</th><td><span class="badge pass">VALID</span></td></tr>
+</table>
+
+<h3>Reviewer findings</h3>
+<table>
+<tr><th>#</th><th>Area</th><th>Severity</th><th>Finding</th></tr>
+<tr><td>1</td><td>A &mdash; coverage</td><td>non-blocking</td><td>Expected/actual evidence/checklist counts are 38/38; no missing or duplicate IDs.</td></tr>
+<tr><td>2</td><td>B &mdash; ordering</td><td>non-blocking</td><td>Timestamps prove individual, exact-order execution with no overlaps.</td></tr>
+<tr><td>3</td><td>C &mdash; no batching</td><td>non-blocking</td><td>All bodies match the prescribed commands; no batching or supplementation. PF-1's first harness attempt launched no process and produced no evidence; the infrastructure retry does not compromise validity.</td></tr>
+<tr><td>4</td><td>D &mdash; verbatim text</td><td>non-blocking</td><td>Every evidence <code>command</code> exactly matches <code>commands.md</code>.</td></tr>
+<tr><td>5</td><td>E &mdash; translation fidelity</td><td>non-blocking</td><td>Byte comparisons, case-sensitive grep, negation/error semantics, and UTF-8 byte sorting are faithful.</td></tr>
+<tr><td>6</td><td>F &mdash; failure propagation</td><td>non-blocking</td><td>Traps and explicit native exit checks correctly propagate failures.</td></tr>
+<tr><td>7</td><td>G &mdash; verdicts</td><td>non-blocking</td><td>All exits are zero; all six PASS verdicts and criteria are supported.</td></tr>
+<tr><td>8</td><td>H &mdash; report schema</td><td>non-blocking</td><td>Required report sections, 38 command details, six file-verification sections, counters, and cross-check placeholder exist.</td></tr>
+<tr><td>9</td><td>I &mdash; isolation / leaks</td><td>non-blocking</td><td>Absolute isolated workspaces were used. Git status matches the disclosed baseline; no root installation or run leaks found.</td></tr>
+<tr><td>10</td><td>J &mdash; freshness of assets under test</td><td>non-blocking</td><td>Raw hashes differ only because <code>generateSkillMd</code> regenerates frontmatter and trims the final LF. Normalized canonical bodies match exactly in all six workspaces and include the current 0.0.6-preview CLI changes.</td></tr>
+</table>
+
+<h3>Cross-check scope</h3>
+<p class="muted">The reviewer was given read-only access to <code>SKILL.md</code>, <code>references/commands.md</code>, <code>references/report-schema.md</code>, this run's <code>checklist.md</code>, <code>report.html</code>, all 38 <code>evidence/*.json</code> files, all 38 translated command bodies under <code>_harness/cmds/</code>, and the harness scripts, and verified checklist items A&ndash;J (coverage, ordering, no batching/skipping/workarounds, verbatim command text, POSIX&rarr;PowerShell translation fidelity, failure propagation, verdict support, report-schema conformance, workspace isolation / git leak assessment, and freshness of the assets actually exercised).</p>
+
+<h3>Disclosed harness event</h3>
+<p class="muted">The first invocation of <code>exec.ps1 -Id PF-1</code> aborted before launching any command process because the harness output directory <code>_harness/out/</code> did not yet exist in the freshly created run directory. No product command process was started and no evidence file was written. After creating the directory, PF-1 was invoked again and executed normally. This was disclosed to the cross-check reviewer, who judged it a harness infrastructure defect that does not compromise evidence validity (finding&nbsp;3). No product command was retried after a real failure.</p>
+
+<h3>Why this run exists</h3>
+<p class="muted">Run <code>20260820-0800</code> passed cross-check as VALID. Afterwards the canonical create skill (<code>templates/skills/azure-functions-create/SKILL.md</code>), the generated plugin payload under <code>.github/plugins/azure-functions-skills/</code>, the eval spec (<code>evals/azure-functions-create/eval.yaml</code>), and a GitHub workflow changed. This run is a complete fresh re-execution of the same six-case, 38-command matrix against that current final workspace state, with a new run ID, a new pre-execution checklist, new evidence, a new report, and a fresh premium-model cross-check. Earlier runs <code>20260819-2337</code>, <code>20260819-2353</code>, <code>20260820-0000</code>, <code>20260820-0715</code>, <code>20260820-0730</code>, and <code>20260820-0745</code> were declared INVALID for POSIX-translation-fidelity defects and were superseded.</p>
+</div>
+
+<footer>Generated by the <code>azure-functions-e2e-tests</code> skill. Evidence JSON: <code>reports/e2e/20260820-0821/evidence/</code> &middot; Checklist: <code>reports/e2e/20260820-0821/checklist.md</code></footer>
 </body>
 </html>

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -15,6 +15,13 @@ Guide the user through creating a new Azure Functions project or adding a functi
 
 Ensure `func` (Azure Functions Core Tools v4) is installed. If not, suggest running **azure-functions-setup** first.
 
+Template discovery and application use the manifest-backed CLI released in
+`@azure/functions-skills@0.0.6-preview`. Invoke it with:
+
+```bash
+npx -y @azure/functions-skills@0.0.6-preview
+```
+
 ## Workflow
 
 ### Step 0 — Check for Go
@@ -23,34 +30,15 @@ If the user asks for **Go** (or Golang), use **Path C** below. Neither the Azure
 
 For every other language, continue with Step 1.
 
-### Step 1 — Detect Azure MCP tools
+### Step 1 — Gather requirements and best practices
 
-Check whether the following Azure MCP tools are available in your current tool list:
-
-- `functions_language_list` — list supported languages and runtime versions
-- `functions_project_get` — scaffold project-level files
-- `functions_template_get` — list templates (language only) or get a specific template (language + template)
-
-These are provided by the [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-functions) (`@azure/mcp`) and return officially maintained templates across C#, Python, TypeScript, JavaScript, Java and PowerShell.
-
-Also check for the best practices tool:
+Check for the best practices tool:
 
 - `get_azure_bestpractices` / `get_azure_bestpractices_get` with `resource: azurefunctions`
 
-- **If available** → proceed with **Path A (MCP primary)**.
-- **If not available** → proceed with **Path B (composition algorithm fallback)**.
+If available, call it before generating code:
 
----
-
-### Path A — MCP primary (recommended)
-
-Use the Azure MCP Server as the **authoritative source of truth** for Azure Functions templates. Do **not** write function code from scratch when these tools are available.
-
-#### A.1 Gather requirements & best practices
-
-If `get_azure_bestpractices` is available, call it first:
-
-```
+```text
 Tool: get_azure_bestpractices
 resource: azurefunctions
 action: code-generation
@@ -61,21 +49,31 @@ Apply the returned guidelines (programming models, extension bundles version, au
 Ask the user (or detect from context):
 
 - **Language**: `csharp` | `python` | `typescript` | `javascript` | `java` | `powershell`
-- **Trigger / template**: let the MCP list decide (step A.3)
+- **Trigger / template**: let the CLI list decide (Path A.1)
 - **Project name**: directory name
 - **Runtime version** (optional): e.g. Node.js `22`, Python `3.11`, Java `21`
 
-#### A.2 Discover supported languages
+Resolve the target directory to an absolute path. Pass it with `--dir` on every apply command so files never land in the wrong workspace.
 
-Call `functions_language_list`. Returns supported languages with runtime versions, programming models, and prerequisites. Use this to confirm the user's language choice is supported and to suggest a default runtime version.
+---
 
-#### A.3 Browse available templates
+### Path A — Manifest-backed CLI (recommended)
 
-Call `functions_template_get` with only the `language` parameter (omit `template`). This returns the list of available templates for the chosen language with descriptions. Present the templates to the user and let them pick.
+The Azure Functions Skills CLI writes official templates directly to disk. This keeps template source files out of the LLM transcript. Do **not** call `functions_template_get`, fetch repository trees, download raw template files, or reproduce template contents manually while this path works.
 
-Do **not** invent or guess template identifiers such as `HttpTrigger`. Azure MCP template IDs are versioned, language-specific strings returned by the template list. For example, the TypeScript HTTP trigger template is currently returned as `http-trigger-typescript-azd`.
+#### A.1 Browse available templates
 
-When the user asks for a common trigger name, map it to one of the template IDs returned by the MCP list before calling the template-get operation. Examples:
+List matching template metadata:
+
+```bash
+npx -y @azure/functions-skills@0.0.6-preview template list --language <language>
+```
+
+Add `--resource <resource>` or `--iac <iac>` when the user supplied those constraints. Use `--json` only when structured metadata is needed for filtering; the default text list consumes fewer tokens. Neither format contains the full template payload. Use the result to confirm language support, available runtime choices, and the exact template ID. Present relevant matches and let the user choose when intent is ambiguous.
+
+Do **not** invent or guess template identifiers such as `HttpTrigger`. Template IDs are versioned, language-specific strings returned by `template list`. For example, the TypeScript HTTP trigger template is currently returned as `http-trigger-typescript-azd`.
+
+When the user asks for a common trigger name, map it to one of the IDs returned by the list. Examples:
 
 | User intent | Language | Prefer a returned template ID like |
 | --- | --- | --- |
@@ -84,36 +82,41 @@ When the user asks for a common trigger name, map it to one of the template IDs 
 | Blob trigger | `typescript` | `blob-eventgrid-trigger-typescript-azd` |
 | Queue / Service Bus trigger | `typescript` | `servicebus-trigger-typescript-azd` |
 
-If a template-get call fails with "template not found", immediately recover by calling `functions_template_get` again with only `language`, then select the closest returned template ID instead of retrying the failed alias.
+If apply reports "template not found", immediately run `template list` again with the same language and filters, then select the closest returned ID instead of retrying a guessed alias.
 
-#### A.4 Initialize the project
+#### A.2 Apply a new project
 
-Call `functions_project_get`:
+For a new project, apply the chosen template directly into the absolute target directory:
 
-```
-Tool: functions_project_get
-language: <chosen language, e.g. typescript>
-```
-
-Returns project-level files (`host.json`, `local.settings.json`, `package.json` / `requirements.txt` / `pom.xml` / `.csproj`, `tsconfig.json`, etc.). Write these into the target directory.
-
-#### A.5 Add the function
-
-Call `functions_template_get` with both `language` and `template`:
-
-```
-Tool: functions_template_get
-language: <chosen language, e.g. typescript>
-template: <chosen returned template ID, e.g. http-trigger-typescript-azd>
-runtime-version: <optional, e.g. 22>
-output: <optional, "New" (default) or "Add" for existing projects>
+```bash
+npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode new --dir <absolute-target-directory>
 ```
 
-Returns the full function source code plus any required app settings and additional package dependencies. Write the returned file(s) into the project and merge any extra settings into `local.settings.json` and any extra packages into the dependency manifest.
+When the user selected a runtime version, also pass `--runtime-version <version>`. Do not add `--force` unless the user explicitly approves overwriting conflicts.
 
-> ⚠️ **Large template output**: Some templates (especially `*-azd` variants that include infrastructure files) can produce very large output (100KB+). If the tool output is truncated or saved to a temporary file, read the file, parse the JSON `files` array, and write each file individually. After writing files, run `npm install` (or the equivalent package manager command) to generate lock files rather than relying on lock files from the template output.
+The command downloads and writes the template locally, performs runtime placeholder substitution, and prints only a concise file summary. Do not read every generated file back into the conversation. Inspect only files needed for user-requested customization or verification.
 
-#### A.6 Verify
+Tailor the generated project to the user's requested trigger and business logic. Remove unrelated demo functions or sample data that the selected repository template included.
+
+#### A.3 Add to an existing project
+
+When `host.json` already exists, apply the selected template in add mode:
+
+```bash
+npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode add --dir <absolute-existing-project-directory>
+```
+
+Add `--runtime-version <version>` when selected. Add mode preserves root project files and existing conflicts by default. Never use `--force` without explicit confirmation.
+
+Review the concise apply summary. When dependency or settings files such as `package.json`, `requirements.txt`, or `local.settings.json` are skipped, apply the same template with `--mode new` into an isolated temporary directory. Compare only the skipped dependency/settings files, merge required entries into the existing project, then delete the temporary directory. This keeps template source local while ensuring the added trigger has every required package and setting.
+
+Keep only the requested function and its supporting code. Remove repository-level documentation, licenses, changelogs, and unrelated demo files that the apply summary shows as newly added to the existing project; never remove files that existed before the command.
+
+If the CLI rejects a nested full-project template in add mode, run `template list` again and choose an add-compatible template. If none exists, use Path B rather than forcing or reinitializing the project.
+
+#### A.4 Install dependencies and verify
+
+Run the appropriate dependency restore in the target directory (`npm install`, `pip install -r requirements.txt`, `dotnet restore`, or `mvn package` as applicable). Generate lock files through the package manager rather than asking the model to recreate them.
 
 For TypeScript and other compiled-language projects, build first:
 
@@ -141,50 +144,23 @@ After the host reports the function endpoints/listeners:
 
 ### Path B — Composition algorithm fallback
 
-Use this path **only when the Azure MCP tools are not available**. When falling back, show this notice to the user verbatim (translate to the user's language if needed):
+Use this path only after the CLI command produces an actual error and retrying discovery cannot resolve it. Do not treat a long-running download as failure without waiting for the command result.
 
-> ℹ️ Azure MCP tools were not found; using the manifest-based fallback path. Enabling the Azure MCP Server unlocks dynamic template discovery and composition. Run `azure-functions-setup` to configure it.
+When falling back, show this notice to the user verbatim (translate to the user's language if needed):
+
+> ℹ️ The manifest-backed template CLI could not complete, so I am using a higher-token fallback path. I will keep template content handling local where possible.
 
 #### B.1 Fallback algorithm
 
-Follow this manifest-based fallback algorithm:
+Prefer the first available fallback:
 
-```
-1. FETCH MANIFEST
-   GET https://cdn.functions.azure.com/public/templates-manifest/manifest.json
-   If fetch fails → fall back to:
-     https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Template-Manifest/manifest.json
-   If both fail → fall back to known-good Azure-Samples/functions-quickstart-* repos
-   If all fail → report error and ask user to retry later
+1. If Azure MCP `functions_template_get` is available, use it only for the selected template after CLI failure. Write returned files directly and avoid echoing their contents in the final response.
+2. Otherwise fetch the public manifest, select the exact entry, and download its repository/folder locally with a ZIP download or shallow clone.
+3. For a new project, use the selected template as the base. For an existing project, copy only the required function/binding files and merge dependencies/settings without replacing user-owned files.
+4. For requests that combine multiple triggers or bindings, use one project template as the base, extract only the additional binding patterns, and merge required IaC resources, RBAC roles, app settings, and dependencies.
+5. If all sources fail, report the exact errors and ask the user to retry later.
 
-2. FILTER TEMPLATES
-   Filter by: language, resource, iac
-
-3. CHECK SINGLE-TEMPLATE MATCH
-   If one template covers ALL requirements → use it alone
-
-4. SELECT TEMPLATES
-   - Trigger template (REQUIRED) — base project with IaC
-   - Binding templates (OPTIONAL) — extract patterns only
-
-5. DOWNLOAD TEMPLATES
-   For each template:
-   - If folderPath == "." → ZIP download + unzip
-   - If folderPath != "." → fetch tree + raw github url file downloads
-   - Fallback: git clone --depth 1
-
-6. COMPOSE
-   - Use trigger template as BASE
-   - EXTRACT binding patterns from binding templates
-   - MERGE IaC resources, RBAC roles and settings
-   - ADD user's custom business logic
-
-7. TRIM unused demo code (keep AzureWebJobsStorage)
-
-8. WRITE all files
-
-9. DEPLOY: azd up --no-prompt
-```
+Do not deploy automatically as part of creation. Deployment remains the responsibility of **azure-functions-deploy**.
 
 #### B.2 Quick code reference
 
@@ -218,8 +194,8 @@ Tell the user up front that **Go support on Azure Functions is in public preview
 
 If `host.json` already exists, do **not** re-initialize. Instead:
 
-- **MCP path**: call `functions_template_get` with the same language as the existing project and specify the desired template name. Write the returned file.
-- **Fallback path**: fetch the manifest, filter for the desired template by language and resource, download the template source, and merge the function files into the existing project.
+- **CLI path**: run `template list` for the existing language, then `template apply` with the exact returned ID, `--mode add`, and the absolute project directory.
+- **Fallback path**: only after an actual CLI error, retrieve the selected template through Azure MCP or the manifest and merge function files, dependencies, and settings without replacing user-owned files.
 - **Go path**: `func new` is not supported for Go. Edit `main.go`, add another `app.*` registration and, for an extension trigger, the blank import. Do not run `func init` or `go mod init` again, and do not create `function.json`. See [references/go-project.md](references/go-project.md).
 
 ## After Creation

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -15,11 +15,12 @@ Guide the user through creating a new Azure Functions project or adding a functi
 
 Ensure `func` (Azure Functions Core Tools v4) is installed. If not, suggest running **azure-functions-setup** first.
 
-Template discovery and application use the manifest-backed CLI released in
-`@azure/functions-skills@0.0.6-preview`. Invoke it with:
+Template discovery and application use the manifest-backed Azure Functions
+Skills CLI. Request the `latest` dist-tag explicitly so `npx` does not reuse
+an older locally installed package:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview
+npx -y @azure/functions-skills@latest
 ```
 
 ## Workflow
@@ -66,7 +67,7 @@ The Azure Functions Skills CLI writes official templates directly to disk. This 
 List matching template metadata:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview template list --language <language>
+npx -y @azure/functions-skills@latest template list --language <language>
 ```
 
 Add `--resource <resource>` or `--iac <iac>` when the user supplied those constraints. Use `--json` only when structured metadata is needed for filtering; the default text list consumes fewer tokens. Neither format contains the full template payload. Use the result to confirm language support, available runtime choices, and the exact template ID. Present relevant matches and let the user choose when intent is ambiguous.
@@ -89,7 +90,7 @@ If apply reports "template not found", immediately run `template list` again wit
 For a new project, apply the chosen template directly into the absolute target directory:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode new --dir <absolute-target-directory>
+npx -y @azure/functions-skills@latest template apply --language <language> --template <returned-template-id> --mode new --dir <absolute-target-directory>
 ```
 
 When the user selected a runtime version, also pass `--runtime-version <version>`. Do not add `--force` unless the user explicitly approves overwriting conflicts.
@@ -103,7 +104,7 @@ Tailor the generated project to the user's requested trigger and business logic.
 When `host.json` already exists, apply the selected template in add mode:
 
 ```bash
-npx -y @azure/functions-skills@0.0.6-preview template apply --language <language> --template <returned-template-id> --mode add --dir <absolute-existing-project-directory>
+npx -y @azure/functions-skills@latest template apply --language <language> --template <returned-template-id> --mode add --dir <absolute-existing-project-directory>
 ```
 
 Add `--runtime-version <version>` when selected. Add mode preserves root project files and existing conflicts by default. Never use `--force` without explicit confirmation.
@@ -148,17 +149,19 @@ Use this path only after the CLI command produces an actual error and retrying d
 
 When falling back, show this notice to the user verbatim (translate to the user's language if needed):
 
-> ℹ️ The manifest-backed template CLI could not complete, so I am using a higher-token fallback path. I will keep template content handling local where possible.
+> ℹ️ The manifest-backed template CLI could not complete, so I am using the public template manifest directly. I will keep template content handling local.
 
 #### B.1 Fallback algorithm
 
-Prefer the first available fallback:
+Prefer the direct manifest path before Azure MCP because the MCP template tool depends on the same manifest:
 
-1. If Azure MCP `functions_template_get` is available, use it only for the selected template after CLI failure. Write returned files directly and avoid echoing their contents in the final response.
-2. Otherwise fetch the public manifest, select the exact entry, and download its repository/folder locally with a ZIP download or shallow clone.
-3. For a new project, use the selected template as the base. For an existing project, copy only the required function/binding files and merge dependencies/settings without replacing user-owned files.
-4. For requests that combine multiple triggers or bindings, use one project template as the base, extract only the additional binding patterns, and merge required IaC resources, RBAC roles, app settings, and dependencies.
-5. If all sources fail, report the exact errors and ask the user to retry later.
+1. Fetch `https://cdn.functions.azure.com/public/templates-manifest/manifest.json`.
+2. If the CDN manifest fails, fetch its raw GitHub mirror at `https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json`.
+3. Select the exact template entry and download its `repositoryUrl` / `folderPath` locally with a ZIP download or shallow clone.
+4. For a new project, use the selected template as the base. For an existing project, copy only the required function/binding files and merge dependencies/settings without replacing user-owned files.
+5. For requests that combine multiple triggers or bindings, use one project template as the base, extract only the additional binding patterns, and merge required IaC resources, RBAC roles, app settings, and dependencies.
+6. Only if direct manifest/repository retrieval fails and Azure MCP `functions_template_get` is available, use it for the selected template. Write returned files directly and avoid echoing their contents in the final response.
+7. If all sources fail, report the exact errors and ask the user to retry later.
 
 Do not deploy automatically as part of creation. Deployment remains the responsibility of **azure-functions-deploy**.
 


### PR DESCRIPTION
## Summary

- migrate `azure-functions-create` to the manifest-backed `template list` / `template apply` CLI introduced in #196
- keep template payloads on disk instead of returning them through the model transcript, while preserving fallback, Go, dependency/settings merge, build, and runtime verification guidance
- add Vally quality and executable new/add E2E coverage, plus authenticated CLI prewarming in the reviewer-gated eval workflow
- leave `azure-functions-agents` unchanged until its replacement name is finalized

## Token impact

For `http-trigger-typescript-azd`, the applied template contained 31 files / 88,654 bytes while the CLI apply summary was 886 bytes: a 99.0% template-payload reduction. The default text template list was 2,008 bytes, 88.38% smaller than JSON metadata for the same language.

## Validation

- `npm run check` — 20 files / 265 tests passed
- `npm run eval:lint -- --eval-spec evals/azure-functions-create/eval.yaml`
- changed-skill E2E: `template apply --mode new` and `--mode add`, both TypeScript builds passed; existing files preserved
- generated Functions host returned HTTP 200 with `Hello, E2E!`
- workspace distribution E2E: 6/6 cases passed, 38/38 commands verified, cross-check VALID (`reports/e2e/current/report.html`)

Closes #231