### PR TITLE
Fix telemetry delivery reliability and add safe diagnostics

### DIFF
--- a/.github/plugins/azure-functions-skills/hooks/copilot-hooks.json
+++ b/.github/plugins/azure-functions-skills/hooks/copilot-hooks.json
@@ -4,7 +4,8 @@
       {
         "type": "command",
         "bash": "${PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh",
-        "powershell": "${PLUGIN_ROOT}/hooks/scripts/track-telemetry.ps1"
+        "powershell": "${PLUGIN_ROOT}/hooks/scripts/track-telemetry.ps1",
+        "timeoutSec": 30
       }
     ]
   }

--- a/.github/plugins/azure-functions-skills/hooks/cursor-hooks.json
+++ b/.github/plugins/azure-functions-skills/hooks/cursor-hooks.json
@@ -4,7 +4,8 @@
     "postToolUse": [
       {
         "type": "command",
-        "command": "bash ${CURSOR_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"
+        "command": "bash ${CURSOR_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh",
+        "timeout": 30
       }
     ]
   }

--- a/.github/plugins/azure-functions-skills/hooks/hooks.json
+++ b/.github/plugins/azure-functions-skills/hooks/hooks.json
@@ -5,7 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh",
+            "timeout": 30
           }
         ]
       }

--- a/.github/plugins/azure-functions-skills/hooks/scripts/track-telemetry.ps1
+++ b/.github/plugins/azure-functions-skills/hooks/scripts/track-telemetry.ps1
@@ -3,7 +3,69 @@
 
 $ErrorActionPreference = "SilentlyContinue"
 
+$packageVersion = "0.0.6-preview"
+$debugEnabled = $env:AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG -and
+    $env:AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG.ToLowerInvariant() -eq "true"
+
+function Write-TelemetryDebug {
+    param(
+        [string] $Action,
+        [string] $Status,
+        [string] $Reason,
+        [string] $RegistryUrl,
+        [object] $NpxExitCode,
+        $Event
+    )
+    if (-not $debugEnabled) { return }
+    try {
+        $directory = $env:AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR
+        if ([string]::IsNullOrWhiteSpace($directory)) {
+            $directory = Join-Path ([IO.Path]::GetTempPath()) "azure-functions-skills-telemetry"
+        }
+        [IO.Directory]::CreateDirectory($directory) | Out-Null
+        $path = Join-Path $directory "telemetry-debug.jsonl"
+        $backupPath = "$path.1"
+        $record = [ordered]@{
+            timestamp = [DateTime]::UtcNow.ToString("o")
+            component = "hook"
+            action = $Action
+            status = $Status
+            packageVersion = $packageVersion
+        }
+        if ($Reason) { $record.reason = $Reason }
+        if ($RegistryUrl) { $record.registryUrl = $RegistryUrl }
+        if ($null -ne $NpxExitCode) { $record.npxExitCode = [int]$NpxExitCode }
+        if ($null -ne $Event) { $record.event = $Event }
+        $line = ($record | ConvertTo-Json -Compress -Depth 5) + [Environment]::NewLine
+        if ((Test-Path $path) -and
+            ((Get-Item $path).Length + [Text.Encoding]::UTF8.GetByteCount($line) -gt 1MB)) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $backupPath
+            Move-Item -Force $path $backupPath
+        }
+        [IO.File]::AppendAllText($path, $line, [Text.UTF8Encoding]::new($false))
+    } catch { }
+}
+
+function Get-SafeRegistryUrl {
+    try {
+        $registry = (& npm config get registry 2>$null | Select-Object -First 1)
+        $uri = [Uri]$registry
+        if ($uri.Scheme -ne "https" -and $uri.Scheme -ne "http") { return $null }
+        $builder = [UriBuilder]$uri
+        $builder.UserName = ""
+        $builder.Password = ""
+        $builder.Query = ""
+        $builder.Fragment = ""
+        return $builder.Uri.AbsoluteUri
+    } catch {
+        return $null
+    }
+}
+
+Write-TelemetryDebug -Action "start" -Status "started"
+
 if ($env:AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY -eq "false" -or $env:AZURE_MCP_COLLECT_TELEMETRY -eq "false") {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "disabled"
     Write-Output '{"continue":true}'
     exit 0
 }
@@ -13,6 +75,7 @@ if (Test-Path $telemetryConfigPath) {
     try {
         $telemetryConfig = Get-Content -Raw -Path $telemetryConfigPath | ConvertFrom-Json
         if ($telemetryConfig.enabled -eq $false) {
+            Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "disabled"
             Write-Output '{"continue":true}'
             exit 0
         }
@@ -33,6 +96,7 @@ try {
 }
 
 if ([string]::IsNullOrWhiteSpace($rawInput)) {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "invalid-input"
     Write-Success
 }
 
@@ -83,6 +147,7 @@ if ($env:COPILOT_CLI -eq "1") {
 }
 
 if (-not $toolName) {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "no-tool-name"
     Write-Success
 }
 
@@ -190,22 +255,46 @@ if (-not $filePath -and -not $skillName) {
 }
 
 if ($shouldTrack) {
+    $correlationId = [guid]::NewGuid().ToString()
     $event = [ordered]@{
         timestamp = $timestamp
         eventType = $eventType
         clientName = $clientName
         pluginName = "azure-functions-skills"
+        pluginVersion = $packageVersion
     }
+    if ($correlationId) { $event.correlationId = $correlationId }
     if ($sessionId) { $event.sessionId = $sessionId }
     if ($skillName) { $event.skillName = $skillName }
     if ($azureToolName) { $event.toolName = $azureToolName }
     if ($filePath) { $event.fileReference = ($filePath -replace '/', '\') }
 
     try {
+        $registryUrl = $null
+        if ($debugEnabled) {
+            $registryUrl = Get-SafeRegistryUrl
+            Write-TelemetryDebug -Action "decision" -Status "tracked" -RegistryUrl $registryUrl -Event $event
+            & npm view "@azure/functions-skills@0.0.6-preview" version *> $null
+            if ($LASTEXITCODE -eq 0 -or ($null -eq $LASTEXITCODE -and $?)) {
+                Write-TelemetryDebug -Action "package-resolution" -Status "resolved" -RegistryUrl $registryUrl
+            } else {
+                Write-TelemetryDebug -Action "package-resolution" -Status "failed" -Reason "npm-resolution" -RegistryUrl $registryUrl
+            }
+        }
+        $global:LASTEXITCODE = $null
         $event | ConvertTo-Json -Compress |
-            & npx -y "@azure/functions-skills@latest" telemetry 2>&1 |
+            & npx -y "@azure/functions-skills@0.0.6-preview" telemetry 2>&1 |
             Out-Null
-    } catch { }
+        $npxExitCode = $LASTEXITCODE
+        if ($null -eq $npxExitCode) {
+            $npxExitCode = if ($?) { 0 } else { 1 }
+        }
+        Write-TelemetryDebug -Action "complete" -Status "completed" -RegistryUrl $registryUrl -NpxExitCode $npxExitCode
+    } catch {
+        Write-TelemetryDebug -Action "complete" -Status "completed" -RegistryUrl $registryUrl -NpxExitCode 1
+    }
+} else {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "filtered"
 }
 
 Write-Success

--- a/.github/plugins/azure-functions-skills/hooks/scripts/track-telemetry.sh
+++ b/.github/plugins/azure-functions-skills/hooks/scripts/track-telemetry.sh
@@ -5,7 +5,64 @@
 
 set +e
 
+package_version="0.0.6-preview"
+debug_enabled=false
+[ "$(printf '%s' "${AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG}" | tr '[:upper:]' '[:lower:]')" = "true" ] && debug_enabled=true
+
+write_debug() {
+    [ "$debug_enabled" = true ] || return
+    DEBUG_ACTION="$1" DEBUG_STATUS="$2" DEBUG_REASON="$3" DEBUG_REGISTRY="$4" \
+        DEBUG_EXIT_CODE="$5" DEBUG_EVENT="$6" \
+        AZURE_FUNCTIONS_SKILLS_PACKAGE_VERSION="$package_version" node --input-type=module -e '
+import { appendFileSync, existsSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+try {
+  const directory = process.env.AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR || join(tmpdir(), "azure-functions-skills-telemetry");
+  const path = join(directory, "telemetry-debug.jsonl");
+  const backup = `${path}.1`;
+  const record = {
+    timestamp: new Date().toISOString(),
+    component: "hook",
+    action: process.env.DEBUG_ACTION,
+    status: process.env.DEBUG_STATUS,
+    packageVersion: process.env.AZURE_FUNCTIONS_SKILLS_PACKAGE_VERSION,
+  };
+  if (process.env.DEBUG_REASON) record.reason = process.env.DEBUG_REASON;
+  if (process.env.DEBUG_REGISTRY) record.registryUrl = process.env.DEBUG_REGISTRY;
+  if (process.env.DEBUG_EXIT_CODE) record.npxExitCode = Number.parseInt(process.env.DEBUG_EXIT_CODE, 10);
+  if (process.env.DEBUG_EVENT) record.event = JSON.parse(process.env.DEBUG_EVENT);
+  const line = `${JSON.stringify(record)}\n`;
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  if (existsSync(path) && statSync(path).size + Buffer.byteLength(line) > 1024 * 1024) {
+    rmSync(backup, { force: true });
+    renameSync(path, backup);
+  }
+  appendFileSync(path, line, { mode: 0o600 });
+} catch {}
+' >/dev/null 2>&1
+}
+
+safe_registry_url() {
+    local registry
+    registry=$(npm config get registry 2>/dev/null)
+    REGISTRY_VALUE="$registry" node --input-type=module -e '
+try {
+  const url = new URL(process.env.REGISTRY_VALUE);
+  if (url.protocol !== "https:" && url.protocol !== "http:") process.exit(1);
+  url.username = "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+  process.stdout.write(url.toString());
+} catch {}
+' 2>/dev/null
+}
+
+write_debug "start" "started" "" "" "" ""
+
 if [ "${AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY}" = "false" ] || [ "${AZURE_MCP_COLLECT_TELEMETRY}" = "false" ]; then
+    write_debug "decision" "skipped" "disabled" "" "" ""
     echo '{"continue":true}'
     exit 0
 fi
@@ -18,6 +75,7 @@ return_success() {
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 config_path="${script_dir}/../telemetry.config.json"
 if [ -f "$config_path" ] && grep -Eq '"enabled"[[:space:]]*:[[:space:]]*false' "$config_path"; then
+    write_debug "decision" "skipped" "disabled" "" "" ""
     echo '{"continue":true}'
     exit 0
 fi
@@ -113,6 +171,7 @@ fi
 
 rawInput=$(cat)
 if [ -z "$rawInput" ]; then
+    write_debug "decision" "skipped" "invalid-input" "" "" ""
     return_success
 fi
 
@@ -150,6 +209,7 @@ else
 fi
 
 if [ -z "$toolName" ]; then
+    write_debug "decision" "skipped" "no-tool-name" "" "" ""
     return_success
 fi
 
@@ -208,11 +268,22 @@ if [ -z "$filePath" ] && [ -z "$skillName" ]; then
 fi
 
 if [ "$shouldTrack" = true ]; then
+    if [ -r /proc/sys/kernel/random/uuid ]; then
+        correlationId=$(cat /proc/sys/kernel/random/uuid 2>/dev/null)
+    elif command -v uuidgen >/dev/null 2>&1; then
+        correlationId=$(uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    else
+        correlationId=$(node --input-type=module -e 'import { randomUUID } from "node:crypto"; console.log(randomUUID())' 2>/dev/null)
+    fi
     payload=$(printf \
-        '{"timestamp":"%s","eventType":"%s","clientName":"%s","pluginName":"azure-functions-skills"}' \
+        '{"timestamp":"%s","eventType":"%s","clientName":"%s","pluginName":"azure-functions-skills","pluginVersion":"%s"}' \
         "$(json_escape "$timestamp")" \
         "$(json_escape "$eventType")" \
-        "$(json_escape "$clientName")")
+        "$(json_escape "$clientName")" \
+        "$(json_escape "$package_version")")
+    if [ -n "$correlationId" ]; then
+        payload="${payload%?},\"correlationId\":\"$(json_escape "$correlationId")\"}"
+    fi
     if [ -n "$sessionId" ]; then
         payload="${payload%?},\"sessionId\":\"$(json_escape "$sessionId")\"}"
     fi
@@ -226,9 +297,23 @@ if [ "$shouldTrack" = true ]; then
         payload="${payload%?},\"fileReference\":\"$(json_escape "$(echo "$filePath" | tr '/' '\\')")\"}"
     fi
 
+    registryUrl=""
+    if [ "$debug_enabled" = true ]; then
+        registryUrl=$(safe_registry_url)
+        write_debug "decision" "tracked" "" "$registryUrl" "" "$payload"
+        npm view "@azure/functions-skills@0.0.6-preview" version >/dev/null 2>&1
+        if [ "$?" -eq 0 ]; then
+            write_debug "package-resolution" "resolved" "" "$registryUrl" "" ""
+        else
+            write_debug "package-resolution" "failed" "npm-resolution" "$registryUrl" "" ""
+        fi
+    fi
     printf '%s' "$payload" |
-        npx -y @azure/functions-skills@latest telemetry >/dev/null 2>&1 ||
-        true
+        npx -y "@azure/functions-skills@0.0.6-preview" telemetry >/dev/null 2>&1
+    npxExitCode=$?
+    write_debug "complete" "completed" "" "$registryUrl" "$npxExitCode" ""
+else
+    write_debug "decision" "skipped" "filtered" "" "" ""
 fi
 
 return_success

--- a/.gitignore
+++ b/.gitignore
@@ -449,3 +449,5 @@ FodyWeavers.xsd
 # Vally eval output
 vally-results/
 results/
+
+plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,12 @@
 - Unit tests live in `tests/*.test.ts`.
 - Use `npm run test:watch` during TDD cycles.
 - Run `npm test` before every commit.
-- CLI changes require E2E verification: `node bin/azure-functions-skills.js <cmd> --dir <isolated-workspace>`.
+- CLI changes require E2E verification. Unless you are in CI pipeline, exec the CLI and verify it works.
 - When the task is not code-related (skills, CI config, documentation), TDD is not required.
+
+## Exec Plans
+
+When writing a complex feature or significant refactor, use an ExecPlan (as described in `PLANS.md`). Store each ExecPlan under `plans/` with a descriptive name, and create the directory if it does not exist.
 
 ## Security
 
@@ -91,3 +95,8 @@
 - If work stalls due to authentication or permission errors, check whether the active account matches the target repository.
 - Switch accounts with `/user switch` or `gh auth login` to match the repo's organization.
 - EMU orgs require SSO authentication; public repos use personal accounts.
+
+## Signed Commit Enforcement
+
+- During the development, commits without signed commit.
+- When you create an official PR, you need to submit signed commit. Help users to provide the signed commit.

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,143 @@
+# Execution Plans (ExecPlans):
+This document describes the requirements for an execution plan ("ExecPlan"), a design document that a coding agent can follow to deliver a working feature or system change. Treat the reader as a complete beginner to this repository: they have only the current working tree and the single ExecPlan file you provide. There is no memory of prior plans and no external context.
+
+## How to use ExecPlans and PLANS.md
+When authoring an executable specification (ExecPlan), follow PLANS.md to the letter. If it is not in your context, refresh your memory by reading the entire PLANS.md file. Be thorough in reading (and re-reading) source material to produce an accurate specification. When creating a spec, start from the skeleton and flesh it out as you do your research.
+
+When implementing an executable specification (ExecPlan), do not prompt the user for "next steps"; simply proceed to the next milestone.
+Keep all sections up to date, add or split entries in the list at every stopping point to affirmatively state the progress made and next steps. Resolve ambiguities autonomously, and commit frequently.
+
+When discussing an executable specification (ExecPlan), record decisions in a log in the spec for posterity; it should be unambiguously clear why any change to the specification was made. ExecPlans are living documents, and it should always be possible to restart from only the ExecPlan and no other work.
+
+When researching a design with challenging requirements or significant unknowns, use milestones to implement proof of concepts, "toy implementations", etc., that allow validating whether the user's proposal is feasible. Read the source code of libraries by finding or acquiring them, research deeply, and include prototypes to guide a fuller implementation.
+
+## Requirements
+
+NON-NEGOTIABLE REQUIREMENTS:
+* Every ExecPlan must be fully self-contained. Self-contained means that in its current form it contains all knowledge and instructions needed for a novice to succeed.
+* Every ExecPlan is a living document. Contributors are required to revise it as progress is made, as discoveries occur, and as design decisions are finalized. Each revision must remain fully self-contained.
+* Every ExecPlan must enable a complete novice to implement the feature end-to-end without prior knowledge of this repo.
+* Every ExecPlan must produce a demonstrably working behavior, not merely code changes to "meet a definition".
+* Every ExecPlan must define every term of art in plain language or do not use it.
+
+Purpose and intent come first. Begin by explaining, in a few sentences, why the work matters from a user's perspective: what someone can do after this change that they could not do before, and how to see it working. Then guide the reader through the exact steps to achieve that outcome, including what to edit, what to run, and what they should observe.
+
+The agent executing your plan can list files, read files, search, run the project, and run tests. It does not know any prior context and cannot infer what you meant from earlier milestones. Repeat any assumption you rely on. Do not point to external blogs or docs; if knowledge is required, embed it in the plan itself in your own words. If an ExecPlan builds upon a prior ExecPlan and that file is checked in, incorporate it by reference. If it is not, you must include all relevant context from that plan.
+
+## Formatting
+
+Format and envelope are simple and strict. Each ExecPlan must be one single fenced code block labeled as `md` that begins and ends with triple backticks. Do not nest additional triple backtick code fences inside; when you need to show commands, transcripts, diffs, or code, present them as indented blocks within that single fence. Use indentation for clarity rather than code fences inside an ExecPlan to avoid prematurely closing the ExecPlan's code fence.
+Use two newlines after every heading, use # and ## and so on, and correct syntax for ordered and unordered lists.
+
+When writing an ExecPlan to a Markdown (.md) file where the content of the file is only the single ExecPlan, you should omit the triple backticks.
+
+Write in plain prose. Prefer sentences over lists. Avoid checklists, tables, and long enumerations unless brevity would obscure meaning. Checklists are permitted only in the `Progress` section, where they are mandatory. Narrative sections must remain prose-first.
+
+## Guidelines
+
+Self-containment and plain language are paramount. If you introduce a phrase that is not ordinary English ("daemon", "middleware", "RPC gateway", "filter graph") define it immediately and remind the reader how it manifests in this repository (for example, by naming the files or commands where it appears). Do not say "as defined previously" or "according to the architecture doc." Include the needed explanation here, even if you repeat yourself.
+
+Avoid common failure modes. Do not rely on undefined jargon. Do not describe "the letter of a feature" so narrowly that the resulting code compiles but does nothing meaningful. Do not outsource key decisions to the reader. When ambiguity exists, resolve it in the plan itself and explain why you chose the path. Err on the side of over-explaining user-visible effects and under-specifying incidental implementation details.
+
+Anchor the plan with observable outcomes. State what the user can do after implementation, the commands to run, and the outputs they should see. Acceptance should be phrased as behavior a human can verify ("after starting the server, navigating to http://localhost:8080/health returns HTTP 200 with body OK") rather than internal attributes ("added a HealthCheck struct"). If a change is internal, explain how its impact can still be demonstrated (for example, by running tests that fail before and pass after, and by showing a scenario that uses the new behavior).
+
+Specify repository context explicitly. Name files with full repository-relative paths, name functions and modules precisely, and describe where new files should be created. If touching multiple areas, include a short orientation paragraph that explains how those parts fit together so a novice can navigate confidently. When running commands, show the working directory and exact command line. When outcomes depend on environment, state the assumptions and provide alternatives when reasonable.
+
+Be idempotent and safe. Write the steps so they can be run multiple times without causing damage or drift. If a step can fail halfway, include how to retry or adapt. If a migration or destructive operation is necessary, spell out backups or safe fallbacks. Prefer additive, testable changes that can be validated as you go.
+
+Validation is not optional. Include instructions to run tests, to start the system if applicable, and to observe it doing something useful. Describe comprehensive testing for any new features or capabilities. Include expected outputs and error messages so a novice can tell success from failure. Where possible, show how to prove that the change is effective beyond compilation (for example, through a small end-to-end scenario, a CLI invocation, or an HTTP request/response transcript). State the exact test commands appropriate to the project's toolchain and how to interpret their results.
+
+Capture evidence. When your steps produce terminal output, short diffs, or logs, include them inside the single fenced block as indented examples. Keep them concise and focused on what proves success. If you need to include a patch, prefer file-scoped diffs or small excerpts that a reader can recreate by following your instructions rather than pasting large blobs.
+
+## Milestones
+Milestones are narrative, not bureaucracy. If you break the work into milestones, introduce each with a brief paragraph that describes the scope, what will exist at the end of the milestone that did not exist before, the commands to run, and the acceptance you expect to observe. Keep it readable as a story: goal, work, result, proof. Progress and milestones are distinct: milestones tell the story, progress tracks granular work. Both must exist. Never abbreviate a milestone merely for the sake of brevity, do not leave out details that could be crucial to a future implementation.
+
+Each milestone must be independently verifiable and incrementally implement the overall goal of the execution plan.
+
+## Living plans and design decisions
+* ExecPlans are living documents. As you make key design decisions, update the plan to record both the decision and the thinking behind it. Record all decisions in the `Decision Log` section.
+* ExecPlans must contain and maintain a `Progress` section, a `Surprises & Discoveries` section, a `Decision Log` and an `Outcome & Retrospective` section. These are not optional.
+* When you discover optimizer behavior, performance tradeoffs, unexpected bugs, or inverse/unapply semantics that shaped your approach, capture those observations in the `Surprises & Discoveries` section with short evidence snippets (test output is ideal).
+* If you change course mid-implementation, document why in the `Decision Log` and reflect the implications in `Progress`. Plans are guides for the next contributor as much as checklists for you.
+* At completion of a major task or the full plan, write an `Outcomes & Retrospective` entry summarizing what was achieved, what remains, and lessons learned.
+
+# Prototyping milestones and parallel implementations
+It is acceptable --and often encouraged-- to include explicit prototyping milestones when they de-risk a larger change. Examples: adding a low-level operator to a dependency to validate feasibility, or exploring two composition orders while measuring optimizer effects. Keep prototypes additive and testable. Clearly label the scope as "prototyping"; describe how to run and observe results; and state the criteria for promoting or discarding the prototype.
+
+Prefer additive code changes followed by subtractions that keep tests passing. Parallel implementations(e.g., keeping an adapter alongside an older path during migration) are fine when they reduce risk or enable tests to continue passing during a large migration. Describe how to validate both paths and how to retire one safely with tests. When working with multiple new libraries or feature areas, consider creating spikes that evaluate the feasibility of these features independently of one another, proving that the external library performs as expected and implements the features we need in isolation.
+
+## Skeleton of a Good ExecPlan
+
+```md
+
+# <Short, action-oriented description>
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+If PLANS.md file is checked into the repo, reference the path to that file here from the repository root and note that this document must be maintained in accordance with PLANS.md.
+
+## Purpose / Big Picture
+
+Explain in a few sentences what someone gains after this change and how they can see it working. State the user-visible behavior you will enable.
+
+## Progress
+
+Use a list with checkboxes to summarize granular steps. Every stopping point must be documented here, even if it requires splitting a partially completed task into two ("done" vs "remaining"). This section must always reflect the actual current state of the work.
+
+- [x] (2025-10-01 13:00Z) Example completed step.
+- [ ] Example incomplete step.
+- [ ] Example partially completed step (completed: X; remaining: Y).
+
+Use timestamps to measure rates of progress.
+
+## Surprises & Discoveries
+
+Document unexpected behaviors, bugs, optimizations, or insights discovered during implementation. Provide concise evidence.
+
+- Observation: ...
+  Evidence: ...
+
+## Decision Log
+
+Record every decision made while working on the plan in the format:
+
+- Decision: ...
+  Rationale: ...
+  Date/Author: ...
+
+## Outcomes & Retrospective
+
+Summarize outcomes, gaps, and lessons learned at major milestones or at completion. Compare the result against the original purpose.
+
+## Context and Orientation
+
+Describe the current state relevant to this task as if the reader knows nothing. Name the key files and modules by full path. Define any non-obvious term you will use. Do not refer to prior plans.
+
+## Plan of Work
+
+Describe, in prose, the sequence of edits and additions. For each edit, name the file and location (function, module) and what to insert or change. Keep it concrete and minimal.
+
+## Concrete Steps
+
+State the exact commands to run and where to run them (working directory). When a command generates output, show a short expected transcript so that reader can compare. This section must be updated as work proceeds.
+
+## Validation and Acceptance
+
+Describe how to start or exercise the system and what to observe. Phrase acceptance as behavior, with specific inputs and outputs. If tests are involved, say "run <project's test command> and expect <N> passed; the new test <name> fails before the change and passes after>".
+
+## Idempotence and Recovery
+
+If steps can be repeated safely, say so. If a step is risky, provide a safe retry or rollback path. Keep the environment clean after completion.
+
+## Artifacts and Notes
+
+Include the most important transcripts, diffs, or snippets as indented examples. Keep them concise and focused on what proves success.
+
+## Interfaces and Dependencies
+
+Be prescriptive. Name the libraries, modules, and services to use and why. Specify the types, traits/interfaces, and function signatures that must exist at the end of the milestone.
+
+If you follow the guidance above, a single, stateless agent -- or a human novice -- can read your ExecPlan from top to bottom and produce a working, observable result. That is the bar: SELF-CONTAINED, SELF-SUFFICIENT, NOVICE-GUIDING, OUTCOME-FOCUSED.
+
+When you revise a plan, you must ensure your changes are comprehensively reflected across all sections, including the living document sections, and you must write a note at the bottom of the plan describing the change and the reason why. ExecPlans must describe not just the what but the why for almost everything.
+```

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ For host-managed plugin installs, opt out by setting either
 in the environment. Workspace-local installs can also use `--no-telemetry`; that preference
 is stored in the installed `telemetry.config.json` and preserved by local updates.
 
+To diagnose telemetry without exposing user content, enable safe JSON Lines logging and run
+the telemetry diagnostic:
+
+```bash
+AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG=true \
+AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR=./telemetry-diagnostics \
+npx @azure/functions-skills telemetry doctor
+```
+
+Diagnostic logs contain only allowlisted telemetry fields, package/plugin versions, a
+credential-free npm registry URL, command status, sanitized ingestion counts, and a
+correlation ID. Logs are limited to a 1 MiB current file and one 1 MiB backup. They never
+contain connection strings, authentication values, prompts, file contents, raw hook input,
+or raw tool arguments.
+
 ## Skills
 
 For contributor guidance on the product boundary between Azure Skills and Azure Functions Skills, see [Azure Skills and Azure Functions Skills Boundary](docs/azure-skills-boundary.md).

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -7,6 +7,10 @@ parameters:
       displayName: 'Dry Run'
       type: boolean
       default: true
+    - name: RunTelemetryCanary
+      displayName: 'Run telemetry canary after publish'
+      type: boolean
+      default: false
 
 trigger: none
 pr: none
@@ -66,3 +70,24 @@ extends:
                             publishMethod: esrp
                             esrpNpmTag: ${{ parameters.NpmPublishTag }}
                             approvers: '$(EsrpManualApprovers)'
+            - ${{ if and(eq(parameters.NpmPublishDryRun, false), eq(parameters.RunTelemetryCanary, true)) }}:
+                - stage: TelemetryCanary
+                  displayName: 'Verify published telemetry ingestion'
+                  dependsOn: Release
+                  pool:
+                      name: 1es-pool-azfunc
+                      image: 1es-ubuntu-22.04
+                      os: linux
+                  jobs:
+                      - job: VerifyTelemetry
+                        steps:
+                            - task: NodeTool@0
+                              inputs:
+                                  versionSpec: 22.x
+                              displayName: 'Install Node.js'
+                            - script: node scripts/telemetry-release-canary.mjs
+                              displayName: 'Download published tarball and verify ingestion'
+                              env:
+                                  NPM_PUBLISH_TAG: ${{ parameters.NpmPublishTag }}
+                                  APPLICATIONINSIGHTS_APP_ID: $(ApplicationInsightsAppId)
+                                  APPLICATIONINSIGHTS_API_KEY: $(ApplicationInsightsApiKey)

--- a/bin/azure-functions-skills.js
+++ b/bin/azure-functions-skills.js
@@ -17,6 +17,7 @@ Commands:
   template list     List Azure Functions templates
   template apply    Apply an Azure Functions template
   build             Build local and plugin artifacts
+  telemetry doctor  Safely test telemetry configuration and ingestion
 
 Plugin installation is managed by the host coding agent, not this package.
 `;
@@ -92,6 +93,27 @@ if (command === 'install' || command === 'update') {
 }
 
 async function runTelemetryCommand() {
+  if (args[1] === 'doctor' || args[1] === 'test') {
+    try {
+      const { diagnoseTelemetry } = await import('../lib/telemetry/index.js');
+      const report = await diagnoseTelemetry(process.env);
+      if (args.includes('--json')) console.log(JSON.stringify(report, null, 2));
+      else {
+        console.log('Azure Functions Skills telemetry diagnostic');
+        console.log(`  Package: resolved (${report.packageVersion})`);
+        console.log(`  Telemetry: ${report.telemetryEnabled ? 'enabled' : 'disabled'}`);
+        console.log(`  Configuration: ${report.configurationStatus}`);
+        console.log(`  Transport: ${report.transportStatus}`);
+        console.log(`  Ingestion accepted: ${report.ingestionAccepted ? 'yes' : 'no'}`);
+        console.log(`  Correlation ID: ${report.correlationId}`);
+        console.log(`  Debug diagnostics: ${report.diagnosticsEnabled ? `enabled (${report.logDirectory})` : 'disabled'}`);
+      }
+      process.exit(report.transportStatus === 'failed' ? 1 : 0);
+    } catch (error) {
+      console.error(`Telemetry diagnostic failed: ${errorMessage(error)}`);
+      process.exit(1);
+    }
+  }
   try {
     const rawInput = await readStdin(16 * 1024);
     if (rawInput.trim().length === 0) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -60,3 +60,16 @@ npm run build:plugin-payload
 ```
 
 The plugin payload always contains skills, MCP configuration, and telemetry hooks. There are no payload profiles.
+
+## Telemetry diagnostics
+
+```bash
+npx @azure/functions-skills telemetry doctor
+npx @azure/functions-skills telemetry doctor --json
+```
+
+The command reports package resolution, opt-out and release configuration state, transport
+status, ingestion acceptance, and a correlation ID. Set
+`AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG=true` to write safe JSON Lines diagnostics. Use
+`AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR` to select the directory; otherwise diagnostics
+use the operating system temporary directory. Debugging remains disabled by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "eslint": "^10.3.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.1",
-        "vitest": "^4.1.7"
+        "vitest": "^4.1.7",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -3715,8 +3716,8 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "resolved": "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "validate:skills": "npm run compile && node lib/build/validate-skills.js",
     "verify:plugin-payload": "npm run compile && node lib/build/verify-plugin-payload.js",
     "release:local": "node scripts/release-local.mjs",
+    "telemetry:canary": "node scripts/telemetry-release-canary.mjs",
     "eval:lint": "vally lint",
     "eval:smoke": "vally eval --suite smoke",
     "eval:full": "vally eval --suite full",
@@ -66,7 +67,8 @@
     "eslint": "^10.3.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "yaml": "^2.9.0"
   },
   "keywords": [
     "azure-functions",

--- a/plans/issue-233-telemetry-reliability.md
+++ b/plans/issue-233-telemetry-reliability.md
@@ -1,0 +1,123 @@
+# Make telemetry delivery reliable and safely diagnosable
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. This document follows `PLANS.md` at the repository root.
+
+## Purpose / Big Picture
+
+Azure Functions Skills telemetry currently reports an Application Insights flush as failed whenever the SDK callback contains any text, even when that text says every item was accepted. After this change, accepted ingestion exits successfully, normal hooks remain silent and fail open, and a user can opt into safe JSON Lines diagnostics with `AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG=true`. A user can also run `azure-functions-skills telemetry doctor` to distinguish opt-out, missing release configuration, and transport or ingestion outcomes without exposing project content or credentials.
+
+## Progress
+
+- [x] (2026-08-25 23:30Z) Read Issue 233, repository instructions, telemetry implementation, generated-hook pipeline, release pipeline, and existing tests.
+- [x] (2026-08-25 23:33Z) Added failing tests for successful ingestion parsing, transient retry, safe bounded diagnostics, deterministic hooks, explicit timeout, dimensions, and the diagnostic CLI.
+- [x] (2026-08-25 23:35Z) Implemented sender result parsing, correlation/version dimensions, safe diagnostics, retry, and telemetry doctor.
+- [x] (2026-08-26 00:10Z) Updated canonical hook templates and build-time version substitution, then regenerated and verified derived plugin payloads.
+- [x] (2026-08-26 00:09Z) Added an explicitly gated post-release canary that waits for the expected public version, downloads its tarball, sends a correlated diagnostic, and queries Application Insights.
+- [x] (2026-08-26 00:12Z) Ran targeted tests, the 276-test repository gate, three isolated E2E matrices after successive review fixes, and a Claude Opus 5 rubber-duck review; the final matrix passed 38/38 commands and 6/6 cases.
+- [x] (2026-08-26 00:20Z) Completed the Claude Sonnet 5 E2E evidence cross-check: VALID, 38/38 commands verified, no missing commands or verdict overrides.
+- [x] (2026-08-26 00:21Z) Published the VALID E2E report to `reports/e2e/current/report.html`.
+- [x] (2026-08-26 00:22Z) Prepared the completed implementation as one conventional commit with the required co-author trailer; its SHA is reported to the parent session after creation.
+- [ ] Commit the complete implementation and report its commit SHA to the parent session.
+
+## Surprises & Discoveries
+
+- Observation: The user-provided working tree contains `PLANS.md`, which defines ExecPlan rules, but no issue-specific ExecPlan.
+  Evidence: `git status --short` lists `PLANS.md`, and `plans/**` initially contains no files.
+- Observation: workspace-local installation builds telemetry hooks without setting `BuildData.packageVersion`.
+  Evidence: `src/setup/index.ts` returns skills, MCP servers, and hooks only, so deterministic hook substitution must also load the installed package version.
+- Observation: Windows PowerShell 5.1 corrupts the original Node inline UUID command, and malformed release YAML was not covered by substring-only tests.
+  Evidence: Claude Opus 5 reproduced an invalid `{}` correlation value and a YAML parse failure; `[guid]::NewGuid()` plus a real PowerShell 5.1-to-CLI test and a `yaml.parse` release test now cover both.
+- Observation: Copilot CLI documents `timeoutSec`, while Claude and Cursor use `timeout`.
+  Evidence: the final canonical registrations use the host-specific key and generated distribution tests assert each shape.
+
+## Decision Log
+
+- Decision: Include the P0 and P1 issue scope plus a single immediate retry for explicitly transient failures and two bounded diagnostic log generations.
+  Rationale: These are small extensions of the same delivery boundary, directly satisfy the issue's reliability goal, and can be proven deterministically without changing telemetry architecture.
+  Date/Author: 2026-08-25 / Copilot
+- Decision: Keep diagnostics allowlisted and typed rather than accepting arbitrary objects for logging.
+  Rationale: A generic logger would make it too easy for future callers to write raw hook input, prompts, arguments, credentials, or connection strings.
+  Date/Author: 2026-08-25 / Copilot
+- Decision: Inject the package version into canonical hook scripts through a `__PACKAGE_VERSION__` placeholder during asset generation.
+  Rationale: The template remains canonical while every generated hook invokes the exact package/plugin version that produced it.
+  Date/Author: 2026-08-25 / Copilot
+- Decision: Keep deterministic package invocation without an `@latest` fallback, and make release publication ordering observable through the gated canary.
+  Rationale: Issue 233 explicitly requires deterministic generated hooks. The canary waits until the exact `package.json` version appears on the requested npm tag before testing, preventing a green result against an older release.
+  Date/Author: 2026-08-26 / Copilot
+- Decision: Use a 30-second host timeout, with Copilot's `timeoutSec` key and Claude/Cursor's `timeout` key.
+  Rationale: Ten seconds is too short for a pinned npx cold cache and debug-only npm resolution, while 30 seconds remains finite and matches documented host schemas.
+  Date/Author: 2026-08-26 / Copilot
+
+## Outcomes & Retrospective
+
+The implementation now correctly recognizes accepted Application Insights responses, emits safe correlation and version dimensions, provides opt-in bounded diagnostics and a telemetry doctor, pins generated hooks, retries one transient failure, and offers a gated expected-version release canary. The full repository gate passes 276 tests. The final isolated E2E run `20260825-171025` passes all 38 commands and all six local-install/update cases, and its Claude Sonnet 5 evidence cross-check is VALID. The validated report is published and no Issue 233 scope is intentionally deferred.
+
+## Context and Orientation
+
+`src/telemetry/sender.ts` validates a narrow telemetry event and sends it through `applicationinsights` version 1.8.10. Its flush callback currently rejects every non-empty response. `bin/azure-functions-skills.js` accepts internal telemetry events on standard input. Canonical hook definitions and scripts live under `templates/hooks/`; build code in `src/build/build-target.ts` copies them into plugin and workspace distributions. Generated repository plugin files under `.github/plugins/`, `.plugin/`, and `.claude-plugin/` must never be edited directly and are regenerated with `npm run build:plugin-payload`.
+
+The diagnostic log is JSON Lines, meaning one JSON object per line. It is enabled only when `AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG` equals `true`, case-insensitively. `AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR` selects its directory. Each record contains only a timestamp and typed safe fields: lifecycle status, skip reason, an already validated telemetry event, package/plugin versions, a credential-free registry origin/path, an integer command exit code, a correlation identifier, and numeric Application Insights acceptance counts or sanitized status categories.
+
+## Plan of Work
+
+First extend unit tests in `tests/telemetry.test.ts` so a JSON callback with equal received and accepted counts succeeds, partial acceptance fails, and only recognized transient responses retry once within one total deadline. Add diagnostics tests that enable logging into a temporary directory, assert safe fields, assert forbidden source values are absent, and force rotation past the byte limit. Extend distribution and hook tests to require `@azure/functions-skills@<build version>`, correlation and version fields, explicit hook timeouts, safe registry logging, exit-code logging, and unchanged fail-open output. Extend CLI tests for `telemetry doctor --json`.
+
+Then refactor `src/telemetry/sender.ts` around a sanitized ingestion-result parser and one total delivery deadline. Add a typed diagnostics module under `src/telemetry/` and a diagnostic-report function exposed by `src/telemetry/index.ts`. Package and plugin versions and correlation IDs become custom dimensions, while older sanitized hook payloads remain accepted and receive safe defaults.
+
+Update `templates/hooks/scripts/track-telemetry.sh` and `.ps1` to construct only the current sanitized event, invoke the deterministic package version, and write hook diagnostics only when opted in. Update canonical hook JSON and workspace-generated hook objects with an explicit timeout. Change `src/build/build-target.ts` to replace the package-version placeholder and `src/setup/index.ts` to load the installed package version.
+
+For release canary support, add a gated script and release-pipeline job only if the current ESRP publish boundary can safely access both the published package and Application Insights verification credentials after publication. If the external release template does not expose a post-publication continuation point, record that boundary and provide a reusable canary script for a separately gated pipeline rather than claiming automatic verification.
+
+## Concrete Steps
+
+Work from the repository root. Run targeted red/green tests with:
+
+    npm test -- tests/telemetry.test.ts tests/telemetry-diagnostics.test.ts tests/telemetry-hook.test.ts tests/simplified-distribution.test.ts tests/simplified-cli.test.ts tests/telemetry-release.test.ts
+
+After canonical template changes, regenerate and verify:
+
+    npm run build:plugin-payload
+    npm run verify:plugin-payload
+
+Run the complete non-LLM gate:
+
+    npm run check
+
+Exercise the CLI in an isolated temporary workspace, never the repository root:
+
+    node bin/azure-functions-skills.js install --local --agent ghcp --dir <temporary-directory>
+    node bin/azure-functions-skills.js telemetry doctor --json
+
+Do not run Vally evaluations and do not run `doctor --deep`.
+
+## Validation and Acceptance
+
+The targeted telemetry suite must show that `{"itemsReceived":1,"itemsAccepted":1,"errors":[]}` succeeds and that partial acceptance does not. Existing silent hook tests must still return only `{"continue":true}` with exit code zero even when the package invocation exits nonzero. Debug hook tests must explain tracked, skipped/disabled, npm resolution, transport, and accepted outcomes using only safe fields, and test source strings representing a connection string, credential, prompt, file content, raw hook input, and raw tool argument must not occur in the log.
+
+Generated shell and PowerShell hooks must contain the package version supplied in `BuildData`, contain no `@latest`, and generated hook registrations must set a finite timeout. Emitted Application Insights properties must include package version, plugin version, and correlation ID. `telemetry doctor --json` must report package resolution, opt-out, configuration, transport, and ingestion acceptance without printing a connection string.
+
+`npm run check` must pass. The isolated install must write a version-pinned hook, and the diagnostic command must produce a structured report. A Claude-family `rubber-duck` agent must review the final diff and any correctness findings must be resolved before commit.
+
+## Idempotence and Recovery
+
+Tests and builds are repeatable. Diagnostic log rotation renames only the known current telemetry log to one known backup and overwrites the previous backup; it never recursively deletes a directory. If template payload verification fails, rerun `npm run build:plugin-payload` rather than editing generated files. Temporary end-to-end directories are created outside the repository and removed after inspection.
+
+## Artifacts and Notes
+
+The observed successful SDK callback that motivated the fix is:
+
+    {"itemsReceived":1,"itemsAccepted":1,"appId":null,"errors":[]}
+
+The intended normal hook output remains:
+
+    {"continue":true}
+
+## Interfaces and Dependencies
+
+`src/telemetry/sender.ts` continues to export `parseTelemetryEvent`, `sendTelemetryEvent`, and `sendTelemetryEventWithDependencies`. `TelemetryEvent` gains optional safe `correlationId` and `pluginVersion` properties and supports an internal `telemetry_diagnostic` event type. `TelemetryDependencies` supplies package version and diagnostics dependencies for deterministic tests.
+
+`src/telemetry/diagnostics.ts` exports typed diagnostic record functions and constants for bounded size. It uses only Node built-ins. No new package dependency is required. `applicationinsights` remains the transport; this work explicitly does not migrate telemetry to Azure MCP.
+
+Revision note (2026-08-25): Created the issue-specific ExecPlan because only the repository-wide `PLANS.md` rules were present. Scope and decisions were derived from Issue 233 and the parent task.
+
+Revision note (2026-08-26): Updated all living sections after implementation and Claude-family review, recorded PowerShell/YAML/schema discoveries, and captured final validation evidence.

--- a/reports/e2e/current/report.html
+++ b/reports/e2e/current/report.html
@@ -3,82 +3,33 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Azure Functions Skills E2E Report — 20260810-132424</title>
-<style>
-  :root { --ok:#1a7f37; --bad:#cf222e; --warn:#9a6700; --bg:#f6f8fa; --bd:#d0d7de; --fg:#1f2328; }
-  * { box-sizing: border-box; }
-  body { font-family: -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; color:var(--fg); margin:0; padding:0 1rem 4rem; line-height:1.5; }
-  header { padding:1.5rem 0 1rem; border-bottom:1px solid var(--bd); }
-  h1 { margin:0 0 .25rem; font-size:1.5rem; }
-  .meta { color:#57606a; font-size:.9rem; }
-  .meta code { background:var(--bg); padding:.05rem .3rem; border-radius:4px; }
-  .cards { display:flex; flex-wrap:wrap; gap:.75rem; margin:1rem 0; }
-  .card { border:1px solid var(--bd); border-radius:8px; padding:.75rem 1rem; min-width:120px; background:#fff; }
-  .card .n { font-size:1.6rem; font-weight:700; }
-  .card.pass .n { color:var(--ok); } .card.fail .n { color:var(--bad); } .card.blocked .n { color:var(--warn); }
-  table.tbl { border-collapse:collapse; width:100%; margin:.5rem 0 1.5rem; }
-  table.tbl th, table.tbl td { border:1px solid var(--bd); padding:.4rem .6rem; text-align:left; font-size:.9rem; vertical-align:top; }
-  table.tbl th { background:var(--bg); }
-  .status { font-weight:700; text-transform:uppercase; font-size:.75rem; padding:.1rem .45rem; border-radius:999px; }
-  .status.pass { color:#fff; background:var(--ok); } .status.fail { color:#fff; background:var(--bad); }
-  .status.blocked { color:#fff; background:var(--warn); } .status.incomplete { color:#fff; background:#8250df; }
-  section.case { border:1px solid var(--bd); border-radius:8px; padding:1rem 1.25rem; margin:1rem 0; background:#fff; }
-  section.case h3 { margin-top:0; }
-  .analysis { color:#57606a; }
-  details.cmd { border:1px solid var(--bd); border-radius:6px; margin:.4rem 0; background:var(--bg); }
-  details.cmd summary { cursor:pointer; padding:.5rem .75rem; display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; }
-  details.cmd summary code { font-size:.82rem; }
-  .cid { font-weight:700; font-family:monospace; }
-  .badge { font-size:.72rem; font-weight:700; padding:.05rem .4rem; border-radius:999px; color:#fff; }
-  .badge.ok { background:var(--ok); } .badge.bad { background:var(--bad); } .badge.warn { background:var(--warn); }
-  details.cmd .kv, details.cmd .io { padding:0 .75rem; }
-  .io-h { font-size:.75rem; text-transform:uppercase; color:#57606a; margin-top:.4rem; }
-  pre { background:#0d1117; color:#e6edf3; padding:.6rem .8rem; border-radius:6px; overflow:auto; font-size:.8rem; max-height:420px; }
-  td.ok, .ok { color:var(--ok); font-weight:600; } td.bad, .bad { color:var(--bad); font-weight:600; }
-  .counters pre { background:var(--bg); color:var(--fg); border:1px solid var(--bd); }
-  a { color:#0969da; }
-  @media print { details.cmd[open] summary { } pre { max-height:none; } details { break-inside: avoid; } }
-</style>
+<title>Azure Functions Skills E2E Report — 20260825-171025</title>
+<style>:root{--ok:#1a7f37;--bad:#cf222e;--warn:#9a6700;--bg:#f6f8fa;--bd:#d0d7de;--fg:#1f2328;}*{box-sizing:border-box}body{font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--fg);margin:0;padding:0 1rem 4rem;line-height:1.5}header{padding:1.5rem 0 1rem;border-bottom:1px solid var(--bd)}h1{margin:0 0 .25rem;font-size:1.5rem}.meta{color:#57606a;font-size:.9rem}.meta code{background:var(--bg);padding:.05rem .3rem;border-radius:4px}.cards{display:flex;flex-wrap:wrap;gap:.75rem;margin:1rem 0}.card{border:1px solid var(--bd);border-radius:8px;padding:.75rem 1rem;min-width:120px;background:#fff}.card .n{font-size:1.6rem;font-weight:700}.card.pass .n{color:var(--ok)}.card.fail .n{color:var(--bad)}.card.blocked .n{color:var(--warn)}table.tbl{border-collapse:collapse;width:100%;margin:.5rem 0 1.5rem}table.tbl th,table.tbl td{border:1px solid var(--bd);padding:.4rem .6rem;text-align:left;font-size:.9rem;vertical-align:top}table.tbl th{background:var(--bg)}.status{font-weight:700;text-transform:uppercase;font-size:.75rem;padding:.1rem .45rem;border-radius:999px}.status.pass{color:#fff;background:var(--ok)}.status.fail{color:#fff;background:var(--bad)}.status.blocked{color:#fff;background:var(--warn)}section.case{border:1px solid var(--bd);border-radius:8px;padding:1rem 1.25rem;margin:1rem 0;background:#fff}section.case h3{margin-top:0}.analysis{color:#57606a}details.cmd{border:1px solid var(--bd);border-radius:6px;margin:.4rem 0;background:var(--bg)}details.cmd summary{cursor:pointer;padding:.5rem .75rem;display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}details.cmd summary code{font-size:.82rem}.cid{font-weight:700;font-family:monospace}.badge{font-size:.72rem;font-weight:700;padding:.05rem .4rem;border-radius:999px;color:#fff}.badge.ok{background:var(--ok)}.badge.bad{background:var(--bad)}details.cmd .kv,details.cmd .io{padding:0 .75rem}.io-h{font-size:.75rem;text-transform:uppercase;color:#57606a;margin-top:.4rem}pre{background:#0d1117;color:#e6edf3;padding:.6rem .8rem;border-radius:6px;overflow:auto;font-size:.8rem;max-height:420px}.ok{color:var(--ok);font-weight:600}.bad{color:var(--bad);font-weight:600}.counters pre{background:var(--bg);color:var(--fg);border:1px solid var(--bd)}a{color:#0969da}@media print{pre{max-height:none}details{break-inside:avoid}}</style>
 </head>
 <body>
 <header>
-  <h1>Azure Functions Skills — Local E2E Report</h1>
-  <div class="meta">
-    Run ID <code>20260810-132424</code> &middot; Generated <code>2026-08-10T20:34:35.094Z</code><br>
-    Package version <code>0.0.6-preview</code> &middot; Platform <code>windows</code> &middot; Git commit <code>0bd094698feb680a684c41905b971ec43fd7eb4c</code>
-  </div>
+<h1>Azure Functions Skills — Local E2E Report</h1>
+<div class="meta">Run ID <code>20260825-171025</code> &middot; Generated <code>2026-08-26T00:11:07.355538Z</code><br>Package version <code>0.0.6-preview</code> &middot; Platform <code>windows</code> &middot; Git commit <code>b71d1a4a796a1d68e2bb05930baf920655fadb84</code></div>
 </header>
-
-<section>
-  <h2>Summary</h2>
-  <div class="cards">
-    <div class="card pass"><div class="n">6</div><div>Pass</div></div>
-    <div class="card fail"><div class="n">0</div><div>Fail</div></div>
-    <div class="card blocked"><div class="n">0</div><div>Blocked</div></div>
-    <div class="card"><div class="n">38/38</div><div>Commands (actual/expected)</div></div>
-    <div class="card"><div class="n">6</div><div>Test cases</div></div>
-  </div>
-</section>
-
-<section>
-  <h2>Preflight</h2>
-  <p>Status: <span class="status pass">pass</span> &middot;
-     <code>install --local</code> listed: <span class="ok">true</span> &middot;
-     <code>update --local</code> listed: <span class="ok">true</span> &middot;
-     no <code>chat</code>: <span class="ok">true</span> &middot;
-     no <code>setup</code>: <span class="ok">true</span></p>
-
-  <details class="cmd">
-    <summary><span class="cid">PF-1</span> <span class="badge ok">exit 0</span> <code>$CLI --version</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>0.0.6-preview
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">PF-2</span> <span class="badge ok">exit 0</span> <code>$CLI --help</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>@azure/functions-skills — Azure Functions skills for coding agents
+<section><h2>Summary</h2><div class="cards">
+<div class="card pass"><div class="n">6</div><div>Pass</div></div>
+<div class="card fail"><div class="n">0</div><div>Fail</div></div>
+<div class="card blocked"><div class="n">0</div><div>Blocked</div></div>
+<div class="card"><div class="n">38/38</div><div>Commands (actual/expected)</div></div>
+<div class="card"><div class="n">6</div><div>Test cases</div></div>
+</div></section>
+<section><h2>Preflight</h2>
+<p>Status: <span class="status pass">pass</span> &middot; <code>install --local</code> listed: <span class="ok">true</span> &middot; <code>update --local</code> listed: <span class="ok">true</span> &middot; no <code>chat</code>: <span class="ok">true</span> &middot; no <code>setup</code>: <span class="ok">true</span></p>
+<details class="cmd">
+<summary><span class="cid">PF-1</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js --version</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>0.0.6-preview</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">PF-2</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js --help</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>@azure/functions-skills — Azure Functions skills for coding agents
 
 Commands:
   install --local   Copy skills, MCP, and telemetry hooks into a workspace
@@ -87,716 +38,918 @@ Commands:
   template list     List Azure Functions templates
   template apply    Apply an Azure Functions template
   build             Build local and plugin artifacts
+  telemetry doctor  Safely test telemetry configuration and ingestion
 
-Plugin installation is managed by the host coding agent, not this package.
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
+Plugin installation is managed by the host coding agent, not this package.</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
 </section>
-
-<section>
-  <h2>Test matrix</h2>
-  <table class="tbl"><thead><tr><th>Test case</th><th>Agent</th><th>Scenario</th><th>Status</th></tr></thead>
-  <tbody>
-  <tr>
-    <td><a href="#TC-S1-GHCP-LOCAL">TC-S1-GHCP-LOCAL</a></td>
-    <td>ghcp</td>
-    <td>fresh-install</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S1-CLAUDE-LOCAL">TC-S1-CLAUDE-LOCAL</a></td>
-    <td>claude</td>
-    <td>fresh-install</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S1-CODEX-LOCAL">TC-S1-CODEX-LOCAL</a></td>
-    <td>codex</td>
-    <td>fresh-install</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S2-GHCP-LOCAL">TC-S2-GHCP-LOCAL</a></td>
-    <td>ghcp</td>
-    <td>update-ownership</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S2-CLAUDE-LOCAL">TC-S2-CLAUDE-LOCAL</a></td>
-    <td>claude</td>
-    <td>update-ownership</td>
-    <td class="status pass">pass</td>
-  </tr>
-  <tr>
-    <td><a href="#TC-S2-CODEX-LOCAL">TC-S2-CODEX-LOCAL</a></td>
-    <td>codex</td>
-    <td>update-ownership</td>
-    <td class="status pass">pass</td>
-  </tr></tbody></table>
-</section>
-
-<section>
-  <h2>Per-case evidence</h2>
-
-  <section class="case" id="TC-S1-GHCP-LOCAL">
-    <h3>TC-S1-GHCP-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Fresh GHCP local install produced skills, MCP, and telemetry hooks only; no legacy or agent-definition artifacts.</p>
-    <h4>Commands</h4>
-
-  <details class="cmd">
-    <summary><span class="cid">S1GL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent ghcp --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+<section><h2>Test matrix</h2><table class="tbl"><thead><tr><th>Test case</th><th>Agent</th><th>Scenario</th><th>Status</th></tr></thead><tbody>
+<tr><td><a href="#TC-S1-GHCP-LOCAL">TC-S1-GHCP-LOCAL</a></td><td>ghcp</td><td>fresh-install</td><td class="status pass">pass</td></tr>
+<tr><td><a href="#TC-S1-CLAUDE-LOCAL">TC-S1-CLAUDE-LOCAL</a></td><td>claude</td><td>fresh-install</td><td class="status pass">pass</td></tr>
+<tr><td><a href="#TC-S1-CODEX-LOCAL">TC-S1-CODEX-LOCAL</a></td><td>codex</td><td>fresh-install</td><td class="status pass">pass</td></tr>
+<tr><td><a href="#TC-S2-GHCP-LOCAL">TC-S2-GHCP-LOCAL</a></td><td>ghcp</td><td>update-ownership</td><td class="status pass">pass</td></tr>
+<tr><td><a href="#TC-S2-CLAUDE-LOCAL">TC-S2-CLAUDE-LOCAL</a></td><td>claude</td><td>update-ownership</td><td class="status pass">pass</td></tr>
+<tr><td><a href="#TC-S2-CODEX-LOCAL">TC-S2-CODEX-LOCAL</a></td><td>codex</td><td>update-ownership</td><td class="status pass">pass</td></tr>
+</tbody></table></section>
+<section><h2>Per-case evidence</h2>
+<section class="case" id="TC-S1-GHCP-LOCAL">
+<h3>TC-S1-GHCP-LOCAL <span class="status pass">pass</span></h3>
+<p class="analysis">Fresh GHCP local install should contain only the expected skill, MCP, and telemetry surfaces.</p>
+<h4>Commands</h4>
+<details class="cmd">
+<summary><span class="cid">S1GL-1</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL&#x27; | Out-Null</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1GL-2</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js install --local --agent ghcp --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
   Agents: ghcp
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-3</span> <span class="badge ok">exit 0</span> <code>find $WS -type f | sort</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\telemetry.config.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-setup\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-GHCP-LOCAL\.mcp.json
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-4</span> <span class="badge ok">exit 0</span> <code>test -f $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.mcp.json &amp;&amp; test -f $WS/.github/hooks/azure-functions-telemetry.json &amp;&amp; test -f $WS/.github/hooks/scripts/track-telemetry.sh</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1GL-5</span> <span class="badge ok">exit 0</span> <code>test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.github/agents &amp;&amp; test ! -e $WS/.github/hooks/welcome-setup.json</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.github/skills/azure-functions-help/SKILL.md</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.mcp.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/azure-functions-telemetry.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/scripts/track-telemetry.sh</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/agents</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/welcome-setup.json</code></td><td>absent</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S1-CLAUDE-LOCAL">
-    <h3>TC-S1-CLAUDE-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Fresh Claude local install produced skills, settings/MCP, and telemetry hooks only; no legacy or agent-definition artifacts.</p>
-    <h4>Commands</h4>
-
-  <details class="cmd">
-    <summary><span class="cid">S1CL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent claude --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
-  Agents: claude
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-3</span> <span class="badge ok">exit 0</span> <code>find $WS -type f | sort</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-setup\SKILL.md
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-4</span> <span class="badge ok">exit 0</span> <code>test -f $WS/.claude/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.claude/settings.json &amp;&amp; test -f $WS/.claude/hooks/hooks.json &amp;&amp; test -f $WS/.claude/hooks/scripts/track-telemetry.sh</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1CL-5</span> <span class="badge ok">exit 0</span> <code>test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/CLAUDE.md &amp;&amp; test ! -e $WS/.claude/agents</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.claude/skills/azure-functions-help/SKILL.md</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/settings.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/hooks/hooks.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/hooks/scripts/track-telemetry.sh</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>CLAUDE.md</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/agents</code></td><td>absent</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S1-CODEX-LOCAL">
-    <h3>TC-S1-CODEX-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Fresh Codex local install produced skills, config/MCP, and telemetry hooks only; no legacy or agent-definition artifacts.</p>
-    <h4>Commands</h4>
-
-  <details class="cmd">
-    <summary><span class="cid">S1XL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent codex --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
-  Agents: codex
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-3</span> <span class="badge ok">exit 0</span> <code>find $WS -type f | sort</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\abbreviations.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-authoring.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\built-in-endpoints.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-schemas.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-smoke-tests.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-teams.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connectors.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\infra-and-deployment.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\models.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\project-files.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\quickstart-reference.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\sessions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\testing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\tools-and-skills.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\triggers.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\troubleshooting.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\remediation-patterns.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\review-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\azure-tables.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\cosmos-db.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\dapr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-grid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-hubs.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\extension-bundles.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\fabric.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\http.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\kafka.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mcp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mysql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\rabbitmq.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\redis.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sendgrid.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\service-bus.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\signalr.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-blob.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-queue.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\timer.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\twilio.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\web-pubsub.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\csharp.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\durable-functions.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\go.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\java.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\node-typescript.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\powershell.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\python.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\local-emulators.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\go-project.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\language-snippets.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-deploy\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\evidence-checklist.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\workflow.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ai-semantic-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ci-usage.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\language-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\routing.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\source-only-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\supply-chain-checks.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-feedback\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\references\inventory-commands.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-setup\SKILL.md
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.ps1
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh
-Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure\reports\e2e\20260810-132424\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\telemetry.config.json
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-4</span> <span class="badge ok">exit 0</span> <code>test -f $WS/.agents/skills/azure-functions-help/SKILL.md &amp;&amp; test -f $WS/.codex/config.toml &amp;&amp; test -f $WS/.codex/hooks.json &amp;&amp; test -f $WS/.codex/hooks/scripts/track-telemetry.sh</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S1XL-5</span> <span class="badge ok">exit 0</span> <code>test ! -e $WS/.azure-functions-skills &amp;&amp; test ! -e $WS/AGENTS.md &amp;&amp; test ! -e $WS/.agents/agents</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.agents/skills/azure-functions-help/SKILL.md</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/hooks.json</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/hooks/scripts/track-telemetry.sh</code></td><td>exists</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>absent</td><td class="ok">pass</td></tr>
-    <tr><td><code>.agents/agents</code></td><td>absent</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S2-GHCP-LOCAL">
-    <h3>TC-S2-GHCP-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">GHCP update refreshed the bundled skill, preserved user-owned skill/hook/MCP entries, migrated telemetry opt-out into telemetry.config.json, and removed legacy state plus managed instruction block.</p>
-    <h4>Commands</h4>
-
-  <details class="cmd">
-    <summary><span class="cid">S2GL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent ghcp --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
-  Agents: ghcp
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-3</span> <span class="badge ok">exit 0</span> <code>printf 'stale bundled\n' &gt; $WS/.github/skills/azure-functions-help/SKILL.md &amp;&amp; mkdir -p $WS/.github/skills/azure-functions-internal-runbook &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/skills/azure-functions-internal-runbook/SKILL.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-4</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS/.github/hooks/scripts &amp;&amp; printf 'user-owned\n' &gt; $WS/.github/hooks/scripts/custom-hook.sh &amp;&amp; printf '{...custom mcp...}\n' &gt; $WS/.mcp.json</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-5</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS/.azure-functions-skills $WS/.github/agents &amp;&amp; printf '{opt-out}' &gt; state.local.json &amp;&amp; printf 'legacy' &gt; functions-copilot.agent.md &amp;&amp; printf 'customer + managed block' &gt; $WS/AGENTS.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-6</span> <span class="badge ok">exit 0</span> <code>$CLI update --local --agent ghcp --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
-  Agents: ghcp
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2GL-7</span> <span class="badge ok">exit 0</span> <code>test -f help/SKILL.md &amp;&amp; ! grep -q 'stale bundled' &amp;&amp; cat runbook == user-owned &amp;&amp; test ! -e .azure-functions-skills &amp;&amp; test ! -e .github/agents/functions-copilot.agent.md &amp;&amp; cat AGENTS.md == customer &amp;&amp; cat custom-hook.sh == user-owned &amp;&amp; node -e (mcp.custom=custom-server, mcp.azure=npx, telemetry.enabled=false)</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.github/skills/azure-functions-help/SKILL.md</code></td><td>refreshed (no &quot;stale bundled&quot;)</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/skills/azure-functions-internal-runbook/SKILL.md</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/hooks/scripts/custom-hook.sh</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>.github/agents/functions-copilot.agent.md</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>managed block stripped (== customer)</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S2-CLAUDE-LOCAL">
-    <h3>TC-S2-CLAUDE-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Claude update refreshed the bundled skill, preserved user settings (allow, custom MCP, custom hook), injected the telemetry hook, migrated opt-out, and removed legacy state plus managed block.</p>
-    <h4>Commands</h4>
-
-  <details class="cmd">
-    <summary><span class="cid">S2CL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent claude --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
-  Agents: claude
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-3</span> <span class="badge ok">exit 0</span> <code>printf 'stale bundled\n' &gt; help/SKILL.md &amp;&amp; mkdir -p runbook &amp;&amp; printf 'user-owned\n' &gt; runbook/SKILL.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-4</span> <span class="badge ok">exit 0</span> <code>mkdir -p .claude/hooks &amp;&amp; printf 'user-owned\n' &gt; custom-hook.json &amp;&amp; printf '{custom settings}' &gt; .claude/settings.json</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-5</span> <span class="badge ok">exit 0</span> <code>mkdir -p .azure-functions-skills &amp;&amp; printf '{opt-out}' &gt; state.local.json &amp;&amp; printf 'customer + managed block' &gt; $WS/CLAUDE.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-6</span> <span class="badge ok">exit 0</span> <code>$CLI update --local --agent claude --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
-  Agents: claude
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2CL-7</span> <span class="badge ok">exit 0</span> <code>test -f help/SKILL.md &amp;&amp; ! grep 'stale bundled' &amp;&amp; cat runbook == user-owned &amp;&amp; test ! -e .azure-functions-skills &amp;&amp; cat CLAUDE.md == customer &amp;&amp; cat custom-hook.json == user-owned &amp;&amp; node -e (allow[0]=Read, mcp.custom=custom-server, mcp.azure=npx, hooks include custom-hook + track-telemetry.sh, telemetry.enabled=false)</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.claude/skills/azure-functions-help/SKILL.md</code></td><td>refreshed (no &quot;stale bundled&quot;)</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/skills/azure-functions-internal-runbook/SKILL.md</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.claude/hooks/custom-hook.json</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>CLAUDE.md</code></td><td>managed block stripped (== customer)</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
-  <section class="case" id="TC-S2-CODEX-LOCAL">
-    <h3>TC-S2-CODEX-LOCAL <span class="status pass">pass</span></h3>
-    <p class="analysis">Codex update refreshed the bundled skill, preserved user runbook/hook, merged config.toml (kept gpt-test model and custom server, replaced azure server with npx removing old-azure), injected telemetry hook, migrated opt-out, and removed legacy state plus managed block.</p>
-    <h4>Commands</h4>
-
-  <details class="cmd">
-    <summary><span class="cid">S2XL-1</span> <span class="badge ok">exit 0</span> <code>mkdir -p $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-2</span> <span class="badge ok">exit 0</span> <code>$CLI install --local --agent codex --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
-  Agents: codex
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-3</span> <span class="badge ok">exit 0</span> <code>printf 'stale bundled\n' &gt; help/SKILL.md &amp;&amp; mkdir -p runbook &amp;&amp; printf 'user-owned\n' &gt; runbook/SKILL.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-4</span> <span class="badge ok">exit 0</span> <code>mkdir -p .codex/hooks &amp;&amp; printf 'user-owned\n' &gt; custom-hook.json &amp;&amp; printf '{custom hooks.json}' &gt; .codex/hooks.json &amp;&amp; printf 'model=gpt-test + custom + azure=old-azure' &gt; .codex/config.toml</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-5</span> <span class="badge ok">exit 0</span> <code>mkdir -p .azure-functions-skills &amp;&amp; printf '{opt-out}' &gt; state.local.json &amp;&amp; printf 'customer + managed block' &gt; $WS/AGENTS.md</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-6</span> <span class="badge ok">exit 0</span> <code>$CLI update --local --agent codex --dir $WS</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
-  Agents: codex
-  Files written: 88
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
-  </details>
-  <details class="cmd">
-    <summary><span class="cid">S2XL-7</span> <span class="badge ok">exit 0</span> <code>test -f help/SKILL.md &amp;&amp; ! grep 'stale bundled' &amp;&amp; cat runbook == user-owned &amp;&amp; test ! -e .azure-functions-skills &amp;&amp; cat AGENTS.md == customer &amp;&amp; cat custom-hook.json == user-owned &amp;&amp; grep 'model = &quot;gpt-test&quot;' &amp;&amp; grep '[mcp_servers.custom]' &amp;&amp; grep 'command = &quot;npx&quot;' &amp;&amp; ! grep 'old-azure' &amp;&amp; node -e (hooks include custom-hook + track-telemetry.sh, telemetry.enabled=false)</code></summary>
-    <div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventure</code></div>
-    <div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>
-</pre></div>
-    <div class="io"><div class="io-h">stderr</div><pre>
-</pre></div>
-  </details>
-    <h4>File verification</h4>
-    <table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Result</th></tr></thead><tbody>
-    <tr><td><code>.agents/skills/azure-functions-help/SKILL.md</code></td><td>refreshed (no &quot;stale bundled&quot;)</td><td class="ok">pass</td></tr>
-    <tr><td><code>.agents/skills/azure-functions-internal-runbook/SKILL.md</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/hooks/custom-hook.json</code></td><td>preserved user-owned</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml (model)</code></td><td>model = &quot;gpt-test&quot; preserved</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml (custom server)</code></td><td>[mcp_servers.custom] preserved</td><td class="ok">pass</td></tr>
-    <tr><td><code>.codex/config.toml (azure server)</code></td><td>command = &quot;npx&quot;, no old-azure</td><td class="ok">pass</td></tr>
-    <tr><td><code>.azure-functions-skills</code></td><td>removed</td><td class="ok">pass</td></tr>
-    <tr><td><code>AGENTS.md</code></td><td>managed block stripped (== customer)</td><td class="ok">pass</td></tr></tbody></table>
-  </section>
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1GL-3</span> <span class="badge ok">exit 0</span> <code>Get-ChildItem -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL&#x27; -Recurse -File | Sort-Object FullName | ForEach-Object { $_.FullName }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\telemetry.config.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-setup\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.mcp.json</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1GL-4</span> <span class="badge ok">exit 0</span> <code>if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.mcp.json&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh&#x27; -PathType Leaf)) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1GL-5</span> <span class="badge ok">exit 0</span> <code>if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.azure-functions-skills&#x27;) { exit 1 }; if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\AGENTS.md&#x27;) { exit 1 }; if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\agents&#x27;) { exit 1 }; if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\welcome-setup.json&#x27;) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<h4>File checks</h4><table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.mcp.json</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\azure-functions-telemetry.json</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\scripts\track-telemetry.sh</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.azure-functions-skills</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\AGENTS.md</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\agents</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-GHCP-LOCAL\.github\hooks\welcome-setup.json</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+</tbody></table><h4>Issues</h4>
+<p><em>None</em></p>
 </section>
-
-<section>
-  <h2>Issues found</h2>
-  <p class="ok">No issues found. All 38 commands exited 0 and all file checks passed.</p>
+<section class="case" id="TC-S1-CLAUDE-LOCAL">
+<h3>TC-S1-CLAUDE-LOCAL <span class="status pass">pass</span></h3>
+<p class="analysis">Fresh Claude local install should contain only the expected skill, settings, and telemetry surfaces.</p>
+<h4>Commands</h4>
+<details class="cmd">
+<summary><span class="cid">S1CL-1</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL&#x27; | Out-Null</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1CL-2</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js install --local --agent claude --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+  Agents: claude
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1CL-3</span> <span class="badge ok">exit 0</span> <code>Get-ChildItem -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL&#x27; -Recurse -File | Sort-Object FullName | ForEach-Object { $_.FullName }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-setup\SKILL.md</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1CL-4</span> <span class="badge ok">exit 0</span> <code>if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh&#x27; -PathType Leaf)) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1CL-5</span> <span class="badge ok">exit 0</span> <code>if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.azure-functions-skills&#x27;) { exit 1 }; if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\CLAUDE.md&#x27;) { exit 1 }; if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\agents&#x27;) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<h4>File checks</h4><table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\settings.json</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\hooks.json</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\hooks\scripts\track-telemetry.sh</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.azure-functions-skills</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\CLAUDE.md</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CLAUDE-LOCAL\.claude\agents</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+</tbody></table><h4>Issues</h4>
+<p><em>None</em></p>
 </section>
+<section class="case" id="TC-S1-CODEX-LOCAL">
+<h3>TC-S1-CODEX-LOCAL <span class="status pass">pass</span></h3>
+<p class="analysis">Fresh Codex local install should contain only the expected skill, config, and telemetry surfaces.</p>
+<h4>Commands</h4>
+<details class="cmd">
+<summary><span class="cid">S1XL-1</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL&#x27; | Out-Null</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1XL-2</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js install --local --agent codex --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+  Agents: codex
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1XL-3</span> <span class="badge ok">exit 0</span> <code>Get-ChildItem -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL&#x27; -Recurse -File | Sort-Object FullName | ForEach-Object { $_.FullName }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\assets\infra\app\trigger-config.bicep
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\abbreviations.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-authoring.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\agent-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\built-in-endpoints.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connectors.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-schemas.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-smoke-tests.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-teams.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\connector-triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\infra-and-deployment.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\models.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\project-files.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\quickstart-reference.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\sessions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\testing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\tools-and-skills.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\triggers.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\references\troubleshooting.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-agents\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\remediation-patterns.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\references\review-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-best-practices\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\azure-tables.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\cosmos-db.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\dapr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-grid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\event-hubs.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\extension-bundles.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\fabric.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\http.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\kafka.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mcp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\mysql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\rabbitmq.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\redis.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sendgrid.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\service-bus.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\signalr.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\sql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-blob.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\storage-queue.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\timer.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\twilio.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\extensions\web-pubsub.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\csharp.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\durable-functions.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\go.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\java.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\node-typescript.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\powershell.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\languages\python.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\local-emulators.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-common\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\go-project.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\references\language-snippets.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-create\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-deploy\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\evidence-checklist.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\references\workflow.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-diagnostics\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ai-semantic-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\ci-usage.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\iac-azure-resource-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\language-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\routing.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\source-only-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\references\supply-chain-checks.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-doctor\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-feedback\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\references\health-status-commands-and-kql.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\scripts\get-functionapp-health-status.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-health-status\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\references\inventory-commands.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\scripts\get-functionapp-inventory.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-inventory\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-setup\SKILL.md
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.ps1
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh
+Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\telemetry.config.json</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1XL-4</span> <span class="badge ok">exit 0</span> <code>if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json&#x27; -PathType Leaf)) { exit 1 }; if (!(Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh&#x27; -PathType Leaf)) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S1XL-5</span> <span class="badge ok">exit 0</span> <code>if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.azure-functions-skills&#x27;) { exit 1 }; if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\AGENTS.md&#x27;) { exit 1 }; if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\agents&#x27;) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<h4>File checks</h4><table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\config.toml</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks.json</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.codex\hooks\scripts\track-telemetry.sh</code></td><td>exists</td><td><pre>exists</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.azure-functions-skills</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\AGENTS.md</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S1-CODEX-LOCAL\.agents\agents</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+</tbody></table><h4>Issues</h4>
+<p><em>None</em></p>
+</section>
+<section class="case" id="TC-S2-GHCP-LOCAL">
+<h3>TC-S2-GHCP-LOCAL <span class="status pass">pass</span></h3>
+<p class="analysis">GHCP update should refresh the bundled skill, preserve user-owned assets, migrate telemetry, and remove legacy state.</p>
+<h4>Commands</h4>
+<details class="cmd">
+<summary><span class="cid">S2GL-1</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL&#x27; | Out-Null</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2GL-2</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js install --local --agent ghcp --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+  Agents: ghcp
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2GL-3</span> <span class="badge ok">exit 0</span> <code>[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md&#x27;, @&#x27;
+stale bundled
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\skills\azure-functions-internal-runbook&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\skills\azure-functions-internal-runbook\SKILL.md&#x27;, @&#x27;
+user-owned
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2GL-4</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\hooks\scripts&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\hooks\scripts\custom-hook.sh&#x27;, @&#x27;
+user-owned
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.mcp.json&#x27;, @&#x27;
+{&quot;inputs&quot;:[{&quot;id&quot;:&quot;subscription&quot;}],&quot;mcpServers&quot;:{&quot;custom&quot;:{&quot;command&quot;:&quot;custom-server&quot;,&quot;args&quot;:[]}}}
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2GL-5</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.azure-functions-skills&#x27;, &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\agents&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.azure-functions-skills\state.local.json&#x27;, @&#x27;
+{&quot;telemetry&quot;:{&quot;enabled&quot;:false}}
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\agents\functions-copilot.agent.md&#x27;, @&#x27;
+legacy
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\AGENTS.md&#x27;, @&#x27;
+customer
+&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;
+legacy routing
+&lt;!-- azure-functions-skills:end --&gt;
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2GL-6</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js update --local --agent ghcp --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
+  Agents: ghcp
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2GL-7</span> <span class="badge ok">exit 0</span> <code>if (Select-String -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md&#x27; -SimpleMatch -Pattern &#x27;stale bundled&#x27; -Quiet) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\skills\azure-functions-internal-runbook\SKILL.md&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;user-owned&#x27;) { exit 1 }
+if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.azure-functions-skills&#x27;) { exit 1 }
+if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\agents\functions-copilot.agent.md&#x27;) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\AGENTS.md&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;customer&#x27;) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\hooks\scripts\custom-hook.sh&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;user-owned&#x27;) { exit 1 }
+$mcp = Get-Content -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.mcp.json&#x27; -Raw | ConvertFrom-Json
+$telemetry = Get-Content -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\hooks\telemetry.config.json&#x27; -Raw | ConvertFrom-Json
+if ($mcp.mcpServers.custom.command -ne &#x27;custom-server&#x27; -or $mcp.mcpServers.azure.command -ne &#x27;npx&#x27; -or $telemetry.enabled -ne $false) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<h4>File checks</h4><table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\skills\azure-functions-help\SKILL.md</code></td><td>refreshed, no stale bundled text</td><td><pre>---
+name: azure-functions-help
+description: &quot;Discover the Azure Functions skill that best matches the user&#x27;s goal&quot;
+---
 
-<section class="counters">
-  <h2>Machine-checkable counters</h2>
-  <pre id="counters-json">{
-  &quot;runId&quot;: &quot;20260810-132424&quot;,
+
+# Azure Functions Help
+
+Use this skill when the user asks what Azure Functions capabilities are available, where to start, or which Azure Functions skill to use.
+
+1. Identify the user&#x27;s immediate Azure Functions goal.
+2. Inspect the available skills whose names start with `azure-functions-`.
+3. Recommend at most three matching skills, with one short reason for each.
+4. Invoke or direct the user to the best match.
+
+Do not reproduce a static catalog when the runtime skill list is available. Do not route generic Azure work here unless the request involves Azure Functions, Function Apps, triggers, bindings, `host.json`, or Functions deployment/runtime behavior.</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\skills\azure-functions-internal-runbook\SKILL.md</code></td><td>user-owned preserved</td><td><pre>user-owned</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.azure-functions-skills</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\agents\functions-copilot.agent.md</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\AGENTS.md</code></td><td>customer only</td><td><pre>customer</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\hooks\scripts\custom-hook.sh</code></td><td>user-owned preserved</td><td><pre>user-owned</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.mcp.json</code></td><td>custom server preserved, azure -&gt; npx</td><td><pre>{
+  &quot;inputs&quot;: [
+    {
+      &quot;id&quot;: &quot;subscription&quot;
+    }
+  ],
+  &quot;mcpServers&quot;: {
+    &quot;custom&quot;: {
+      &quot;command&quot;: &quot;custom-server&quot;,
+      &quot;args&quot;: []
+    },
+    &quot;azure&quot;: {
+      &quot;type&quot;: &quot;stdio&quot;,
+      &quot;command&quot;: &quot;npx&quot;,
+      &quot;args&quot;: [
+        &quot;-y&quot;,
+        &quot;@azure/mcp@latest&quot;,
+        &quot;server&quot;,
+        &quot;start&quot;
+      ],
+      &quot;tools&quot;: [
+        &quot;*&quot;
+      ]
+    }
+  }
+}</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-GHCP-LOCAL\.github\hooks\telemetry.config.json</code></td><td>telemetry disabled</td><td><pre>{
+  &quot;enabled&quot;: false
+}</pre></td><td class="ok">pass</td></tr>
+</tbody></table><h4>Issues</h4>
+<p><em>None</em></p>
+</section>
+<section class="case" id="TC-S2-CLAUDE-LOCAL">
+<h3>TC-S2-CLAUDE-LOCAL <span class="status pass">pass</span></h3>
+<p class="analysis">Claude update should refresh the bundled skill, preserve user-owned assets, migrate telemetry, and remove legacy state.</p>
+<h4>Commands</h4>
+<details class="cmd">
+<summary><span class="cid">S2CL-1</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL&#x27; | Out-Null</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2CL-2</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js install --local --agent claude --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+  Agents: claude
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2CL-3</span> <span class="badge ok">exit 0</span> <code>[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md&#x27;, @&#x27;
+stale bundled
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\skills\azure-functions-internal-runbook&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\skills\azure-functions-internal-runbook\SKILL.md&#x27;, @&#x27;
+user-owned
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2CL-4</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\hooks&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\hooks\custom-hook.json&#x27;, @&#x27;
+user-owned
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\settings.json&#x27;, @&#x27;
+{&quot;permissions&quot;:{&quot;allow&quot;:[&quot;Read&quot;]},&quot;mcpServers&quot;:{&quot;custom&quot;:{&quot;command&quot;:&quot;custom-server&quot;,&quot;args&quot;:[]}},&quot;hooks&quot;:{&quot;PostToolUse&quot;:[{&quot;hooks&quot;:[{&quot;type&quot;:&quot;command&quot;,&quot;command&quot;:&quot;custom-hook&quot;}]}]}}
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2CL-5</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.azure-functions-skills&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.azure-functions-skills\state.local.json&#x27;, @&#x27;
+{&quot;telemetry&quot;:{&quot;enabled&quot;:false}}
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\CLAUDE.md&#x27;, @&#x27;
+customer
+&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;
+legacy routing
+&lt;!-- azure-functions-skills:end --&gt;
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2CL-6</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js update --local --agent claude --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
+  Agents: claude
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2CL-7</span> <span class="badge ok">exit 0</span> <code>if (Select-String -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md&#x27; -SimpleMatch -Pattern &#x27;stale bundled&#x27; -Quiet) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\skills\azure-functions-internal-runbook\SKILL.md&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;user-owned&#x27;) { exit 1 }
+if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.azure-functions-skills&#x27;) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\CLAUDE.md&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;customer&#x27;) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\hooks\custom-hook.json&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;user-owned&#x27;) { exit 1 }
+$settings = Get-Content -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\settings.json&#x27; -Raw | ConvertFrom-Json
+$telemetry = Get-Content -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json&#x27; -Raw | ConvertFrom-Json
+if ($settings.permissions.allow[0] -ne &#x27;Read&#x27; -or $settings.mcpServers.custom.command -ne &#x27;custom-server&#x27; -or $settings.mcpServers.azure.command -ne &#x27;npx&#x27; -or ((($settings.hooks | ConvertTo-Json -Depth 10)) -notmatch &#x27;custom-hook&#x27;) -or ((($settings.hooks | ConvertTo-Json -Depth 10)) -notmatch &#x27;track-telemetry\.sh&#x27;) -or $telemetry.enabled -ne $false) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<h4>File checks</h4><table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\skills\azure-functions-help\SKILL.md</code></td><td>refreshed, no stale bundled text</td><td><pre>---
+name: azure-functions-help
+description: &quot;Discover the Azure Functions skill that best matches the user&#x27;s goal&quot;
+---
+
+
+# Azure Functions Help
+
+Use this skill when the user asks what Azure Functions capabilities are available, where to start, or which Azure Functions skill to use.
+
+1. Identify the user&#x27;s immediate Azure Functions goal.
+2. Inspect the available skills whose names start with `azure-functions-`.
+3. Recommend at most three matching skills, with one short reason for each.
+4. Invoke or direct the user to the best match.
+
+Do not reproduce a static catalog when the runtime skill list is available. Do not route generic Azure work here unless the request involves Azure Functions, Function Apps, triggers, bindings, `host.json`, or Functions deployment/runtime behavior.</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\skills\azure-functions-internal-runbook\SKILL.md</code></td><td>user-owned preserved</td><td><pre>user-owned</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.azure-functions-skills</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\CLAUDE.md</code></td><td>customer only</td><td><pre>customer</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\hooks\custom-hook.json</code></td><td>user-owned preserved</td><td><pre>user-owned</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\settings.json</code></td><td>custom mcp plus telemetry hook preserved</td><td><pre>{
+  &quot;permissions&quot;: {
+    &quot;allow&quot;: [
+      &quot;Read&quot;
+    ]
+  },
+  &quot;mcpServers&quot;: {
+    &quot;custom&quot;: {
+      &quot;command&quot;: &quot;custom-server&quot;,
+      &quot;args&quot;: []
+    },
+    &quot;azure&quot;: {
+      &quot;command&quot;: &quot;npx&quot;,
+      &quot;args&quot;: [
+        &quot;-y&quot;,
+        &quot;@azure/mcp@latest&quot;,
+        &quot;server&quot;,
+        &quot;start&quot;
+      ]
+    }
+  },
+  &quot;hooks&quot;: {
+    &quot;PostToolUse&quot;: [
+      {
+        &quot;hooks&quot;: [
+          {
+            &quot;type&quot;: &quot;command&quot;,
+            &quot;command&quot;: &quot;custom-hook&quot;
+          }
+        ]
+      },
+      {
+        &quot;hooks&quot;: [
+          {
+            &quot;type&quot;: &quot;command&quot;,
+            &quot;command&quot;: &quot;bash .claude/hooks/scripts/track-telemetry.sh&quot;,
+            &quot;timeout&quot;: 30
+          }
+        ]
+      }
+    ]
+  }
+}</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CLAUDE-LOCAL\.claude\hooks\telemetry.config.json</code></td><td>telemetry disabled</td><td><pre>{
+  &quot;enabled&quot;: false
+}</pre></td><td class="ok">pass</td></tr>
+</tbody></table><h4>Issues</h4>
+<p><em>None</em></p>
+</section>
+<section class="case" id="TC-S2-CODEX-LOCAL">
+<h3>TC-S2-CODEX-LOCAL <span class="status pass">pass</span></h3>
+<p class="analysis">Codex update should refresh the bundled skill, preserve user-owned assets, migrate telemetry, and remove legacy state.</p>
+<h4>Commands</h4>
+<details class="cmd">
+<summary><span class="cid">S2XL-1</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL&#x27; | Out-Null</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2XL-2</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js install --local --agent codex --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally installed.
+  Agents: codex
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2XL-3</span> <span class="badge ok">exit 0</span> <code>[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md&#x27;, @&#x27;
+stale bundled
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.agents\skills\azure-functions-internal-runbook&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.agents\skills\azure-functions-internal-runbook\SKILL.md&#x27;, @&#x27;
+user-owned
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2XL-4</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks\custom-hook.json&#x27;, @&#x27;
+user-owned
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks.json&#x27;, @&#x27;
+{&quot;hooks&quot;:{&quot;PostToolUse&quot;:[{&quot;type&quot;:&quot;command&quot;,&quot;command&quot;:&quot;custom-hook&quot;}]}}
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\config.toml&#x27;, @&#x27;
+model = &quot;gpt-test&quot;
+
+[mcp_servers.custom]
+command = &quot;custom-server&quot;
+
+[mcp_servers.azure]
+command = &quot;old-azure&quot;
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2XL-5</span> <span class="badge ok">exit 0</span> <code>New-Item -ItemType Directory -Force -Path &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.azure-functions-skills&#x27; | Out-Null
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.azure-functions-skills\state.local.json&#x27;, @&#x27;
+{&quot;telemetry&quot;:{&quot;enabled&quot;:false}}
+&#x27;@, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\AGENTS.md&#x27;, @&#x27;
+customer
+&lt;!-- azure-functions-skills:start version=0.0.2 --&gt;
+legacy routing
+&lt;!-- azure-functions-skills:end --&gt;
+&#x27;@, [System.Text.UTF8Encoding]::new($false))</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2XL-6</span> <span class="badge ok">exit 0</span> <code>node Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\bin\azure-functions-skills.js update --local --agent codex --dir &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL&#x27;</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre>Azure Functions Skills locally updated.
+  Agents: codex
+  Files written: 88</pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<details class="cmd">
+<summary><span class="cid">S2XL-7</span> <span class="badge ok">exit 0</span> <code>if (Select-String -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md&#x27; -SimpleMatch -Pattern &#x27;stale bundled&#x27; -Quiet) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.agents\skills\azure-functions-internal-runbook\SKILL.md&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;user-owned&#x27;) { exit 1 }
+if (Test-Path -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.azure-functions-skills&#x27;) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\AGENTS.md&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;customer&#x27;) { exit 1 }
+if ((([System.IO.File]::ReadAllText(&#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks\custom-hook.json&#x27;)).TrimEnd(&quot;`r&quot;,&quot;`n&quot;)) -ne &#x27;user-owned&#x27;) { exit 1 }
+if (-not (Select-String -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\config.toml&#x27; -Pattern &#x27;model = &quot;gpt-test&quot;&#x27; -Quiet)) { exit 1 }
+if (-not (Select-String -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\config.toml&#x27; -Pattern &#x27;\[mcp_servers.custom\]&#x27; -Quiet)) { exit 1 }
+if (-not (Select-String -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\config.toml&#x27; -Pattern &#x27;command = &quot;npx&quot;&#x27; -Quiet)) { exit 1 }
+if (Select-String -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\config.toml&#x27; -Pattern &#x27;old-azure&#x27; -Quiet) { exit 1 }
+$hooks = Get-Content -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks.json&#x27; -Raw | ConvertFrom-Json
+$telemetry = Get-Content -LiteralPath &#x27;Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks\telemetry.config.json&#x27; -Raw | ConvertFrom-Json
+if ((($hooks.hooks | ConvertTo-Json -Depth 10)) -notmatch &#x27;custom-hook&#x27; -or (($hooks.hooks | ConvertTo-Json -Depth 10)) -notmatch &#x27;track-telemetry\.sh&#x27; -or $telemetry.enabled -ne $false) { exit 1 }</code></summary>
+<div class="kv"><strong>cwd:</strong> <code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle</code></div>
+<div class="io"><div class="io-h">stdout (first 200 lines)</div><pre><em>(empty)</em></pre></div>
+<div class="io"><div class="io-h">stderr</div><pre><em>(empty)</em></pre></div>
+</details>
+<h4>File checks</h4><table class="tbl"><thead><tr><th>Path</th><th>Expected</th><th>Actual</th><th>Status</th></tr></thead><tbody>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.agents\skills\azure-functions-help\SKILL.md</code></td><td>refreshed, no stale bundled text</td><td><pre>---
+name: azure-functions-help
+description: &quot;Discover the Azure Functions skill that best matches the user&#x27;s goal&quot;
+---
+
+
+# Azure Functions Help
+
+Use this skill when the user asks what Azure Functions capabilities are available, where to start, or which Azure Functions skill to use.
+
+1. Identify the user&#x27;s immediate Azure Functions goal.
+2. Inspect the available skills whose names start with `azure-functions-`.
+3. Recommend at most three matching skills, with one short reason for each.
+4. Invoke or direct the user to the best match.
+
+Do not reproduce a static catalog when the runtime skill list is available. Do not route generic Azure work here unless the request involves Azure Functions, Function Apps, triggers, bindings, `host.json`, or Functions deployment/runtime behavior.</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.agents\skills\azure-functions-internal-runbook\SKILL.md</code></td><td>user-owned preserved</td><td><pre>user-owned</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.azure-functions-skills</code></td><td>missing</td><td><pre>missing</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\AGENTS.md</code></td><td>customer only</td><td><pre>customer</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks\custom-hook.json</code></td><td>user-owned preserved</td><td><pre>user-owned</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\config.toml</code></td><td>model/custom mcp updated, old azure removed</td><td><pre>model = &quot;gpt-test&quot;
+
+[mcp_servers.custom]
+command = &quot;custom-server&quot;
+
+# azure-functions-skills:start
+# Azure Functions MCP Servers
+
+[mcp_servers.azure]
+command = &quot;npx&quot;
+args = [&quot;-y&quot;, &quot;@azure/mcp@latest&quot;, &quot;server&quot;, &quot;start&quot;]
+# azure-functions-skills:end</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks.json</code></td><td>custom hook + telemetry hook present</td><td><pre>{
+  &quot;hooks&quot;: {
+    &quot;PostToolUse&quot;: [
+      {
+        &quot;type&quot;: &quot;command&quot;,
+        &quot;command&quot;: &quot;custom-hook&quot;
+      },
+      {
+        &quot;type&quot;: &quot;command&quot;,
+        &quot;command&quot;: &quot;bash .codex/hooks/scripts/track-telemetry.sh&quot;,
+        &quot;timeout&quot;: 30
+      }
+    ]
+  }
+}</pre></td><td class="ok">pass</td></tr>
+<tr><td><code>Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-cuddly-sniffle\reports\e2e\20260825-171025\workspaces\TC-S2-CODEX-LOCAL\.codex\hooks\telemetry.config.json</code></td><td>telemetry disabled</td><td><pre>{
+  &quot;enabled&quot;: false
+}</pre></td><td class="ok">pass</td></tr>
+</tbody></table><h4>Issues</h4>
+<p><em>None</em></p>
+</section>
+<section><h2>Notes</h2><ul>
+<li><pre>Prerequisite node --version: v24.18.1</pre></li>
+<li><pre>Mandatory git status check captured after command execution and before report generation.</pre></li>
+<li><pre>Cross-check deferred per user instruction; report.html is generated in the run directory only.</pre></li>
+<li><pre>git status --short:
+M .claude-plugin/marketplace.json
+ M .github/plugins/azure-functions-skills/.claude-plugin/plugin.json
+ M .github/plugins/azure-functions-skills/.codex-plugin/plugin.json
+ M .github/plugins/azure-functions-skills/.mcp.json
+ M .github/plugins/azure-functions-skills/.plugin/plugin.json
+ M .github/plugins/azure-functions-skills/hooks/copilot-hooks.json
+ M .github/plugins/azure-functions-skills/hooks/cursor-hooks.json
+ M .github/plugins/azure-functions-skills/hooks/hooks.json
+ M .github/plugins/azure-functions-skills/hooks/scripts/track-telemetry.ps1
+ M .github/plugins/azure-functions-skills/hooks/scripts/track-telemetry.sh
+ M .github/plugins/azure-functions-skills/plugin.json
+ M .github/plugins/azure-functions-skills/skills/azure-functions-agents/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-best-practices/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-common/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-deploy/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-diagnostics/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-doctor/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-feedback/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-health-status/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-help/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-inventory/SKILL.md
+ M .github/plugins/azure-functions-skills/skills/azure-functions-setup/SKILL.md
+ M .gitignore
+ M .plugin/marketplace.json
+ M AGENTS.md
+ M README.md
+ M azure-pipelines/release.yml
+ M bin/azure-functions-skills.js
+ M docs/cli-reference.md
+ M package-lock.json
+ M package.json
+ M src/build/build-target.ts
+ M src/setup/index.ts
+ M src/telemetry/index.ts
+ M src/telemetry/sender.ts
+ M templates/hooks/copilot-hooks.json
+ M templates/hooks/cursor-hooks.json
+ M templates/hooks/hooks.json
+ M templates/hooks/scripts/track-telemetry.ps1
+ M templates/hooks/scripts/track-telemetry.sh
+ M tests/simplified-cli.test.ts
+ M tests/simplified-distribution.test.ts
+ M tests/telemetry-hook.test.ts
+ M tests/telemetry-release.test.ts
+ M tests/telemetry.test.ts
+?? PLANS.md
+?? scripts/telemetry-release-canary.mjs
+?? src/telemetry/diagnostics.ts
+?? src/telemetry/doctor.ts
+?? src/telemetry/version.ts
+?? tests/telemetry-diagnostics.test.ts</pre></li>
+</ul></section>
+<section class="counters"><h2>Machine-readable counters</h2>
+<p>expectedCommandCount = <strong>38</strong> &middot; actualCommandCount = <strong>38</strong> &middot; missingCommandIds = <strong>(none)</strong></p>
+<pre>{
+  &quot;runId&quot;: &quot;20260825-171025&quot;,
   &quot;packageVersion&quot;: &quot;0.0.6-preview&quot;,
   &quot;platform&quot;: &quot;windows&quot;,
-  &quot;gitCommit&quot;: &quot;0bd094698feb680a684c41905b971ec43fd7eb4c&quot;,
+  &quot;gitCommit&quot;: &quot;b71d1a4a796a1d68e2bb05930baf920655fadb84&quot;,
   &quot;expectedCommandCount&quot;: 38,
   &quot;actualCommandCount&quot;: 38,
   &quot;missingCommandIds&quot;: [],
@@ -808,23 +961,9 @@ Q:\ghcpapp\copilot-worktrees\azure-functions-skills\tsuyoshiushio-fluffy-adventu
     &quot;unsupported&quot;: 0
   }
 }</pre>
-  <p>expectedCommandCount = <strong>38</strong> &middot; actualCommandCount = <strong>38</strong> &middot; missingCommandIds = <strong>(none)</strong></p>
-  <script type="application/json" id="e2e-counters">{"runId":"20260810-132424","packageVersion":"0.0.6-preview","platform":"windows","gitCommit":"0bd094698feb680a684c41905b971ec43fd7eb4c","expectedCommandCount":38,"actualCommandCount":38,"missingCommandIds":[],"testCases":{"total":6,"pass":6,"fail":0,"blocked":0,"unsupported":0}}</script>
 </section>
-
-<section>
-  <h2>Cross-Check Results</h2>
-  <p><strong>Overall: VALID</strong></p>
-  <table class="tbl"><tbody>
-    <tr><th>Reviewer model</th><td>claude-opus-4.8</td></tr>
-    <tr><th>Verified command count</th><td>38/38</td></tr>
-    <tr><th>Missing command IDs</th><td>none</td></tr>
-    <tr><th>Workarounds / extra / batched / reordered commands</th><td>none</td></tr>
-    <tr><th>Verdict overrides</th><td>none</td></tr>
-  </tbody></table>
-  <p>The reviewer compared <code>commands.md</code>, <code>checklist.md</code>, and this report: every command ID has evidence, no commands were skipped, batched, simplified, or supplemented with workarounds, and every verdict matches its command exit code and pass criteria.</p>
-  <p><strong>Non-blocking note:</strong> Several Scenario-2 seed and verify command strings are paraphrased in the per-case report summaries. This does not affect the run: the command IDs, the raw stdout/stderr/exit evidence under <code>raw/</code>, and the authoritative <code>commands.md</code> preserve full traceability of the exact commands executed.</p>
+<section><h2>Cross-Check Results</h2>
+<p>Status: <strong>VALID</strong> &middot; reviewerModel: <code>Claude Sonnet 5</code> &middot; verifiedCount: <code>38/38</code> &middot; missingCommands: <code>(none)</code> &middot; workarounds: <code>(none affecting verdicts)</code> &middot; verdictOverrides: <code>(none)</code></p>
+<p>The reviewer independently matched all command IDs, exact command/cwd/exit/stdout/stderr evidence, raw logs, run metadata, live workspace state, and all six verdicts. One outcome-neutral translation gap was recorded: the three Scenario 2 case-7 PowerShell translations rely on the report's independent file checks rather than repeating the source command's explicit <code>test -f</code> guard before the stale-content check. All three required files were independently confirmed present and fresh.</p>
 </section>
-
-</body>
-</html>
+</body></html>

--- a/scripts/telemetry-release-canary.mjs
+++ b/scripts/telemetry-release-canary.mjs
@@ -1,0 +1,141 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const packageName = '@azure/functions-skills';
+const publishTag = process.env.NPM_PUBLISH_TAG || 'latest';
+const appId = requiredEnvironment('APPLICATIONINSIGHTS_APP_ID');
+const apiKey = requiredEnvironment('APPLICATIONINSIGHTS_API_KEY');
+const workDir = mkdtempSync(join(tmpdir(), 'azure-functions-skills-canary-'));
+
+try {
+  const expectedVersion = expectedPackageVersion();
+  const version = await waitForPublishedVersion(expectedVersion);
+
+  const packOutput = execFileSync(
+    npmCommand(),
+    ['pack', `${packageName}@${version}`, '--json', '--ignore-scripts', '--registry', 'https://registry.npmjs.org'],
+    { encoding: 'utf-8', cwd: workDir },
+  );
+  const packResult = JSON.parse(packOutput);
+  if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
+    throw new Error('npm pack did not return a published tarball.');
+  }
+  const tarball = join(workDir, packResult[0].filename);
+
+  const diagnostic = spawnSync(
+    npmCommand(),
+    ['exec', '--silent', '--yes', '--package', tarball, '--', 'azure-functions-skills', 'telemetry', 'doctor', '--json'],
+    {
+      cwd: workDir,
+      encoding: 'utf-8',
+      env: {
+        ...canaryChildEnvironment(),
+        AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG: 'false',
+      },
+      timeout: 30_000,
+    },
+  );
+  if (diagnostic.status !== 0) {
+    throw new Error(`Published package telemetry diagnostic exited ${diagnostic.status ?? 'without a status'}.`);
+  }
+  const report = JSON.parse(diagnostic.stdout);
+  if (report.ingestionAccepted !== true || typeof report.correlationId !== 'string') {
+    throw new Error('Published package did not report accepted telemetry ingestion.');
+  }
+
+  await waitForIngestion(appId, apiKey, report.correlationId);
+  console.log(`Telemetry canary accepted for ${packageName}@${version} (${report.correlationId}).`);
+} finally {
+  rmSync(workDir, { recursive: true, force: true });
+}
+
+async function waitForIngestion(appId, apiKey, correlationId) {
+  const deadline = Date.now() + 5 * 60_000;
+  const query = [
+    'customEvents',
+    "| where name == 'AzureFunctionsSkillsPluginExecuted'",
+    `| where tostring(customDimensions.Plugin_CorrelationId) == '${correlationId}'`,
+    '| take 1',
+  ].join('\n');
+  const endpoint = new URL(`https://api.applicationinsights.io/v1/apps/${encodeURIComponent(appId)}/query`);
+  endpoint.searchParams.set('query', query);
+
+  while (Date.now() < deadline) {
+    const response = await globalThis.fetch(endpoint, {
+      headers: { 'x-api-key': apiKey },
+      signal: globalThis.AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Application Insights query failed with HTTP ${response.status}.`);
+    }
+
+    const body = await response.json();
+    if (hasQueryRow(body)) return;
+    await delay(10_000);
+  }
+  throw new Error('Telemetry canary was not queryable within 5 minutes.');
+}
+
+async function waitForPublishedVersion(expectedVersion) {
+  const deadline = Date.now() + 5 * 60_000;
+  while (Date.now() < deadline) {
+    try {
+      const visibleVersion = execFileSync(
+        npmCommand(),
+        ['view', `${packageName}@${publishTag}`, 'version', '--registry', 'https://registry.npmjs.org'],
+        { encoding: 'utf-8', cwd: workDir },
+      ).trim();
+      if (visibleVersion === expectedVersion) return visibleVersion;
+    } catch {
+      // Registry propagation can briefly return a missing tag or package.
+    }
+    await delay(10_000);
+  }
+  throw new Error(`${packageName}@${expectedVersion} was not visible on the ${publishTag} tag within 5 minutes.`);
+}
+
+function hasQueryRow(value) {
+  return typeof value === 'object'
+    && value !== null
+    && Array.isArray(value.tables)
+    && value.tables.some(table => typeof table === 'object'
+      && table !== null
+      && Array.isArray(table.rows)
+      && table.rows.length > 0);
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value || value.startsWith('$(')) {
+    throw new Error(`${name} must be configured for the telemetry canary.`);
+  }
+
+  return value;
+}
+
+function expectedPackageVersion() {
+  const configured = process.env.EXPECTED_PACKAGE_VERSION;
+  if (configured) return configured;
+  const packageJson = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
+  );
+  if (typeof packageJson.version !== 'string'
+    || !/^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(packageJson.version)) {
+    throw new Error('package.json contains an invalid expected package version.');
+  }
+  return packageJson.version;
+}
+
+function canaryChildEnvironment() {
+  const environment = { ...process.env };
+  delete environment.APPLICATIONINSIGHTS_APP_ID;
+  delete environment.APPLICATIONINSIGHTS_API_KEY;
+  return environment;
+}
+
+function npmCommand() {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}

--- a/src/build/build-target.ts
+++ b/src/build/build-target.ts
@@ -132,8 +132,15 @@ function writeTelemetryScripts(data: BuildData, hooksDir: string): void {
   const scriptsDir = join(hooksDir, 'scripts');
   mkdirSync(scriptsDir, { recursive: true });
   writeFileSync(join(hooksDir, 'telemetry.config.json'), data.hooks.telemetryConfig);
-  writeFileSync(join(scriptsDir, 'track-telemetry.ps1'), data.hooks.trackTelemetryPowerShell);
-  writeFileSync(join(scriptsDir, 'track-telemetry.sh'), data.hooks.trackTelemetryShell);
+  const packageVersion = data.packageVersion || '0.0.0-dev';
+  writeFileSync(
+    join(scriptsDir, 'track-telemetry.ps1'),
+    data.hooks.trackTelemetryPowerShell.replaceAll('__PACKAGE_VERSION__', packageVersion),
+  );
+  writeFileSync(
+    join(scriptsDir, 'track-telemetry.sh'),
+    data.hooks.trackTelemetryShell.replaceAll('__PACKAGE_VERSION__', packageVersion),
+  );
 }
 
 function workspaceCopilotHooks() {
@@ -144,6 +151,7 @@ function workspaceCopilotHooks() {
           type: 'command',
           bash: '.github/hooks/scripts/track-telemetry.sh',
           powershell: '.github/hooks/scripts/track-telemetry.ps1',
+          timeoutSec: 30,
         }],
       }],
     },
@@ -157,6 +165,7 @@ function workspaceClaudeHooks() {
         hooks: [{
           type: 'command',
           command: 'bash .claude/hooks/scripts/track-telemetry.sh',
+          timeout: 30,
         }],
       }],
     },
@@ -169,6 +178,7 @@ function workspaceCodexHooks() {
       PostToolUse: [{
         type: 'command',
         command: 'bash .codex/hooks/scripts/track-telemetry.sh',
+        timeout: 30,
       }],
     },
   };

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -22,6 +22,7 @@ import {
   telemetryConfigPath,
 } from './workspace-assets.js';
 import type { BuildData, CliAgentName } from '../types.js';
+import { PACKAGE_VERSION } from '../telemetry/version.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', '..', 'templates');
@@ -107,6 +108,7 @@ function loadBuildData(): BuildData {
     skills: loadSkills(join(TEMPLATES_DIR, 'skills')),
     mcpServers: loadMcpServers(join(TEMPLATES_DIR, 'mcp', 'servers.yaml')),
     hooks: loadHooks(join(TEMPLATES_DIR, 'hooks')),
+    packageVersion: PACKAGE_VERSION,
   };
 }
 

--- a/src/telemetry/diagnostics.ts
+++ b/src/telemetry/diagnostics.ts
@@ -1,0 +1,89 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const TELEMETRY_DIAGNOSTIC_LOG_NAME = 'telemetry-debug.jsonl';
+export const TELEMETRY_DIAGNOSTIC_MAX_BYTES = 1024 * 1024;
+
+export interface TelemetryDiagnosticEnvironment {
+  readonly AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG?: string;
+  readonly AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR?: string;
+}
+
+export interface SafeDiagnosticTelemetryEvent {
+  readonly timestamp: string;
+  readonly eventType: string;
+  readonly clientName: string;
+  readonly pluginName: 'azure-functions-skills';
+  readonly correlationId: string;
+  readonly pluginVersion: string;
+  readonly sessionId?: string;
+  readonly skillName?: string;
+  readonly toolName?: string;
+  readonly fileReference?: string;
+}
+
+export interface SafeIngestionDiagnostic {
+  readonly itemsReceived?: number;
+  readonly itemsAccepted?: number;
+  readonly statusCode?: number;
+  readonly category: 'accepted' | 'empty-response' | 'partial' | 'network' | 'timeout' | 'unknown';
+}
+
+export interface TelemetryDiagnosticEntry {
+  readonly component: 'sender' | 'cli';
+  readonly action: 'start' | 'decision' | 'delivery' | 'complete';
+  readonly status: 'started' | 'tracked' | 'skipped' | 'accepted' | 'failed';
+  readonly reason?: 'disabled' | 'not-configured' | 'invalid-input' | 'transport';
+  readonly correlationId?: string;
+  readonly packageVersion?: string;
+  readonly pluginVersion?: string;
+  readonly attempt?: number;
+  readonly event?: SafeDiagnosticTelemetryEvent;
+  readonly ingestion?: SafeIngestionDiagnostic;
+}
+
+export function isTelemetryDebugEnabled(environment: TelemetryDiagnosticEnvironment): boolean {
+  return environment.AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG?.toLowerCase() === 'true';
+}
+
+export function telemetryDiagnosticLogDirectory(
+  environment: TelemetryDiagnosticEnvironment,
+): string {
+  return environment.AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR?.trim()
+    || join(tmpdir(), 'azure-functions-skills-telemetry');
+}
+
+export function writeTelemetryDiagnostic(
+  environment: TelemetryDiagnosticEnvironment,
+  entry: TelemetryDiagnosticEntry,
+): boolean {
+  if (!isTelemetryDebugEnabled(environment)) return false;
+
+  try {
+    const directory = telemetryDiagnosticLogDirectory(environment);
+    const path = join(directory, TELEMETRY_DIAGNOSTIC_LOG_NAME);
+    const backupPath = `${path}.1`;
+    const line = `${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      ...entry,
+    })}\n`;
+    const lineBytes = Buffer.byteLength(line);
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    if (existsSync(path) && statSync(path).size + lineBytes > TELEMETRY_DIAGNOSTIC_MAX_BYTES) {
+      rmSync(backupPath, { force: true });
+      renameSync(path, backupPath);
+    }
+    appendFileSync(path, line, { encoding: 'utf-8', mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/telemetry/doctor.ts
+++ b/src/telemetry/doctor.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto';
+import { APPLICATION_INSIGHTS_CONNECTION_STRING } from './config.js';
+import {
+  isTelemetryConfigured,
+  isTelemetryOptedOut,
+  sendTelemetryEvent,
+  type TelemetryEnvironment,
+} from './sender.js';
+import {
+  isTelemetryDebugEnabled,
+  telemetryDiagnosticLogDirectory,
+} from './diagnostics.js';
+import { PACKAGE_VERSION } from './version.js';
+
+export interface TelemetryDiagnosticReport {
+  readonly packageResolved: true;
+  readonly packageVersion: string;
+  readonly telemetryEnabled: boolean;
+  readonly configurationStatus: 'disabled' | 'not-configured' | 'configured';
+  readonly transportStatus: 'not-attempted' | 'accepted' | 'failed';
+  readonly ingestionAccepted: boolean;
+  readonly correlationId: string;
+  readonly diagnosticsEnabled: boolean;
+  readonly logDirectory?: string;
+}
+
+export async function diagnoseTelemetry(
+  environment: TelemetryEnvironment = process.env,
+): Promise<TelemetryDiagnosticReport> {
+  const correlationId = randomUUID();
+  const diagnosticsEnabled = isTelemetryDebugEnabled(environment);
+  const common = {
+    packageResolved: true as const,
+    packageVersion: PACKAGE_VERSION,
+    correlationId,
+    diagnosticsEnabled,
+    ...(diagnosticsEnabled
+      ? { logDirectory: telemetryDiagnosticLogDirectory(environment) }
+      : {}),
+  };
+
+  if (isTelemetryOptedOut(environment)) {
+    return {
+      ...common,
+      telemetryEnabled: false,
+      configurationStatus: 'disabled',
+      transportStatus: 'not-attempted',
+      ingestionAccepted: false,
+    };
+  }
+  if (!isTelemetryConfigured(APPLICATION_INSIGHTS_CONNECTION_STRING)) {
+    return {
+      ...common,
+      telemetryEnabled: true,
+      configurationStatus: 'not-configured',
+      transportStatus: 'not-attempted',
+      ingestionAccepted: false,
+    };
+  }
+
+  try {
+    await sendTelemetryEvent({
+      timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      eventType: 'telemetry_diagnostic',
+      clientName: 'unknown',
+      pluginName: 'azure-functions-skills',
+      correlationId,
+      pluginVersion: PACKAGE_VERSION,
+    }, environment);
+    return {
+      ...common,
+      telemetryEnabled: true,
+      configurationStatus: 'configured',
+      transportStatus: 'accepted',
+      ingestionAccepted: true,
+    };
+  } catch {
+    return {
+      ...common,
+      telemetryEnabled: true,
+      configurationStatus: 'configured',
+      transportStatus: 'failed',
+      ingestionAccepted: false,
+    };
+  }
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -6,3 +6,7 @@ export {
   type TelemetrySendResult,
   type TelemetrySendStatus,
 } from './sender.js';
+export {
+  diagnoseTelemetry,
+  type TelemetryDiagnosticReport,
+} from './doctor.js';

--- a/src/telemetry/sender.ts
+++ b/src/telemetry/sender.ts
@@ -1,8 +1,15 @@
 import applicationInsights from 'applicationinsights';
+import { randomUUID } from 'node:crypto';
 import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { APPLICATION_INSIGHTS_CONNECTION_STRING } from './config.js';
+import {
+  writeTelemetryDiagnostic,
+  type SafeIngestionDiagnostic,
+  type TelemetryDiagnosticEnvironment,
+} from './diagnostics.js';
+import { PACKAGE_VERSION } from './version.js';
 
 const EVENT_NAME = 'AzureFunctionsSkillsPluginExecuted';
 const DEFAULT_TIMEOUT_MS = 5_000;
@@ -13,6 +20,8 @@ const ALLOWED_PROPERTIES = new Set([
   'eventType',
   'clientName',
   'pluginName',
+  'correlationId',
+  'pluginVersion',
   'sessionId',
   'skillName',
   'toolName',
@@ -22,6 +31,7 @@ const EVENT_TYPES = new Set<TelemetryEventType>([
   'skill_invocation',
   'tool_invocation',
   'reference_file_read',
+  'telemetry_diagnostic',
 ]);
 const CLIENT_NAMES = new Set([
   'copilot-cli',
@@ -48,13 +58,16 @@ export const BUNDLED_SKILL_NAMES = new Set([
 export type TelemetryEventType =
   | 'skill_invocation'
   | 'tool_invocation'
-  | 'reference_file_read';
+  | 'reference_file_read'
+  | 'telemetry_diagnostic';
 
 export interface TelemetryEvent {
   readonly timestamp: string;
   readonly eventType: TelemetryEventType;
   readonly clientName: string;
   readonly pluginName: 'azure-functions-skills';
+  readonly correlationId?: string;
+  readonly pluginVersion?: string;
   readonly sessionId?: string;
   readonly skillName?: string;
   readonly toolName?: string;
@@ -75,7 +88,7 @@ export interface ApplicationInsightsClient {
   flush(options: { readonly callback: (response?: string) => void }): void;
 }
 
-interface TelemetryEnvironment {
+export interface TelemetryEnvironment extends TelemetryDiagnosticEnvironment {
   readonly AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY?: string;
   readonly AZURE_MCP_COLLECT_TELEMETRY?: string;
 }
@@ -84,6 +97,7 @@ export interface TelemetryDependencies {
   readonly connectionString: string;
   readonly createClient: (connectionString: string) => ApplicationInsightsClient;
   readonly environment: TelemetryEnvironment;
+  readonly packageVersion: string;
   readonly timeoutMs: number;
 }
 
@@ -118,9 +132,19 @@ export function parseTelemetryEvent(value: unknown): TelemetryEvent {
   }
 
   const sessionId = optionalString(value, 'sessionId', 256);
+  const correlationId = optionalString(value, 'correlationId', 64);
+  const pluginVersion = optionalString(value, 'pluginVersion', 64);
   const skillName = optionalString(value, 'skillName', 128);
   const toolName = optionalString(value, 'toolName', 256);
   const fileReference = optionalString(value, 'fileReference', 512);
+
+  if (correlationId !== undefined
+    && !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(correlationId)) {
+    throw new Error('Invalid telemetry correlation ID.');
+  }
+  if (pluginVersion !== undefined && !/^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(pluginVersion)) {
+    throw new Error('Invalid telemetry plugin version.');
+  }
 
   if (skillName !== undefined && !BUNDLED_SKILL_NAMES.has(skillName)) {
     throw new Error(`Unsupported skill name: ${skillName}`);
@@ -147,6 +171,8 @@ export function parseTelemetryEvent(value: unknown): TelemetryEvent {
     eventType,
     clientName,
     pluginName: 'azure-functions-skills',
+    ...(correlationId === undefined ? {} : { correlationId }),
+    ...(pluginVersion === undefined ? {} : { pluginVersion }),
     ...(sessionId === undefined ? {} : { sessionId }),
     ...(skillName === undefined ? {} : { skillName }),
     ...(toolName === undefined ? {} : { toolName }),
@@ -159,27 +185,97 @@ export async function sendTelemetryEventWithDependencies(
   dependencies: TelemetryDependencies,
 ): Promise<TelemetrySendResult> {
   const parsedEvent = parseTelemetryEvent(event);
-  if (isOptedOut(dependencies.environment)) {
+  const enrichedEvent = {
+    ...parsedEvent,
+    correlationId: parsedEvent.correlationId || randomUUID(),
+    pluginVersion: parsedEvent.pluginVersion || dependencies.packageVersion,
+  };
+  writeTelemetryDiagnostic(dependencies.environment, {
+    component: 'sender',
+    action: 'start',
+    status: 'started',
+    correlationId: enrichedEvent.correlationId,
+    packageVersion: dependencies.packageVersion,
+    pluginVersion: enrichedEvent.pluginVersion,
+    event: enrichedEvent,
+  });
+  if (isTelemetryOptedOut(dependencies.environment)) {
+    writeTelemetryDiagnostic(dependencies.environment, {
+      component: 'sender',
+      action: 'decision',
+      status: 'skipped',
+      reason: 'disabled',
+      correlationId: enrichedEvent.correlationId,
+    });
     return { status: 'disabled' };
   }
-  if (!isConfiguredConnectionString(dependencies.connectionString)) {
+  if (!isTelemetryConfigured(dependencies.connectionString)) {
+    writeTelemetryDiagnostic(dependencies.environment, {
+      component: 'sender',
+      action: 'decision',
+      status: 'skipped',
+      reason: 'not-configured',
+      correlationId: enrichedEvent.correlationId,
+    });
     return { status: 'not-configured' };
   }
 
-  const client = dependencies.createClient(dependencies.connectionString);
-  client.trackEvent({
-    name: EVENT_NAME,
-    properties: telemetryProperties(parsedEvent),
-  });
-  await flushWithTimeout(client, dependencies.timeoutMs);
-  return { status: 'sent' };
+  const deadline = Date.now() + dependencies.timeoutMs;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      const client = dependencies.createClient(dependencies.connectionString);
+      client.trackEvent({
+        name: EVENT_NAME,
+        properties: telemetryProperties(
+          enrichedEvent,
+          dependencies.packageVersion,
+        ),
+      });
+      const ingestion = await flushWithTimeout(
+        client,
+        remainingTime(deadline),
+        dependencies.timeoutMs,
+      );
+      writeTelemetryDiagnostic(dependencies.environment, {
+        component: 'sender',
+        action: 'delivery',
+        status: 'accepted',
+        correlationId: enrichedEvent.correlationId,
+        packageVersion: dependencies.packageVersion,
+        pluginVersion: enrichedEvent.pluginVersion,
+        attempt,
+        ingestion,
+      });
+      return { status: 'sent' };
+    } catch (error) {
+      const deliveryError = toDeliveryError(error);
+      writeTelemetryDiagnostic(dependencies.environment, {
+        component: 'sender',
+        action: 'delivery',
+        status: 'failed',
+        reason: 'transport',
+        correlationId: enrichedEvent.correlationId,
+        packageVersion: dependencies.packageVersion,
+        pluginVersion: enrichedEvent.pluginVersion,
+        attempt,
+        ingestion: deliveryError.ingestion,
+      });
+      if (attempt === 1 && deliveryError.transient && Date.now() < deadline) continue;
+      throw deliveryError;
+    }
+  }
+  throw new Error('Telemetry delivery failed.');
 }
 
-export async function sendTelemetryEvent(event: TelemetryEvent): Promise<TelemetrySendResult> {
+export async function sendTelemetryEvent(
+  event: TelemetryEvent,
+  environment: TelemetryEnvironment = process.env,
+): Promise<TelemetrySendResult> {
   return sendTelemetryEventWithDependencies(event, {
     connectionString: APPLICATION_INSIGHTS_CONNECTION_STRING,
     createClient: createApplicationInsightsClient,
-    environment: process.env,
+    environment,
+    packageVersion: PACKAGE_VERSION,
     timeoutMs: DEFAULT_TIMEOUT_MS,
   });
 }
@@ -188,11 +284,17 @@ function createApplicationInsightsClient(connectionString: string): ApplicationI
   return new applicationInsights.TelemetryClient(connectionString);
 }
 
-function telemetryProperties(event: TelemetryEvent): Record<string, string> {
+function telemetryProperties(
+  event: TelemetryEvent & { readonly correlationId: string; readonly pluginVersion: string },
+  packageVersion: string,
+): Record<string, string> {
   return {
     Plugin_ClientName: event.clientName,
+    Plugin_CorrelationId: event.correlationId,
     Plugin_EventType: event.eventType,
+    Plugin_PackageVersion: packageVersion,
     Plugin_PluginName: event.pluginName,
+    Plugin_PluginVersion: event.pluginVersion,
     Plugin_Timestamp: event.timestamp,
     ...(event.sessionId === undefined ? {} : { Plugin_SessionId: event.sessionId }),
     ...(event.skillName === undefined ? {} : { Plugin_SkillName: event.skillName }),
@@ -201,19 +303,27 @@ function telemetryProperties(event: TelemetryEvent): Record<string, string> {
   };
 }
 
-function flushWithTimeout(client: ApplicationInsightsClient, timeoutMs: number): Promise<void> {
+function flushWithTimeout(
+  client: ApplicationInsightsClient,
+  timeoutMs: number,
+  totalTimeoutMs: number,
+): Promise<SafeIngestionDiagnostic> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
-      reject(new Error(`Telemetry delivery timed out after ${timeoutMs}ms`));
+      reject(new TelemetryDeliveryError(
+        `Telemetry delivery timed out after ${totalTimeoutMs}ms`,
+        false,
+        { category: 'timeout' },
+      ));
     }, timeoutMs);
     try {
       client.flush({
         callback: response => {
           clearTimeout(timeout);
-          if (response) {
-            reject(new Error(`Telemetry delivery failed: ${response}`));
-          } else {
-            resolve();
+          try {
+            resolve(parseIngestionResponse(response));
+          } catch (error) {
+            reject(error);
           }
         },
       });
@@ -224,14 +334,99 @@ function flushWithTimeout(client: ApplicationInsightsClient, timeoutMs: number):
   });
 }
 
-function isConfiguredConnectionString(connectionString: string): boolean {
+export function isTelemetryConfigured(connectionString: string): boolean {
   return connectionString.trim().length > 0
     && connectionString !== CONNECTION_STRING_PLACEHOLDER;
 }
 
-function isOptedOut(environment: TelemetryEnvironment): boolean {
+export function isTelemetryOptedOut(environment: TelemetryEnvironment): boolean {
   return environment.AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY?.toLowerCase() === 'false'
     || environment.AZURE_MCP_COLLECT_TELEMETRY?.toLowerCase() === 'false';
+}
+
+class TelemetryDeliveryError extends Error {
+  readonly transient: boolean;
+  readonly ingestion: SafeIngestionDiagnostic;
+
+  constructor(message: string, transient: boolean, ingestion: SafeIngestionDiagnostic) {
+    super(message);
+    this.name = 'TelemetryDeliveryError';
+    this.transient = transient;
+    this.ingestion = ingestion;
+  }
+}
+
+function parseIngestionResponse(response?: string): SafeIngestionDiagnostic {
+  if (!response) return { category: 'empty-response' };
+
+  let value: unknown;
+  try {
+    value = JSON.parse(response);
+  } catch {
+    const transient = /\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|429|5\d\d)\b/i
+      .test(response);
+    throw new TelemetryDeliveryError(
+      transient ? 'Telemetry delivery failed due to a transient network error.' : 'Telemetry delivery failed.',
+      transient,
+      { category: transient ? 'network' : 'unknown' },
+    );
+  }
+  if (!isRecord(value)
+    || typeof value.itemsReceived !== 'number'
+    || typeof value.itemsAccepted !== 'number'
+    || !Array.isArray(value.errors)) {
+    throw new TelemetryDeliveryError(
+      'Telemetry delivery returned an unrecognized response.',
+      false,
+      { category: 'unknown' },
+    );
+  }
+
+  const itemsReceived = value.itemsReceived;
+  const itemsAccepted = value.itemsAccepted;
+  if (itemsReceived === itemsAccepted && value.errors.length === 0) {
+    return { category: 'accepted', itemsReceived, itemsAccepted };
+  }
+
+  const statusCodes = value.errors
+    .filter(isRecord)
+    .map(error => error.statusCode)
+    .filter((statusCode): statusCode is number => typeof statusCode === 'number');
+  const statusCode = statusCodes[0];
+  const transient = statusCodes.some(code => code === 429 || (code >= 500 && code <= 599));
+  throw new TelemetryDeliveryError(
+    `Telemetry ingestion rejected ${itemsReceived - itemsAccepted} of ${itemsReceived} item(s).`,
+    transient,
+    {
+      category: 'partial',
+      itemsReceived,
+      itemsAccepted,
+      ...(statusCode === undefined ? {} : { statusCode }),
+    },
+  );
+}
+
+function toDeliveryError(error: unknown): TelemetryDeliveryError {
+  if (error instanceof TelemetryDeliveryError) return error;
+  const message = error instanceof Error ? error.message : '';
+  const transient = /\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN)\b/i.test(message);
+  return new TelemetryDeliveryError(
+    transient ? 'Telemetry delivery failed due to a transient network error.' : 'Telemetry delivery failed.',
+    transient,
+    { category: transient ? 'network' : 'unknown' },
+  );
+}
+
+function remainingTime(deadline: number): number {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    throw new TelemetryDeliveryError(
+      'Telemetry delivery timed out.',
+      false,
+      { category: 'timeout' },
+    );
+  }
+  return remaining;
 }
 
 function isFunctionsToolName(toolName: string): boolean {

--- a/src/telemetry/version.ts
+++ b/src/telemetry/version.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+
+const packageJsonUrl = new URL('../../package.json', import.meta.url);
+
+export const PACKAGE_VERSION = readPackageVersion();
+
+function readPackageVersion(): string {
+  const value: unknown = JSON.parse(readFileSync(packageJsonUrl, 'utf-8'));
+  if (!isRecord(value) || typeof value.version !== 'string' || value.version.length === 0) {
+    throw new Error('Package version is missing from package.json.');
+  }
+  return value.version;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/templates/hooks/copilot-hooks.json
+++ b/templates/hooks/copilot-hooks.json
@@ -4,7 +4,8 @@
       {
         "type": "command",
         "bash": "${PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh",
-        "powershell": "${PLUGIN_ROOT}/hooks/scripts/track-telemetry.ps1"
+        "powershell": "${PLUGIN_ROOT}/hooks/scripts/track-telemetry.ps1",
+        "timeoutSec": 30
       }
     ]
   }

--- a/templates/hooks/cursor-hooks.json
+++ b/templates/hooks/cursor-hooks.json
@@ -4,7 +4,8 @@
     "postToolUse": [
       {
         "type": "command",
-        "command": "bash ${CURSOR_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"
+        "command": "bash ${CURSOR_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh",
+        "timeout": 30
       }
     ]
   }

--- a/templates/hooks/hooks.json
+++ b/templates/hooks/hooks.json
@@ -5,7 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh",
+            "timeout": 30
           }
         ]
       }

--- a/templates/hooks/scripts/track-telemetry.ps1
+++ b/templates/hooks/scripts/track-telemetry.ps1
@@ -3,7 +3,69 @@
 
 $ErrorActionPreference = "SilentlyContinue"
 
+$packageVersion = "__PACKAGE_VERSION__"
+$debugEnabled = $env:AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG -and
+    $env:AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG.ToLowerInvariant() -eq "true"
+
+function Write-TelemetryDebug {
+    param(
+        [string] $Action,
+        [string] $Status,
+        [string] $Reason,
+        [string] $RegistryUrl,
+        [object] $NpxExitCode,
+        $Event
+    )
+    if (-not $debugEnabled) { return }
+    try {
+        $directory = $env:AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR
+        if ([string]::IsNullOrWhiteSpace($directory)) {
+            $directory = Join-Path ([IO.Path]::GetTempPath()) "azure-functions-skills-telemetry"
+        }
+        [IO.Directory]::CreateDirectory($directory) | Out-Null
+        $path = Join-Path $directory "telemetry-debug.jsonl"
+        $backupPath = "$path.1"
+        $record = [ordered]@{
+            timestamp = [DateTime]::UtcNow.ToString("o")
+            component = "hook"
+            action = $Action
+            status = $Status
+            packageVersion = $packageVersion
+        }
+        if ($Reason) { $record.reason = $Reason }
+        if ($RegistryUrl) { $record.registryUrl = $RegistryUrl }
+        if ($null -ne $NpxExitCode) { $record.npxExitCode = [int]$NpxExitCode }
+        if ($null -ne $Event) { $record.event = $Event }
+        $line = ($record | ConvertTo-Json -Compress -Depth 5) + [Environment]::NewLine
+        if ((Test-Path $path) -and
+            ((Get-Item $path).Length + [Text.Encoding]::UTF8.GetByteCount($line) -gt 1MB)) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $backupPath
+            Move-Item -Force $path $backupPath
+        }
+        [IO.File]::AppendAllText($path, $line, [Text.UTF8Encoding]::new($false))
+    } catch { }
+}
+
+function Get-SafeRegistryUrl {
+    try {
+        $registry = (& npm config get registry 2>$null | Select-Object -First 1)
+        $uri = [Uri]$registry
+        if ($uri.Scheme -ne "https" -and $uri.Scheme -ne "http") { return $null }
+        $builder = [UriBuilder]$uri
+        $builder.UserName = ""
+        $builder.Password = ""
+        $builder.Query = ""
+        $builder.Fragment = ""
+        return $builder.Uri.AbsoluteUri
+    } catch {
+        return $null
+    }
+}
+
+Write-TelemetryDebug -Action "start" -Status "started"
+
 if ($env:AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY -eq "false" -or $env:AZURE_MCP_COLLECT_TELEMETRY -eq "false") {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "disabled"
     Write-Output '{"continue":true}'
     exit 0
 }
@@ -13,6 +75,7 @@ if (Test-Path $telemetryConfigPath) {
     try {
         $telemetryConfig = Get-Content -Raw -Path $telemetryConfigPath | ConvertFrom-Json
         if ($telemetryConfig.enabled -eq $false) {
+            Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "disabled"
             Write-Output '{"continue":true}'
             exit 0
         }
@@ -33,6 +96,7 @@ try {
 }
 
 if ([string]::IsNullOrWhiteSpace($rawInput)) {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "invalid-input"
     Write-Success
 }
 
@@ -83,6 +147,7 @@ if ($env:COPILOT_CLI -eq "1") {
 }
 
 if (-not $toolName) {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "no-tool-name"
     Write-Success
 }
 
@@ -190,22 +255,46 @@ if (-not $filePath -and -not $skillName) {
 }
 
 if ($shouldTrack) {
+    $correlationId = [guid]::NewGuid().ToString()
     $event = [ordered]@{
         timestamp = $timestamp
         eventType = $eventType
         clientName = $clientName
         pluginName = "azure-functions-skills"
+        pluginVersion = $packageVersion
     }
+    if ($correlationId) { $event.correlationId = $correlationId }
     if ($sessionId) { $event.sessionId = $sessionId }
     if ($skillName) { $event.skillName = $skillName }
     if ($azureToolName) { $event.toolName = $azureToolName }
     if ($filePath) { $event.fileReference = ($filePath -replace '/', '\') }
 
     try {
+        $registryUrl = $null
+        if ($debugEnabled) {
+            $registryUrl = Get-SafeRegistryUrl
+            Write-TelemetryDebug -Action "decision" -Status "tracked" -RegistryUrl $registryUrl -Event $event
+            & npm view "@azure/functions-skills@__PACKAGE_VERSION__" version *> $null
+            if ($LASTEXITCODE -eq 0 -or ($null -eq $LASTEXITCODE -and $?)) {
+                Write-TelemetryDebug -Action "package-resolution" -Status "resolved" -RegistryUrl $registryUrl
+            } else {
+                Write-TelemetryDebug -Action "package-resolution" -Status "failed" -Reason "npm-resolution" -RegistryUrl $registryUrl
+            }
+        }
+        $global:LASTEXITCODE = $null
         $event | ConvertTo-Json -Compress |
-            & npx -y "@azure/functions-skills@latest" telemetry 2>&1 |
+            & npx -y "@azure/functions-skills@__PACKAGE_VERSION__" telemetry 2>&1 |
             Out-Null
-    } catch { }
+        $npxExitCode = $LASTEXITCODE
+        if ($null -eq $npxExitCode) {
+            $npxExitCode = if ($?) { 0 } else { 1 }
+        }
+        Write-TelemetryDebug -Action "complete" -Status "completed" -RegistryUrl $registryUrl -NpxExitCode $npxExitCode
+    } catch {
+        Write-TelemetryDebug -Action "complete" -Status "completed" -RegistryUrl $registryUrl -NpxExitCode 1
+    }
+} else {
+    Write-TelemetryDebug -Action "decision" -Status "skipped" -Reason "filtered"
 }
 
 Write-Success

--- a/templates/hooks/scripts/track-telemetry.sh
+++ b/templates/hooks/scripts/track-telemetry.sh
@@ -5,7 +5,64 @@
 
 set +e
 
+package_version="__PACKAGE_VERSION__"
+debug_enabled=false
+[ "$(printf '%s' "${AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG}" | tr '[:upper:]' '[:lower:]')" = "true" ] && debug_enabled=true
+
+write_debug() {
+    [ "$debug_enabled" = true ] || return
+    DEBUG_ACTION="$1" DEBUG_STATUS="$2" DEBUG_REASON="$3" DEBUG_REGISTRY="$4" \
+        DEBUG_EXIT_CODE="$5" DEBUG_EVENT="$6" \
+        AZURE_FUNCTIONS_SKILLS_PACKAGE_VERSION="$package_version" node --input-type=module -e '
+import { appendFileSync, existsSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+try {
+  const directory = process.env.AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR || join(tmpdir(), "azure-functions-skills-telemetry");
+  const path = join(directory, "telemetry-debug.jsonl");
+  const backup = `${path}.1`;
+  const record = {
+    timestamp: new Date().toISOString(),
+    component: "hook",
+    action: process.env.DEBUG_ACTION,
+    status: process.env.DEBUG_STATUS,
+    packageVersion: process.env.AZURE_FUNCTIONS_SKILLS_PACKAGE_VERSION,
+  };
+  if (process.env.DEBUG_REASON) record.reason = process.env.DEBUG_REASON;
+  if (process.env.DEBUG_REGISTRY) record.registryUrl = process.env.DEBUG_REGISTRY;
+  if (process.env.DEBUG_EXIT_CODE) record.npxExitCode = Number.parseInt(process.env.DEBUG_EXIT_CODE, 10);
+  if (process.env.DEBUG_EVENT) record.event = JSON.parse(process.env.DEBUG_EVENT);
+  const line = `${JSON.stringify(record)}\n`;
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  if (existsSync(path) && statSync(path).size + Buffer.byteLength(line) > 1024 * 1024) {
+    rmSync(backup, { force: true });
+    renameSync(path, backup);
+  }
+  appendFileSync(path, line, { mode: 0o600 });
+} catch {}
+' >/dev/null 2>&1
+}
+
+safe_registry_url() {
+    local registry
+    registry=$(npm config get registry 2>/dev/null)
+    REGISTRY_VALUE="$registry" node --input-type=module -e '
+try {
+  const url = new URL(process.env.REGISTRY_VALUE);
+  if (url.protocol !== "https:" && url.protocol !== "http:") process.exit(1);
+  url.username = "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+  process.stdout.write(url.toString());
+} catch {}
+' 2>/dev/null
+}
+
+write_debug "start" "started" "" "" "" ""
+
 if [ "${AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY}" = "false" ] || [ "${AZURE_MCP_COLLECT_TELEMETRY}" = "false" ]; then
+    write_debug "decision" "skipped" "disabled" "" "" ""
     echo '{"continue":true}'
     exit 0
 fi
@@ -18,6 +75,7 @@ return_success() {
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 config_path="${script_dir}/../telemetry.config.json"
 if [ -f "$config_path" ] && grep -Eq '"enabled"[[:space:]]*:[[:space:]]*false' "$config_path"; then
+    write_debug "decision" "skipped" "disabled" "" "" ""
     echo '{"continue":true}'
     exit 0
 fi
@@ -113,6 +171,7 @@ fi
 
 rawInput=$(cat)
 if [ -z "$rawInput" ]; then
+    write_debug "decision" "skipped" "invalid-input" "" "" ""
     return_success
 fi
 
@@ -150,6 +209,7 @@ else
 fi
 
 if [ -z "$toolName" ]; then
+    write_debug "decision" "skipped" "no-tool-name" "" "" ""
     return_success
 fi
 
@@ -208,11 +268,22 @@ if [ -z "$filePath" ] && [ -z "$skillName" ]; then
 fi
 
 if [ "$shouldTrack" = true ]; then
+    if [ -r /proc/sys/kernel/random/uuid ]; then
+        correlationId=$(cat /proc/sys/kernel/random/uuid 2>/dev/null)
+    elif command -v uuidgen >/dev/null 2>&1; then
+        correlationId=$(uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    else
+        correlationId=$(node --input-type=module -e 'import { randomUUID } from "node:crypto"; console.log(randomUUID())' 2>/dev/null)
+    fi
     payload=$(printf \
-        '{"timestamp":"%s","eventType":"%s","clientName":"%s","pluginName":"azure-functions-skills"}' \
+        '{"timestamp":"%s","eventType":"%s","clientName":"%s","pluginName":"azure-functions-skills","pluginVersion":"%s"}' \
         "$(json_escape "$timestamp")" \
         "$(json_escape "$eventType")" \
-        "$(json_escape "$clientName")")
+        "$(json_escape "$clientName")" \
+        "$(json_escape "$package_version")")
+    if [ -n "$correlationId" ]; then
+        payload="${payload%?},\"correlationId\":\"$(json_escape "$correlationId")\"}"
+    fi
     if [ -n "$sessionId" ]; then
         payload="${payload%?},\"sessionId\":\"$(json_escape "$sessionId")\"}"
     fi
@@ -226,9 +297,23 @@ if [ "$shouldTrack" = true ]; then
         payload="${payload%?},\"fileReference\":\"$(json_escape "$(echo "$filePath" | tr '/' '\\')")\"}"
     fi
 
+    registryUrl=""
+    if [ "$debug_enabled" = true ]; then
+        registryUrl=$(safe_registry_url)
+        write_debug "decision" "tracked" "" "$registryUrl" "" "$payload"
+        npm view "@azure/functions-skills@__PACKAGE_VERSION__" version >/dev/null 2>&1
+        if [ "$?" -eq 0 ]; then
+            write_debug "package-resolution" "resolved" "" "$registryUrl" "" ""
+        else
+            write_debug "package-resolution" "failed" "npm-resolution" "$registryUrl" "" ""
+        fi
+    fi
     printf '%s' "$payload" |
-        npx -y @azure/functions-skills@latest telemetry >/dev/null 2>&1 ||
-        true
+        npx -y "@azure/functions-skills@__PACKAGE_VERSION__" telemetry >/dev/null 2>&1
+    npxExitCode=$?
+    write_debug "complete" "completed" "" "$registryUrl" "$npxExitCode" ""
+else
+    write_debug "decision" "skipped" "filtered" "" "" ""
 fi
 
 return_success

--- a/tests/simplified-cli.test.ts
+++ b/tests/simplified-cli.test.ts
@@ -79,7 +79,29 @@ describe('simplified CLI', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).not.toMatch(/^\s+telemetry(?:\s|$)/m);
+    expect(result.stdout).toContain('telemetry doctor');
+  });
+
+  it('reports telemetry diagnostic state without exposing configuration secrets', () => {
+    const result = spawnSync(process.execPath, [CLI_PATH, 'telemetry', 'doctor', '--json'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY: 'false',
+        APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=must-not-appear',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      packageResolved: true,
+      telemetryEnabled: false,
+      configurationStatus: 'disabled',
+      transportStatus: 'not-attempted',
+      ingestionAccepted: false,
+    });
+    expect(`${result.stdout}${result.stderr}`).not.toContain('must-not-appear');
   });
 
   it('accepts one sanitized telemetry event over stdin', () => {

--- a/tests/simplified-distribution.test.ts
+++ b/tests/simplified-distribution.test.ts
@@ -39,11 +39,16 @@ describe('simplified distribution', () => {
     expect(existsSync(join(root, '.mcp.json'))).toBe(true);
     expect(existsSync(join(root, 'hooks', 'copilot-hooks.json'))).toBe(true);
     expect(existsSync(join(root, 'hooks', 'hooks.json'))).toBe(true);
+    const hookRegistration = JSON.parse(
+      readFileSync(join(root, 'hooks', 'copilot-hooks.json'), 'utf-8'),
+    ) as { hooks: { PostToolUse: Array<{ timeoutSec?: number }> } };
+    expect(hookRegistration.hooks.PostToolUse[0].timeoutSec).toBe(30);
     const telemetryScript = readFileSync(
       join(root, 'hooks', 'scripts', 'track-telemetry.sh'),
       'utf-8',
     );
-    expect(telemetryScript).toContain('@azure/functions-skills@latest');
+    expect(telemetryScript).toContain('@azure/functions-skills@1.2.3');
+    expect(telemetryScript).not.toContain('@latest');
     expect(telemetryScript).toContain(' telemetry');
     expect(telemetryScript).not.toContain('@azure/mcp');
     expect(existsSync(join(root, 'agents'))).toBe(false);
@@ -77,8 +82,13 @@ describe('simplified distribution', () => {
         join(targetRoot, hookRoot, 'hooks', 'scripts', 'track-telemetry.sh'),
         'utf-8',
       );
-      expect(telemetryScript).toContain('@azure/functions-skills@latest');
+      expect(telemetryScript).toContain('@azure/functions-skills@1.2.3');
+      expect(telemetryScript).not.toContain('@latest');
       expect(telemetryScript).not.toContain('@azure/mcp');
+      const hookRegistrationContent = readFileSync(join(targetRoot, hookPath), 'utf-8');
+      expect(hookRegistrationContent).toContain(
+        target === 'ghcp' ? '"timeoutSec": 30' : '"timeout": 30',
+      );
       expect(existsSync(join(targetRoot, 'AGENTS.md'))).toBe(false);
       expect(existsSync(join(targetRoot, 'CLAUDE.md'))).toBe(false);
       expect(existsSync(join(targetRoot, '.github', 'agents'))).toBe(false);

--- a/tests/telemetry-diagnostics.test.ts
+++ b/tests/telemetry-diagnostics.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import {
+  TELEMETRY_DIAGNOSTIC_LOG_NAME,
+  TELEMETRY_DIAGNOSTIC_MAX_BYTES,
+  writeTelemetryDiagnostic,
+} from '../src/telemetry/diagnostics.js';
+import { createTempDir, removeDir } from './helpers/fs.js';
+
+const TEMP_DIRS: string[] = [];
+
+afterEach(() => {
+  for (const directory of TEMP_DIRS.splice(0)) removeDir(directory);
+});
+
+describe('writeTelemetryDiagnostic', () => {
+  it('is silent unless explicitly enabled', () => {
+    const directory = createTempDir('af-skills-telemetry-debug-off-');
+    TEMP_DIRS.push(directory);
+
+    expect(writeTelemetryDiagnostic({
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR: directory,
+    }, {
+      component: 'sender',
+      action: 'decision',
+      status: 'skipped',
+      reason: 'disabled',
+    })).toBe(false);
+    expect(existsSync(join(directory, TELEMETRY_DIAGNOSTIC_LOG_NAME))).toBe(false);
+  });
+
+  it('writes only the typed safe diagnostic contract', () => {
+    const directory = createTempDir('af-skills-telemetry-debug-on-');
+    TEMP_DIRS.push(directory);
+    const secretValues = [
+      'InstrumentationKey=connection-secret',
+      'npm-password',
+      'customer prompt',
+      'customer file contents',
+      '{"rawHookInput":true}',
+      '{"rawToolArguments":true}',
+    ];
+
+    expect(writeTelemetryDiagnostic({
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG: 'true',
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR: directory,
+      SECRET_TEST_VALUES: secretValues.join('|'),
+    } as NodeJS.ProcessEnv, {
+      component: 'sender',
+      action: 'delivery',
+      status: 'accepted',
+      correlationId: '11111111-1111-4111-8111-111111111111',
+      packageVersion: '1.2.3',
+      pluginVersion: '1.2.3',
+      attempt: 1,
+      ingestion: {
+        category: 'accepted',
+        itemsReceived: 1,
+        itemsAccepted: 1,
+      },
+    })).toBe(true);
+
+    const content = readFileSync(join(directory, TELEMETRY_DIAGNOSTIC_LOG_NAME), 'utf-8');
+    expect(JSON.parse(content)).toMatchObject({
+      component: 'sender',
+      action: 'delivery',
+      status: 'accepted',
+      ingestion: {
+        category: 'accepted',
+        itemsReceived: 1,
+        itemsAccepted: 1,
+      },
+    });
+    for (const secret of secretValues) expect(content).not.toContain(secret);
+  });
+
+  it('rotates to one bounded backup', () => {
+    const directory = createTempDir('af-skills-telemetry-debug-rotate-');
+    TEMP_DIRS.push(directory);
+    const path = join(directory, TELEMETRY_DIAGNOSTIC_LOG_NAME);
+    writeFileSync(path, 'x'.repeat(TELEMETRY_DIAGNOSTIC_MAX_BYTES));
+
+    writeTelemetryDiagnostic({
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG: 'true',
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR: directory,
+    }, {
+      component: 'sender',
+      action: 'complete',
+      status: 'accepted',
+    });
+
+    expect(statSync(path).size).toBeLessThan(TELEMETRY_DIAGNOSTIC_MAX_BYTES);
+    expect(statSync(`${path}.1`).size).toBe(TELEMETRY_DIAGNOSTIC_MAX_BYTES);
+    expect(existsSync(`${path}.2`)).toBe(false);
+  });
+});

--- a/tests/telemetry-hook.test.ts
+++ b/tests/telemetry-hook.test.ts
@@ -14,6 +14,7 @@ const ROOT = join(import.meta.dirname, '..');
 const TEMP_DIRS: string[] = [];
 const POWERSHELL_PROCESS_TIMEOUT_MS = 45_000;
 const HOOK_TEST_TIMEOUT_MS = process.platform === 'win32' ? 50_000 : 5_000;
+const TEST_REGISTRY = 'https://npm-user:npm-password@example.test/npm?token=registry-secret';
 const HOOK_INPUT = JSON.stringify({
   toolName: 'skill',
   sessionId: 'session-123',
@@ -62,7 +63,7 @@ describe('telemetry hook transport', () => {
     expect(result.stdout.trim()).toBe('{"continue":true}');
     expect(JSON.parse(readFileSync(argsPath, 'utf-8'))).toEqual([
       '-y',
-      '@azure/functions-skills@latest',
+      '@azure/functions-skills@__PACKAGE_VERSION__',
       'telemetry',
     ]);
     expect(JSON.parse(readFileSync(capturePath, 'utf-8'))).toEqual({
@@ -70,6 +71,10 @@ describe('telemetry hook transport', () => {
       eventType: 'skill_invocation',
       clientName: 'copilot-cli',
       pluginName: 'azure-functions-skills',
+      correlationId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      ),
+      pluginVersion: '__PACKAGE_VERSION__',
       sessionId: 'session-123',
       skillName: 'azure-functions-help',
     });
@@ -125,9 +130,204 @@ describe('telemetry hook transport', () => {
     expect(result.stdout.trim()).toBe('{"continue":true}');
     expect(existsSync(capturePath)).toBe(false);
   });
+
+  it('writes safe opt-in diagnostics without raw hook data or registry credentials', () => {
+    const tempDir = createTempDir('af-skills-hook-debug-');
+    TEMP_DIRS.push(tempDir);
+    const capturePath = join(tempDir, 'payload.json');
+    const argsPath = join(tempDir, 'args.json');
+    const captureScript = join(tempDir, 'capture.mjs');
+    writeFileSync(captureScript, [
+      "import { writeFileSync } from 'node:fs';",
+      "let input = '';",
+      "for await (const chunk of process.stdin) input += chunk;",
+      "writeFileSync(process.env.TELEMETRY_CAPTURE, input);",
+      "writeFileSync(process.env.TELEMETRY_ARGS, JSON.stringify(process.argv.slice(2)));",
+      "process.exit(17);",
+      '',
+    ].join('\n'));
+    const rawInput = JSON.stringify({
+      ...JSON.parse(HOOK_INPUT) as Record<string, unknown>,
+      prompt: 'customer prompt must not be logged',
+      fileContents: 'customer file contents must not be logged',
+      credentials: 'hook-input-secret',
+    });
+    const environment = {
+      ...process.env,
+      COPILOT_CLI: '1',
+      FAKE_NPX_CAPTURE: captureScript,
+      TELEMETRY_CAPTURE: capturePath,
+      TELEMETRY_ARGS: argsPath,
+      TELEMETRY_TEST_REGISTRY: TEST_REGISTRY,
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG: 'true',
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR: tempDir,
+      PATH: `${tempDir}${delimiter}${process.env.PATH || ''}`,
+    };
+
+    const result = process.platform === 'win32'
+      ? runPowerShellHook(tempDir, environment, rawInput)
+      : runShellHook(tempDir, environment, rawInput);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('{"continue":true}');
+    const log = readFileSync(join(tempDir, 'telemetry-debug.jsonl'), 'utf-8');
+    const records = log.trim().split(/\r?\n/).map(line => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toEqual(expect.arrayContaining([
+      expect.objectContaining({ component: 'hook', action: 'start', status: 'started' }),
+      expect.objectContaining({
+        component: 'hook',
+        action: 'decision',
+        status: 'tracked',
+        registryUrl: 'https://example.test/npm',
+      }),
+      expect.objectContaining({
+        component: 'hook',
+        action: 'complete',
+        npxExitCode: expect.any(Number),
+      }),
+      expect.objectContaining({
+        component: 'hook',
+        action: 'package-resolution',
+        status: 'resolved',
+      }),
+    ]));
+    for (const forbidden of [
+      'npm-user',
+      'npm-password',
+      'registry-secret',
+      'customer prompt',
+      'customer file contents',
+      'hook-input-secret',
+      'customer-secret.txt',
+      rawInput,
+    ]) {
+      expect(log).not.toContain(forbidden);
+    }
+  }, HOOK_TEST_TIMEOUT_MS);
+
+  it('records a safe filtered reason in debug mode', () => {
+    const tempDir = createTempDir('af-skills-hook-filtered-');
+    TEMP_DIRS.push(tempDir);
+    const environment = {
+      ...process.env,
+      TELEMETRY_TEST_REGISTRY: TEST_REGISTRY,
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG: 'true',
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR: tempDir,
+      PATH: `${tempDir}${delimiter}${process.env.PATH || ''}`,
+    };
+    const input = JSON.stringify({
+      toolName: 'read_file',
+      toolArgs: { path: 'customer-secret.txt', contents: 'must-not-be-logged' },
+    });
+
+    const result = process.platform === 'win32'
+      ? runPowerShellHook(tempDir, environment, input)
+      : runShellHook(tempDir, environment, input);
+
+    expect(result.status).toBe(0);
+    const log = readFileSync(join(tempDir, 'telemetry-debug.jsonl'), 'utf-8');
+    expect(log).toContain('"reason":"filtered"');
+    expect(log).not.toContain('customer-secret.txt');
+    expect(log).not.toContain('must-not-be-logged');
+  }, HOOK_TEST_TIMEOUT_MS);
+
+  it('runs a generated host payload through the real telemetry CLI', async () => {
+    const tempDir = createTempDir('af-skills-hook-generated-');
+    TEMP_DIRS.push(tempDir);
+    await installLocalSkills({
+      targetDir: tempDir,
+      agents: ['ghcp'],
+      checkForUpdates: false,
+    });
+    const environment = {
+      ...process.env,
+      TELEMETRY_CLI: join(ROOT, 'bin', 'azure-functions-skills.js'),
+      TELEMETRY_TEST_REGISTRY: TEST_REGISTRY,
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG: 'true',
+      AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR: tempDir,
+      PATH: `${tempDir}${delimiter}${process.env.PATH || ''}`,
+    };
+    if (process.platform === 'win32') {
+      writeFileSync(join(tempDir, 'npm.cmd'), [
+        '@echo off',
+        'if "%1"=="config" echo %TELEMETRY_TEST_REGISTRY%',
+        'exit /b 0',
+        '',
+      ].join('\r\n'));
+      writeFileSync(join(tempDir, 'npx.cmd'), [
+        '@echo off',
+        'node "%TELEMETRY_CLI%" telemetry',
+        'exit /b %ERRORLEVEL%',
+        '',
+      ].join('\r\n'));
+    } else {
+      const npmPath = join(tempDir, 'npm');
+      writeFileSync(npmPath, [
+        '#!/usr/bin/env sh',
+        '[ "$1" = "config" ] && printf "%s\\n" "$TELEMETRY_TEST_REGISTRY"',
+        'exit 0',
+        '',
+      ].join('\n'));
+      chmodSync(npmPath, 0o755);
+      const npxPath = join(tempDir, 'npx');
+      writeFileSync(npxPath, '#!/usr/bin/env sh\nnode "$TELEMETRY_CLI" telemetry\n');
+      chmodSync(npxPath, 0o755);
+    }
+
+    const script = join(
+      tempDir,
+      '.github',
+      'hooks',
+      'scripts',
+      process.platform === 'win32' ? 'track-telemetry.ps1' : 'track-telemetry.sh',
+    );
+    const input = JSON.stringify({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Skill',
+      tool_input: { skill: 'azure-functions-help' },
+    });
+    const result = process.platform === 'win32'
+      ? spawnSync('powershell.exe', [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        script,
+      ], {
+        cwd: tempDir,
+        encoding: 'utf-8',
+        env: environment,
+        input,
+        timeout: POWERSHELL_PROCESS_TIMEOUT_MS,
+      })
+      : spawnSync('bash', [script], {
+        cwd: tempDir,
+        encoding: 'utf-8',
+        env: environment,
+        input,
+      });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('{"continue":true}');
+    expect(result.stderr).toBe('');
+    const log = readFileSync(join(tempDir, 'telemetry-debug.jsonl'), 'utf-8');
+    const packageVersion = (
+      JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')) as { version: string }
+    ).version;
+    expect(log).not.toContain('__PACKAGE_VERSION__');
+    expect(log).not.toContain('"reason":"filtered"');
+    expect(log).toContain('"npxExitCode":0');
+    expect(log).toContain(`"pluginVersion":"${packageVersion}"`);
+  }, HOOK_TEST_TIMEOUT_MS);
 });
 
-function runPowerShellHook(tempDir: string, environment: NodeJS.ProcessEnv) {
+function runPowerShellHook(
+  tempDir: string,
+  environment: NodeJS.ProcessEnv,
+  input = HOOK_INPUT,
+) {
   const hookScript = join(ROOT, 'templates', 'hooks', 'scripts', 'track-telemetry.ps1');
   const harness = [
     'function npx {',
@@ -136,6 +336,9 @@ function runPowerShellHook(tempDir: string, environment: NodeJS.ProcessEnv) {
     '  [IO.File]::WriteAllText($env:TELEMETRY_CAPTURE, $payload)',
     '  [IO.File]::WriteAllText($env:TELEMETRY_ARGS, (ConvertTo-Json -Compress -InputObject $arguments))',
     '  $global:LASTEXITCODE = 17',
+    '}',
+    'function npm {',
+    '  Write-Output $env:TELEMETRY_TEST_REGISTRY',
     '}',
     '& $env:TELEMETRY_HOOK',
     '',
@@ -156,16 +359,23 @@ function runPowerShellHook(tempDir: string, environment: NodeJS.ProcessEnv) {
         ...environment,
         TELEMETRY_HOOK: hookScript,
       },
-      input: HOOK_INPUT,
+      input,
       timeout: POWERSHELL_PROCESS_TIMEOUT_MS,
     },
   );
 }
 
-function runShellHook(tempDir: string, environment: NodeJS.ProcessEnv) {
+function runShellHook(
+  tempDir: string,
+  environment: NodeJS.ProcessEnv,
+  input = HOOK_INPUT,
+) {
   const npxPath = join(tempDir, 'npx');
   writeFileSync(npxPath, '#!/usr/bin/env sh\nnode "$FAKE_NPX_CAPTURE" "$@"\n');
   chmodSync(npxPath, 0o755);
+  const npmPath = join(tempDir, 'npm');
+  writeFileSync(npmPath, '#!/usr/bin/env sh\nprintf "%s\\n" "$TELEMETRY_TEST_REGISTRY"\n');
+  chmodSync(npmPath, 0o755);
   return spawnSync(
     'bash',
     [join(ROOT, 'templates', 'hooks', 'scripts', 'track-telemetry.sh')],
@@ -173,7 +383,7 @@ function runShellHook(tempDir: string, environment: NodeJS.ProcessEnv) {
       cwd: ROOT,
       encoding: 'utf-8',
       env: environment,
-      input: HOOK_INPUT,
+      input,
     },
   );
 }

--- a/tests/telemetry-release.test.ts
+++ b/tests/telemetry-release.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { parse } from 'yaml';
 
 const ROOT = join(import.meta.dirname, '..');
 
@@ -58,5 +59,25 @@ describe('telemetry release contract', () => {
       expect(content).toContain('rm -f .npmrc');
       expect(content.indexOf('rm -f .npmrc')).toBeLessThan(content.indexOf('actions/setup-node'));
     }
+  });
+
+  it('provides an explicitly gated post-release telemetry canary', () => {
+    const releasePipeline = readFileSync(
+      join(ROOT, 'azure-pipelines', 'release.yml'),
+      'utf-8',
+    );
+    const canary = readFileSync(
+      join(ROOT, 'scripts', 'telemetry-release-canary.mjs'),
+      'utf-8',
+    );
+
+    expect(() => parse(releasePipeline)).not.toThrow();
+    expect(releasePipeline).toContain('RunTelemetryCanary');
+    expect(releasePipeline).toContain('dependsOn: Release');
+    expect(releasePipeline).toContain('APPLICATIONINSIGHTS_API_KEY: $(ApplicationInsightsApiKey)');
+    expect(canary).toContain("['pack', `${packageName}@${version}`");
+    expect(canary).toContain('waitForPublishedVersion(expectedVersion)');
+    expect(canary).toContain('Plugin_CorrelationId');
+    expect(canary).not.toContain('console.log(apiKey)');
   });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -18,6 +18,8 @@ const EVENT: TelemetryEvent = {
   eventType: 'skill_invocation',
   clientName: 'copilot-cli',
   pluginName: 'azure-functions-skills',
+  correlationId: '11111111-1111-4111-8111-111111111111',
+  pluginVersion: '1.2.3',
   sessionId: 'session-123',
   skillName: 'azure-functions-help',
 };
@@ -78,6 +80,7 @@ describe('sendTelemetryEventWithDependencies', () => {
       connectionString: 'InstrumentationKey=test-key',
       createClient,
       environment: {},
+      packageVersion: '1.2.3',
       timeoutMs: 100,
     });
 
@@ -88,8 +91,11 @@ describe('sendTelemetryEventWithDependencies', () => {
       name: 'AzureFunctionsSkillsPluginExecuted',
       properties: {
         Plugin_ClientName: 'copilot-cli',
+        Plugin_CorrelationId: '11111111-1111-4111-8111-111111111111',
         Plugin_EventType: 'skill_invocation',
+        Plugin_PackageVersion: '1.2.3',
         Plugin_PluginName: 'azure-functions-skills',
+        Plugin_PluginVersion: '1.2.3',
         Plugin_SessionId: 'session-123',
         Plugin_SkillName: 'azure-functions-help',
         Plugin_Timestamp: '2026-07-17T20:00:00Z',
@@ -105,6 +111,7 @@ describe('sendTelemetryEventWithDependencies', () => {
       connectionString: 'InstrumentationKey=test-key',
       createClient,
       environment: { AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY: 'false' },
+      packageVersion: '1.2.3',
       timeoutMs: 100,
     })).resolves.toEqual({ status: 'disabled' });
 
@@ -112,6 +119,7 @@ describe('sendTelemetryEventWithDependencies', () => {
       connectionString: '__APPLICATIONINSIGHTS_CONNECTION_STRING__',
       createClient,
       environment: {},
+      packageVersion: '1.2.3',
       timeoutMs: 100,
     })).resolves.toEqual({ status: 'not-configured' });
 
@@ -126,6 +134,7 @@ describe('sendTelemetryEventWithDependencies', () => {
       connectionString: 'InstrumentationKey=test-key',
       createClient,
       environment: {},
+      packageVersion: '1.2.3',
       timeoutMs: 10,
     })).rejects.toThrow('Telemetry delivery timed out after 10ms');
 
@@ -142,12 +151,73 @@ describe('sendTelemetryEventWithDependencies', () => {
       connectionString: 'InstrumentationKey=test-key',
       createClient,
       environment: {},
+      packageVersion: '1.2.3',
       timeoutMs: 100,
-    })).rejects.toThrow('Telemetry delivery failed: network unavailable');
+    })).rejects.toThrow('Telemetry delivery failed.');
 
     expect(client.trackEvent).toHaveBeenCalledOnce();
     expect(client.flush).toHaveBeenCalledOnce();
     expect(createClient).toHaveBeenCalledOnce();
+  });
+
+  it('treats a structured all-items-accepted SDK response as success', async () => {
+    const response = JSON.stringify({
+      itemsReceived: 1,
+      itemsAccepted: 1,
+      appId: null,
+      errors: [],
+    });
+    const client = makeClient(({ callback }) => callback(response));
+
+    await expect(sendTelemetryEventWithDependencies(EVENT, {
+      connectionString: 'InstrumentationKey=test-key',
+      createClient: () => client,
+      environment: {},
+      packageVersion: '1.2.3',
+      timeoutMs: 100,
+    })).resolves.toEqual({ status: 'sent' });
+  });
+
+  it('rejects partial ingestion without logging the raw SDK response', async () => {
+    const response = JSON.stringify({
+      itemsReceived: 2,
+      itemsAccepted: 1,
+      errors: [{ index: 1, statusCode: 400, message: 'secret backend detail' }],
+    });
+    const client = makeClient(({ callback }) => callback(response));
+
+    await expect(sendTelemetryEventWithDependencies(EVENT, {
+      connectionString: 'InstrumentationKey=test-key',
+      createClient: () => client,
+      environment: {},
+      packageVersion: '1.2.3',
+      timeoutMs: 100,
+    })).rejects.toThrow('Telemetry ingestion rejected 1 of 2 item(s)');
+  });
+
+  it('retries once for transient ingestion failures', async () => {
+    const first = makeClient(({ callback }) => callback(JSON.stringify({
+      itemsReceived: 1,
+      itemsAccepted: 0,
+      errors: [{ index: 0, statusCode: 503, message: 'temporarily unavailable' }],
+    })));
+    const second = makeClient(({ callback }) => callback(JSON.stringify({
+      itemsReceived: 1,
+      itemsAccepted: 1,
+      errors: [],
+    })));
+    const createClient = vi.fn()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second);
+
+    await expect(sendTelemetryEventWithDependencies(EVENT, {
+      connectionString: 'InstrumentationKey=test-key',
+      createClient,
+      environment: {},
+      packageVersion: '1.2.3',
+      timeoutMs: 100,
+    })).resolves.toEqual({ status: 'sent' });
+    expect(createClient).toHaveBeenCalledTimes(2);
   });
 
   it('delivers through the isolated Application Insights client', async () => {
@@ -176,6 +246,7 @@ describe('sendTelemetryEventWithDependencies', () => {
         connectionString,
         createClient: value => new applicationInsights.TelemetryClient(value),
         environment: {},
+        packageVersion: '1.2.3',
         timeoutMs: 1_000,
       })).resolves.toEqual({ status: 'sent' });
     } finally {


### PR DESCRIPTION
## Summary

- treat successful Application Insights ingestion responses as successful delivery
- add opt-in, bounded, allowlisted JSONL diagnostics through `AZURE_FUNCTIONS_SKILLS_TELEMETRY_DEBUG` and `AZURE_FUNCTIONS_SKILLS_TELEMETRY_LOG_DIR` while preserving silent fail-open behavior by default
- add package/plugin version and correlation dimensions, one bounded transient retry, and a `telemetry doctor` command
- generate version-pinned hooks with explicit host-specific timeouts and PowerShell 5.1 compatibility
- add an explicitly gated post-release canary that waits for the expected npm version, runs the published tarball, and verifies the correlated event in Application Insights

## Validation

- `npm run check` — 21 test files, 276 tests passed
- canonical plugin payload regenerated and verified
- release pipeline YAML parsed in unit tests
- generated hook exercised through the real telemetry CLI under Windows PowerShell 5.1
- isolated local install/update E2E: 38/38 commands and 6/6 cases passed
- Claude Sonnet 5 E2E evidence cross-check: VALID

## Release canary prerequisites

The canary is disabled unless `RunTelemetryCanary=true`. The release variable group must provide `ApplicationInsightsAppId` and a query-capable `ApplicationInsightsApiKey`; the expected package version must become visible on the selected npm tag within five minutes.

Closes #233