### PR TITLE
Validate Vally eval specs in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,8 @@ on:
       - 'src/**'
       - 'templates/**'
       - 'tests/**'
+      - 'evals/**'
+      - '.vally.yaml'
       - 'eslint.config.js'
       - 'package.json'
       - 'package-lock.json'
@@ -29,6 +31,8 @@ on:
       - 'src/**'
       - 'templates/**'
       - 'tests/**'
+      - 'evals/**'
+      - '.vally.yaml'
       - 'eslint.config.js'
       - 'package.json'
       - 'package-lock.json'
@@ -51,6 +55,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Validate eval specs
+        run: npm run eval:lint
 
       - name: Run lint
         run: npm run lint

--- a/evals/azure-functions-agents/eval.yaml
+++ b/evals/azure-functions-agents/eval.yaml
@@ -11,7 +11,7 @@ tags:
   type: integration
   skill: azure-functions-agents
 
-config:
+defaults:
   runs: 1
   timeout: "15m"
   executor: copilot-sdk
@@ -20,12 +20,12 @@ config:
 scoring:
   threshold: 0.8
   weights:
-    skill-invocation: 2.0
-    file-exists: 1.0
-    file-matches: 1.0
-    output-matches: 1.0
-    output-not-matches: 1.5
-    completed: 1.0
+    skill-invocation: 0.2667
+    file-exists: 0.1333
+    file-matches: 0.1333
+    output-matches: 0.1333
+    output-not-matches: 0.2
+    completed: 0.1334
 
 stimuli:
   - name: "Routing - scaffold chat UI and scheduled blog summary agent"

--- a/evals/azure-functions-create/eval.yaml
+++ b/evals/azure-functions-create/eval.yaml
@@ -40,7 +40,7 @@ tags:
   type: integration
   skill: azure-functions-create
 
-config:
+defaults:
   runs: 3
   timeout: "10m"
   executor: copilot-sdk
@@ -49,15 +49,15 @@ config:
 scoring:
   threshold: 0.8
   weights:
-    skill-invocation: 2.0
-    tool-calls: 2.0
-    run-command: 2.0
-    file-exists: 1.0
-    file-not-exists: 1.5
-    output-contains: 0.5
-    output-matches: 1.0
-    output-not-matches: 1.5
-    completed: 1.0
+    skill-invocation: 0.16
+    tool-calls: 0.16
+    run-command: 0.16
+    file-exists: 0.08
+    file-not-exists: 0.12
+    output-contains: 0.04
+    output-matches: 0.08
+    output-not-matches: 0.12
+    completed: 0.08
 
 stimuli:
   # ─────────────────────────────────────────────────────────────────

--- a/evals/azure-functions-deploy/eval.yaml
+++ b/evals/azure-functions-deploy/eval.yaml
@@ -32,7 +32,7 @@ tags:
   type: integration
   skill: azure-functions-deploy
 
-config:
+defaults:
   runs: 1
   timeout: "30m"
   executor: copilot-sdk
@@ -41,11 +41,11 @@ config:
 scoring:
   threshold: 0.95
   weights:
-    skill-invocation: 2.0
-    tool-calls: 2.0
-    output-matches: 1.0
-    output-not-matches: 1.5
-    completed: 1.0
+    skill-invocation: 0.2667
+    tool-calls: 0.2667
+    output-matches: 0.1333
+    output-not-matches: 0.2
+    completed: 0.1333
 
 stimuli:
   - name: "Live — deploy TypeScript HTTP FC1 to Azure"

--- a/evals/azure-functions-setup/eval.yaml
+++ b/evals/azure-functions-setup/eval.yaml
@@ -21,7 +21,7 @@ tags:
   type: integration
   skill: azure-functions-setup
 
-config:
+defaults:
   runs: 3
   timeout: "5m"
   executor: copilot-sdk
@@ -30,10 +30,11 @@ config:
 scoring:
   threshold: 0.8
   weights:
-    skill-invocation: 2.0
-    output-matches: 1.0
-    output-not-matches: 1.5
-    completed: 1.0
+    skill-invocation: 0.3077
+    output-contains: 0.1538
+    output-matches: 0.1538
+    output-not-matches: 0.2308
+    completed: 0.1539
 
 stimuli:
   # ─────────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "npm run compile && node lib/build/build.js",
     "build:plugin-payload": "npm run compile && node lib/build/build.js --plugin-only --repo-plugin-dir .github/plugins/azure-functions-skills --marketplace-root .",
-    "check": "npm run lint && npm run typecheck && npm run lint:security && npm run validate:skills && npm run verify:plugin-payload && npm test && npm run build",
+    "check": "npm run lint && npm run typecheck && npm run lint:security && npm run validate:skills && npm run eval:lint && npm run verify:plugin-payload && npm test && npm run build",
     "ci": "npm run check",
     "compile": "tsc",
     "lint": "eslint .",
@@ -51,7 +51,7 @@
     "validate:skills": "npm run compile && node lib/build/validate-skills.js",
     "verify:plugin-payload": "npm run compile && node lib/build/verify-plugin-payload.js",
     "release:local": "node scripts/release-local.mjs",
-    "eval:lint": "vally lint",
+    "eval:lint": "vally lint --eval-spec evals",
     "eval:smoke": "vally eval --suite smoke",
     "eval:full": "vally eval --suite full",
     "eval": "vally eval"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     exclude: ['tests/e2e/**'],
     globalSetup: ['./tests/global-setup.ts'],
+    testTimeout: process.platform === 'win32' ? 30_000 : 5_000,
   },
 });


### PR DESCRIPTION
Updates Vally eval specs to use the current schema and normalized scoring weights. Adds static eval validation to the local check command and Build and Test workflow so invalid specs fail early.

The updated Build and Test pipeline runs:

vally lint --eval-spec evals

This only parses and validates the eval YAML schema. It does not execute stimuli, invoke Copilot or another AI agent, consume LLM tokens, require agent authentication, or deploy Azure resources.

Agent-backed evaluations run through commands such as  `vally eval --suite smoke`  or  `vally eval --suite full`, which this pipeline does not call.