### PR TITLE
fix(create): harden manifest fallback retrieval

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-create/SKILL.md
@@ -150,9 +150,16 @@ Follow this manifest-based fallback algorithm:
 
 ```
 1. FETCH MANIFEST
-   GET https://cdn.functions.azure.com/public/templates-manifest/manifest.json
-   If fetch fails → fall back to:
-     https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Template-Manifest/manifest.json
+    Fetch the raw response with an HTTP client from:
+       https://cdn.functions.azure.com/public/templates-manifest/manifest.json
+    Do not use webpage extraction, summarization, or HTML parsing for this URL. The CDN can
+    return the JSON payload as `application/octet-stream`. Verify a successful HTTP status;
+    if the client exposes a byte buffer, decode it as UTF-8 text; then parse the text as JSON.
+    Before filtering, verify that the parsed object contains a top-level `templates` array.
+    Treat an HTTP error, JSON parse failure, or missing `templates` array as a fetch failure.
+    If the CDN fetch fails → download the raw GitHub file from:
+       https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json
+    Do not use the GitHub `/blob/` page URL because it returns HTML rather than raw JSON.
    If both fail → fall back to known-good Azure-Samples/functions-quickstart-* repos
    If all fail → report error and ask user to retry later
 

--- a/templates/skills/azure-functions-create/SKILL.md
+++ b/templates/skills/azure-functions-create/SKILL.md
@@ -151,9 +151,16 @@ Follow this manifest-based fallback algorithm:
 
 ```
 1. FETCH MANIFEST
-   GET https://cdn.functions.azure.com/public/templates-manifest/manifest.json
-   If fetch fails → fall back to:
-     https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Template-Manifest/manifest.json
+    Fetch the raw response with an HTTP client from:
+       https://cdn.functions.azure.com/public/templates-manifest/manifest.json
+    Do not use webpage extraction, summarization, or HTML parsing for this URL. The CDN can
+    return the JSON payload as `application/octet-stream`. Verify a successful HTTP status;
+    if the client exposes a byte buffer, decode it as UTF-8 text; then parse the text as JSON.
+    Before filtering, verify that the parsed object contains a top-level `templates` array.
+    Treat an HTTP error, JSON parse failure, or missing `templates` array as a fetch failure.
+    If the CDN fetch fails → download the raw GitHub file from:
+       https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json
+    Do not use the GitHub `/blob/` page URL because it returns HTML rather than raw JSON.
    If both fail → fall back to known-good Azure-Samples/functions-quickstart-* repos
    If all fail → report error and ask user to retry later
 


### PR DESCRIPTION
## Summary

- fetch the Azure Functions template manifest as a raw HTTP response instead of using webpage extraction
- handle the CDN's `application/octet-stream` response by decoding byte buffers as UTF-8 before JSON parsing
- validate the minimum manifest shape before filtering templates
- replace the GitHub `/blob/` fallback with the raw content URL

## Motivation

During the `azure-functions-create` fallback workflow, the CDN returned HTTP 200 and a valid 79-template manifest, but webpage extraction reported that it could not extract meaningful content because the JSON was served as `application/octet-stream`. The documented GitHub fallback URL returned an HTML page rather than JSON.

## Validation

- `npm run check`
- 20 test files passed
- 265 tests passed
- generated plugin payload verified as up to date
- direct retrieval verified for both the CDN and `raw.githubusercontent.com` manifest URLs