### PR TITLE
docs: add FRD governance process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,13 +42,19 @@
 
 ## Feature Design and Approval
 
-Use the [FRD process](docs/frds/README.md) for changes that add a public CLI or
-library surface, an authoring format, discovery behavior, or a cross-module feature.
-Typos, bug fixes with a reproduction test, and small internal changes do not need
-a new FRD; explain their scope in the PR.
+Use the [FRD process](docs/frds/README.md) for changes that add or materially
+change a public CLI or library surface, an authoring format, discovery or routing
+behavior, shared infrastructure, or a canonical skill. Typos, documentation-only
+clarifications, bug fixes with a reproduction test, and small internal changes do
+not need a new FRD; explain their scope in the PR.
 
 1. Read the relevant FRD and its status before starting. New FRDs belong in
    `docs/frds/`; preserve the historical documents and numbering in `docs/prd-docs/`.
+   Maintain one lifecycle FRD per canonical skill rather than creating an FRD for
+   each skill enhancement. Generated payload copies and aliases do not get their
+   own FRDs. Give cross-skill mechanisms a separate shared-infrastructure FRD.
+   Add a new skill's FRD before implementation; introduce an FRD for an existing
+   skill when its contract next changes materially.
 2. Complete all eight sections of the [template](docs/frds/_template.md), including
    requirements, non-goals, decisions, tests, and documentation impact.
 3. Obtain a separate architecture review and explicit human sign-off on the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,40 @@
 - `templates/` is the canonical source; generated payloads are derived.
 - Never hand-edit files under `.github/plugins/`, `.plugin/`, or `.claude-plugin/`. Change `templates/`, then regenerate with `npm run build:plugin-payload`.
 
+## Feature Design and Approval
+
+Use the [FRD process](docs/frds/README.md) for changes that add a public CLI or
+library surface, an authoring format, discovery behavior, or a cross-module feature.
+Typos, bug fixes with a reproduction test, and small internal changes do not need
+a new FRD; explain their scope in the PR.
+
+1. Read the relevant FRD and its status before starting. New FRDs belong in
+   `docs/frds/`; preserve the historical documents and numbering in `docs/prd-docs/`.
+2. Complete all eight sections of the [template](docs/frds/_template.md), including
+   requirements, non-goals, decisions, tests, and documentation impact.
+3. Obtain a separate architecture review and explicit human sign-off on the
+   identified revision. **Do not implement a feature before its FRD is
+   `Finalized`.** Approval of a task plan is not approval of an unwritten FRD.
+   Drafting/reviewing FRDs and maintaining this documentation process are allowed
+   before feature approval.
+4. Record non-trivial decisions with alternatives, rationale, decision-maker,
+   and date. If an approved contract or scope changes, update the FRD and obtain
+   approval for the changed portion before implementing it.
+5. Link tasks, PRs, tests, and completion evidence to the FRD's requirement IDs.
+   Report what is complete, what remains, and which decisions changed at each
+   agreed checkpoint.
+6. Default to one primary implementer progressing through understandable slices,
+   not a fleet of concurrent implementation agents. Use a separate review pass
+   at meaningful checkpoints; do not expand scope ahead of human understanding.
+7. Mark an FRD `Implemented` only after its acceptance criteria and evidence are
+   complete. A benchmark or evaluation FRD requires actual approved runs and a
+   report, not just sample code. Missing approval, measurements, or cleanup
+   remain explicit blockers.
+
+FRD approval does not authorize live Azure experiments or bypass the security
+rules below. Confirm the target, budget, repetition count, and owned-resource
+cleanup policy separately before paid experiments.
+
 ## Testing
 
 - **TDD**: Write tests first. Every new function or module must have tests before implementation.

--- a/docs/frds/README.md
+++ b/docs/frds/README.md
@@ -1,0 +1,96 @@
+# Feature Requirement Documents
+
+FRDs make substantial changes understandable and reviewable before implementation.
+This process adapts the [Azure Functions Agents Runtime design workflow](https://github.com/Azure/azure-functions-agents-runtime/blob/1351d6e79905399d9338ee8c1dd0092ed945a8f0/AGENTS.md#L15-L46)
+and [FRD template](https://github.com/Azure/azure-functions-agents-runtime/blob/1351d6e79905399d9338ee8c1dd0092ed945a8f0/docs/frds/_template.md)
+to this TypeScript CLI and skill repository. It does not introduce a new execution
+framework or a requirement to launch multiple agents.
+
+## Index
+
+| ID | Feature | Status | Depends on |
+| --- | --- | --- | --- |
+
+No FRDs have been authored yet. Use `_template.md` to write the first one as
+`0001-kebab-case-title.md`, add a row to the table above, and keep the index and
+the document's status in sync as it moves through the lifecycle below.
+
+[Historical F1-F21 specifications](../prd-docs/README.md) remain in `docs/prd-docs/`.
+Do not move, renumber, or silently reinterpret them. Refer to old features as
+`F21`, for example, and new features as `FRD-0001`; these are separate sequences.
+The current CLI contract is documented in [CLI Reference](../cli-reference.md).
+
+## Choose the development lane
+
+| Scope | Examples | Process |
+| --- | --- | --- |
+| Nit | Typo, formatting, comment correction | Change, appropriate checks, PR |
+| Bug | Incorrect behavior or regression | Reproduction test, fix, checks, PR |
+| Small internal feature | One module, no public contract change | Short design note in PR, tests, implementation, docs |
+| Medium or larger feature | Public CLI/library surface, new authoring format, discovery behavior, cross-module feature | FRD, independent review, human sign-off, implementation, evidence |
+
+Update a related FRD rather than creating one for every module or test case.
+If a bug fix changes an approved public contract, record and review that contract
+change even if the code patch is small. Pure FRD/process documentation can be
+written before feature approval.
+
+## Authoring
+
+Use `_template.md` and the next available `NNNN-kebab-case-title.md` name.
+Check the index for collisions before choosing a number.
+
+Keep all eight sections: summary, motivation, goals/non-goals, proposed design,
+decisions log, test plan, docs impact, and status/sign-off. Use stable requirement
+IDs such as `XX-001`, and link each to acceptance evidence. A test name, fixture,
+or report link is more useful than a statement that something was "verified."
+
+Use English for committed documents. User-facing explanations and temporary
+review summaries may use the user's language.
+
+The decisions log is append-only: retain previous decisions and link a superseding
+decision when a choice changes. Identify whether a choice was made by a human or
+proposed by an agent. Do not present an agent proposal as human approval.
+
+## Lifecycle and gates
+
+| Status | Meaning | Required transition evidence |
+| --- | --- | --- |
+| Draft | Authoring; not permission to implement | All sections written, unresolved questions explicit |
+| In review | Ready for an independent architecture review and human reading | Review findings and resolutions |
+| Finalized | Identified revision explicitly approved by a human | Approver, date, revision, scope, approval reference |
+| Implemented | Approved scope delivered, documented, and evidenced | Accepted tests/results and implementation reference |
+
+Implementation starts only after `Finalized`. A general task-plan approval does
+not finalize a document that the human has not reviewed. The agent may record an
+explicit human approval; it may not approve its own FRD.
+
+Identify the approved revision with a commit SHA or a content hash for an
+uncommitted draft. Update the index and document together when status changes.
+If a contract changes after approval, identify the affected requirements, append
+the decision, and return that scope to review before implementing it.
+
+For multi-stage work, distinguish core implementation from sample development
+and experiments. Split dependent stages into separate FRDs (using `Depends on`)
+so that completing one stage cannot silently close a dependent experiment or
+follow-on stage.
+
+## Delivery discipline
+
+Default to a primary implementer working in understandable slices. At the agreed
+checkpoints, present the requirements completed, remaining work, and changed
+decisions. Use a separate review pass at meaningful boundaries, not a fleet of
+concurrent implementers or an FRD per small task.
+
+PR descriptions should link the relevant FRD and requirement IDs, summarize any
+decision changes, and identify evidence. This is process guidance, not a new
+automated merge gate.
+
+Follow the repository's [development standards](../../AGENTS.md): TypeScript
+strict mode, ESM, TDD for code, existing npm/Vitest checks, and canonical template
+generation. Do not copy Python-specific tooling from the reference project.
+
+For paid or live experiments, design approval and execution authorization are
+different gates. Confirm the approved code revision, target, identity, budget,
+repetition count, and cleanup policy. Existing reviewer-gated evaluation and
+untrusted-code restrictions still apply. An experiment is complete only when its
+required runs, measurements, report, and resource disposition are recorded.

--- a/docs/frds/README.md
+++ b/docs/frds/README.md
@@ -34,6 +34,25 @@ If a bug fix changes an approved public contract, record and review that contrac
 change even if the code patch is small. Pure FRD/process documentation can be
 written before feature approval.
 
+## Choose FRD ownership
+
+| Area | FRD ownership |
+| --- | --- |
+| CLI or library | One FRD per coherent public feature or contract; update it as that feature evolves |
+| Canonical skill | One lifecycle FRD per skill; update the same document for substantive behavior changes |
+| Shared skill infrastructure | A separate FRD for cross-skill routing, metadata, generation, evaluation, or other shared contracts |
+
+A canonical skill is the authored source skill, not each generated payload copy,
+target-specific rendering, or alias. Those derived forms are covered by the
+canonical skill's FRD and the relevant shared-infrastructure FRD.
+
+New canonical skills require an FRD before implementation. Existing skills do
+not need placeholder FRDs created in bulk; add one when the skill next receives a
+substantive contract change. Update the skill's FRD when its purpose, triggering,
+inputs or outputs, tool chain, transitions, safety boundary, or acceptance criteria
+change. Typos, reference refreshes, and editorial clarifications do not require an
+FRD revision unless they alter the skill's behavior or contract.
+
 ## Authoring
 
 Use `_template.md` and the next available `NNNN-kebab-case-title.md` name.
@@ -43,6 +62,11 @@ Keep all eight sections: summary, motivation, goals/non-goals, proposed design,
 decisions log, test plan, docs impact, and status/sign-off. Use stable requirement
 IDs such as `XX-001`, and link each to acceptance evidence. A test name, fixture,
 or report link is more useful than a statement that something was "verified."
+
+For a skill FRD, identify the canonical skill path and cover its purpose, trigger
+contract, inputs and outputs, tool dependencies, recommended transitions, safety
+constraints, and evaluation criteria. Extend this document as the skill evolves
+instead of creating a new FRD for each enhancement.
 
 Use English for committed documents. User-facing explanations and temporary
 review summaries may use the user's language.

--- a/docs/frds/_template.md
+++ b/docs/frds/_template.md
@@ -8,6 +8,7 @@
 | Updated | YYYY-MM-DD |
 | Author | Human or agent identity |
 | Depends on | FRD links or None |
+| Component | CLI, Library, Shared infrastructure, or Skill: canonical-skill-name |
 
 ## 1. Summary
 
@@ -36,6 +37,11 @@ State what will not be built or changed.
 Describe public commands/formats, examples, module ownership, data flow,
 compatibility, failure behavior, and trust boundaries. Explain the smallest
 solution and why existing helpers cannot meet any new requirement.
+
+For a skill FRD, identify the canonical source path and describe the purpose,
+trigger contract, inputs and outputs, tool dependencies, recommended transitions,
+safety constraints, and evaluation criteria. Keep one lifecycle FRD for the skill;
+update it for substantive behavior changes instead of creating one per enhancement.
 
 For experiments, define controls, inputs, measurement semantics, success
 criteria, resource ownership, and separate execution authorization.

--- a/docs/frds/_template.md
+++ b/docs/frds/_template.md
@@ -1,0 +1,92 @@
+# FRD-NNNN: Feature title
+
+| Metadata | Value |
+| --- | --- |
+| Status | Draft |
+| Revision | 1 |
+| Created | YYYY-MM-DD |
+| Updated | YYYY-MM-DD |
+| Author | Human or agent identity |
+| Depends on | FRD links or None |
+
+## 1. Summary
+
+Describe the user-visible outcome in one paragraph. State whether this is a
+proposal or an implemented capability.
+
+## 2. Motivation / problem
+
+Describe the concrete problem, an example user workflow, the current behavior,
+and alternatives already available in this repository. Link relevant evidence.
+
+## 3. Goals / non-goals
+
+### Requirements and acceptance criteria
+
+| ID | Requirement | Observable acceptance criterion |
+| --- | --- | --- |
+| XX-001 | Required behavior | Evidence that distinguishes success from a plausible approximation |
+
+### Non-goals
+
+State what will not be built or changed.
+
+## 4. Proposed design
+
+Describe public commands/formats, examples, module ownership, data flow,
+compatibility, failure behavior, and trust boundaries. Explain the smallest
+solution and why existing helpers cannot meet any new requirement.
+
+For experiments, define controls, inputs, measurement semantics, success
+criteria, resource ownership, and separate execution authorization.
+
+### Delivery checkpoints
+
+Describe the understandable implementation slices and where human review is
+required. Do not give estimates or create an agent fleet by default.
+
+### Open questions
+
+List unresolved choices and their owners, or explicitly state None. Questions
+that affect an implementation contract must be resolved before finalizing it.
+Run-specific execution details may remain pending when they are an explicit
+later gate rather than an implementation assumption.
+
+## 5. Decisions log
+
+Append decisions; preserve superseded entries and link their replacements.
+
+| ID | Decision / options | Choice and rationale | Decided by | Date |
+| --- | --- | --- | --- | --- |
+| D-001 | Alternatives considered | Proposed choice; not approval | Human name or Agent name (proposal) | YYYY-MM-DD |
+
+## 6. Test plan
+
+| Requirement | Test / fixture / experiment | Expected evidence |
+| --- | --- | --- |
+| XX-001 | Planned test, fixture, or experiment | Observable result |
+
+Cover failures, compatibility, and security boundaries as well as the happy path.
+Use existing test infrastructure. LLM/live evaluations require reviewed code and
+the existing reviewer gate; sample creation alone is not experimental evidence.
+
+## 7. Docs impact
+
+List the exact documents, CLI help, and canonical skill templates that change.
+Identify generated outputs, compatibility notes, and user guidance. Do not modify
+generated plugin payloads by hand or the user-facing `templates/agents/AGENTS.md`.
+
+## 8. Status & sign-off
+
+| Item | Evidence |
+| --- | --- |
+| Independent architecture review | Pending |
+| Human approval | Pending |
+| Approved revision and scope | Pending; record commit SHA or content hash |
+| Approval reference and date | Pending |
+| Implementation reference | Not started |
+| Acceptance evidence | Not collected |
+
+Status remains Draft until ready for review. No feature implementation before
+explicit human sign-off and Finalized status. A task-plan approval is not a
+substitute. Update this section and the FRD index together.

--- a/docs/prd-docs/README.md
+++ b/docs/prd-docs/README.md
@@ -2,6 +2,11 @@
 
 Individual feature specs broken out from the Draft Spec. Each FRD is self-contained and can be implemented independently.
 
+> **Historical specifications:** New FRDs use the [FRD process and index](../frds/README.md)
+> in `docs/frds/`. These F1-F21 documents retain their existing paths and numbering;
+> their descriptions and statuses are not a substitute for the current CLI
+> reference or approval of a new feature.
+
 ## Vision
 
 `azure-functions-skills` is the **canonical repository** for Azure Functions skills, agents, hooks, MCP integrations, and references. It generates plugin artifacts and repo templates targeting GHCP, Claude Code, and Codex from a single knowledge base.


### PR DESCRIPTION
## Summary

- Add a repository-level FRD process for substantial public or cross-module changes.
- Add an eight-section FRD template with requirements, decisions, test evidence, documentation impact, lifecycle, and explicit human sign-off.
- Define FRD ownership for the repository's main surfaces:
  - CLI and library contracts use one FRD per coherent public feature.
  - Each canonical skill has one lifecycle FRD that is updated for substantive behavior changes.
  - Generated payload copies and aliases do not receive separate FRDs.
  - Cross-skill routing, metadata, generation, and evaluation use shared-infrastructure FRDs.
- Introduce FRDs for new skills before implementation and for existing skills at their next substantive contract change, without bulk placeholder documents.
- Preserve the existing F1-F21 documents as historical specifications while giving new FRDs a separate index and numbering sequence.
- Adapt and attribute the Azure Functions Agents Runtime design process for this TypeScript CLI and skills repository.

## Scope

This PR contains governance documentation only. It does not include the workflow runner, workflow-specific FRDs, CLI/runtime changes, CI changes, tests, or generated plugin payloads. The new FRD index is intentionally empty. Typos, reference refreshes, and editorial clarification do not require an FRD revision unless they change behavior or contract.

## Validation

- Confirmed the four-file documentation-only branch diff with `git diff --check`.
- Verified all newly introduced relative Markdown links resolve in the repository.
- Scanned the changed files for credential and private-key patterns; none were found.

## Source

The process documentation links to the pinned Azure Functions Agents Runtime `AGENTS.md` workflow and FRD template that it adapts.