### PR TITLE
docs: propose local skill evaluation framework

### DIFF
--- a/docs/frds/0001-local-skill-evaluation.md
+++ b/docs/frds/0001-local-skill-evaluation.md
@@ -3,7 +3,7 @@
 | Metadata | Value |
 | --- | --- |
 | Status | Draft |
-| Revision | 3 |
+| Revision | 4 |
 | Created | 2026-09-08 |
 | Updated | 2026-09-08 |
 | Author | GitHub Copilot, agent proposal based on maintainer discussion |
@@ -48,7 +48,7 @@ measured agent.
 | SE-002 | Preserve versioned local results independently of reporting and Azure | Each planned trial has a terminal or interrupted record; reports and upload can run from saved results without another model call; interrupted batches are visibly incomplete |
 | SE-003 | Measure consumption, latency, and agent activity with explicit semantics | Record input/output tokens, model calls, tool calls, agent duration, and available cache, skill-activation, and subagent measurements; missing/partial values are not zero or complete totals |
 | SE-004 | Separate correctness from skill invocation and measurement coverage | Mandatory deterministic checks determine task success; invocation is a separate metric; failures, skips, timeouts, and coverage denominators are visible |
-| SE-005 | Support fair baseline and historical comparisons | Compare matched controls; show sample count, success count, median and range; incompatible histories and zero-denominator percentage deltas are labeled rather than silently compared |
+| SE-005 | Support fair without-skill baseline and historical comparisons | For the without-skill variant, keep the user task instruction, runtime/system instructions, fixtures, tools, limits, and graders identical while removing only the declared skill bundle; show sample count, success count, median and range; incompatible histories and zero-denominator percentage deltas are labeled rather than silently compared |
 | SE-006 | Generate a safe public static HTML summary | Local file and Pages-hosted views work without an API/backend; filter by skill/scenario/model/variant; show versions, dates, limitations, activity and quality metrics; export only an allowlisted public schema |
 | SE-007 | Generate a separate evidence-based improvement report | Markdown findings identify trial/event evidence, observed behavior, hypothesis, suggested skill change, and a re-evaluation check; no finding asserts causality or guaranteed savings |
 | SE-008 | Detect a small set of inefficiency candidates deterministically | Versioned repeated-read, repeated-failure, search-without-progress, input-growth, and matched-regression rules have positive, negative, and insufficient-evidence fixtures |
@@ -85,10 +85,14 @@ private Markdown/JSON findings. A separate uploader exports numeric measurements
 controlled identifiers, and finding counts to Application Insights. Use the same
 trial IDs for retries and deduplicate in Workbook queries.
 
-The adapter must prove compatibility with the repository-pinned Vally/SDK versions.
+The adapter must start from the repository-pinned Vally/SDK versions and prove
+compatibility with the selected versions. A Vally upgrade is allowed when source
+and changelog review finds no material breaking change for existing suites and
+targeted regression tests pass; pin the approved version and record the decision.
 Do not assume upstream main's optional usage or billing fields exist in `0.7.0`.
-A capability gap must result in an explicit unsupported/partial measurement or a
-reviewed adapter/version decision, not invented numbers or a replacement engine.
+A remaining capability gap must result in an explicit unsupported/partial
+measurement or a reviewed adapter/version decision, not invented numbers or a
+replacement engine.
 Use supported Azure Monitor instrumentation for new evaluation telemetry rather
 than expanding the existing legacy invocation sender's contract.
 
@@ -156,6 +160,7 @@ later skill rollout order.
 | D-007 | Two representative models vs capability-tier catalog | Replace the two-model proposal with lightweight, versatile, and powerful configurations, including separate Astra effort levels, so users can identify the least expensive observed-fit option per scenario | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
 | D-008 | Temporarily remove user plugins vs isolate evaluation state | Use an evaluation-owned home/profile, an external trial root, explicit user/project discovery roots, inventory/hash checks, and a disposable-profile fallback; never mutate user-level installations | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
 | D-009 | One broad run vs staged skill milestones | Run `azure-functions-create` first, then hosted agents under separate execution approvals; add doctor, diagnostics, setup, and help later through plan revisions based on evidence and usage priority | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
+| D-010 | Keep Vally `0.7.0` fixed vs permit an upgrade | Permit a reviewed upgrade when it introduces no material breaking change for existing suites and targeted regressions pass; the lockfile remains the reproducible source of the selected version | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
 
 ## 6. Test plan
 
@@ -167,7 +172,7 @@ and repository validation commands. No new test framework.
 | SE-001, SE-011 | `benchmark-runner.test.ts`: fake executor and isolation configuration | Exact matrix, independent session/workspace per trial, no personal tools, explicit model failure instead of fallback |
 | SE-002 | `benchmark-storage.test.ts`: termination, duplicate IDs, truncated line, unsupported schema | Durable partial results; explicit recovery/error; no silent loss or overwritten trials |
 | SE-003 | `benchmark-normalize.test.ts`: real-schema sanitized fixtures, nested usage, absent fields | No double-counting, correct units and timing boundaries, missing/partial coverage surfaced |
-| SE-004, SE-005 | `benchmark-aggregate.test.ts`: mixed status, mandatory failures, incompatible controls | Correct denominators and medians, no false skill uplift or invented percentages |
+| SE-004, SE-005 | `benchmark-aggregate.test.ts`: mixed status, mandatory failures, incompatible controls, and matched with-skill/without-skill instruction hashes | Correct denominators and medians; only the declared skill bundle differs; no false skill uplift or invented percentages |
 | SE-006, SE-010 | `benchmark-report.test.ts`: hostile labels, paths, transcript fields | Standalone escaped HTML, exact public allowlist, no private content; browser walkthrough recorded |
 | SE-007, SE-008 | `benchmark-analyze.test.ts`: each detector and benign lookalikes | Stable evidence IDs and suggestions; rereads after writes and unknown progress do not become proven waste |
 | SE-009, SE-010 | `benchmark-upload.test.ts`: fake transport, flush timeout, ambiguous delivery, dedup fixture | Explicit opt-in, no credentials in artifacts, retry-safe IDs, truthful failure, correct unique-trial query results |

--- a/docs/frds/0001-local-skill-evaluation.md
+++ b/docs/frds/0001-local-skill-evaluation.md
@@ -1,0 +1,207 @@
+# FRD-0001: Local skill evaluation, model suitability, and improvement reporting
+
+| Metadata | Value |
+| --- | --- |
+| Status | Draft |
+| Revision | 3 |
+| Created | 2026-09-08 |
+| Updated | 2026-09-08 |
+| Author | GitHub Copilot, agent proposal based on maintainer discussion |
+| Depends on | [FRD governance PR #244](https://github.com/Azure/azure-functions-skills/pull/244), revision `aff24690ae7dae787ad521b4bce718121647ffa7` |
+| Component | Skill evaluation capability |
+
+## 1. Summary
+
+Propose a small, local-first evaluation workflow using the existing Vally and
+GitHub Copilot SDK integration. Persist reproducible trial results, determine the
+least capable model tier that demonstrates correct behavior for each scenario,
+produce a public static HTML performance summary and a separate private Markdown
+improvement report, and optionally send allowlisted measurements to a designated
+Application Insights resource for historical analysis. This one FRD owns the
+capability and its acceptance criteria. Infrastructure delivery, the
+`azure-functions-create` pilot, and the hosted-agents pilot are sequential
+milestones in the implementation plan, not separate features or FRDs.
+
+## 2. Motivation / problem
+
+Users need evidence of skill quality, latency, and consumption under representative
+models and scenarios. Maintainers also need to explain regressions: extra model
+calls, repeated reads, repeated failures, and excessive context accumulation.
+A single success score or aggregate token count cannot identify these behaviors.
+
+The repository already has [Vally configuration](../../.vally.yaml),
+[skill eval specifications](../../evals/README.md), and
+[invocation telemetry](../../src/telemetry/sender.ts). Reuse the evaluation engine,
+not a new scheduler or agent framework. Existing invocation telemetry has a
+different purpose and does not establish benchmark quality or cost.
+GitHub Copilot App can initiate the local workflow, but its interactive session
+history is not the measurement source. Reports identify Copilot CLI/SDK as the
+measured agent.
+
+## 3. Goals / non-goals
+
+### Requirements and acceptance criteria
+
+| ID | Requirement | Observable acceptance criterion |
+| --- | --- | --- |
+| SE-001 | Run a declared skill/scenario/model/variant/repetition matrix through Vally, locally | A plan enumerates every trial before execution; an isolated test executor demonstrates fresh workspaces, fresh sessions, explicit models, bounded execution, and no inherited unrelated skills/MCP servers |
+| SE-002 | Preserve versioned local results independently of reporting and Azure | Each planned trial has a terminal or interrupted record; reports and upload can run from saved results without another model call; interrupted batches are visibly incomplete |
+| SE-003 | Measure consumption, latency, and agent activity with explicit semantics | Record input/output tokens, model calls, tool calls, agent duration, and available cache, skill-activation, and subagent measurements; missing/partial values are not zero or complete totals |
+| SE-004 | Separate correctness from skill invocation and measurement coverage | Mandatory deterministic checks determine task success; invocation is a separate metric; failures, skips, timeouts, and coverage denominators are visible |
+| SE-005 | Support fair baseline and historical comparisons | Compare matched controls; show sample count, success count, median and range; incompatible histories and zero-denominator percentage deltas are labeled rather than silently compared |
+| SE-006 | Generate a safe public static HTML summary | Local file and Pages-hosted views work without an API/backend; filter by skill/scenario/model/variant; show versions, dates, limitations, activity and quality metrics; export only an allowlisted public schema |
+| SE-007 | Generate a separate evidence-based improvement report | Markdown findings identify trial/event evidence, observed behavior, hypothesis, suggested skill change, and a re-evaluation check; no finding asserts causality or guaranteed savings |
+| SE-008 | Detect a small set of inefficiency candidates deterministically | Versioned repeated-read, repeated-failure, search-without-progress, input-growth, and matched-regression rules have positive, negative, and insufficient-evidence fixtures |
+| SE-009 | Send optional evaluation telemetry and support a history Workbook | An explicit upload reads saved results, validates destination/configuration, sends one event per trial, flushes, reports failures, and supports retry; a Workbook deduplicates trial events and separates missing data |
+| SE-010 | Keep private execution evidence out of public and telemetry outputs | Content capture is opt-in; default evidence contains no raw prompts, code, arguments, outputs, absolute paths, or credentials; adversarial fixtures prove public/telemetry allowlisting and HTML escaping |
+| SE-011 | Preserve existing behavior and leave a small extension boundary | Existing eval commands, specs, hooks, package exports, and normal invocation telemetry retain their contracts; common results identify the executor but do not require a second executor implementation |
+| SE-012 | Produce a reproducible maintainer handoff | Documentation defines commands, schema, setup, authorization, failure recovery, publication, and tests; a fixture-only end-to-end flow demonstrates all artifacts without LLM/Azure access |
+| SE-013 | Show which model capability/cost level is sufficient for each skill scenario | The manifest supports named capability tiers and reasoning settings; reports show scenario complexity, per-configuration quality/cost, and the lowest-cost observed-fit configuration only when one Copilot billing unit is available across all compared configurations |
+| SE-014 | Isolate evaluation from user- and project-level skills, plugins, instructions, and memory | Trial workspaces live outside the source repository, use an evaluation-owned home/profile and explicit discovery roots; preflight/result evidence prove the target hash/bundle and reject conflicting user/project Azure Functions Skills installations without modifying user files |
+
+### Non-goals
+
+No new evaluation CI, scheduling service, database server, frontend framework,
+OTel collector service, automatic skill rewriting, default LLM judge/analyzer,
+or per-skill feature documents for ordinary scenario additions. No Codex/Claude
+Code executor in v1. No App-session scraping,
+claim of identical App/CLI behavior, per-file attribution of all token costs,
+or vendor API-price multiplication presented as a Copilot invoice.
+No live Azure deployment scenarios, infrastructure provisioning, automatic upload,
+automatic Pages publishing, or real measurements in this documentation change.
+
+## 4. Proposed design
+
+The [technical design](../internal/skill-evaluation-design.md) defines the proposed
+contracts. Add a development-only `benchmark` entry point around Vally:
+`plan`, `run`, `report`, `analyze`, and `upload`. These commands are proposed,
+not currently available, and do not extend the published setup/chat CLI.
+Use Vally specs for prompts, environments, and graders; use a small matrix
+manifest for selection, versions, variants, and repetitions.
+
+Data flows from isolated trials to versioned JSONL and optional private evidence.
+Deterministic aggregation feeds standalone public HTML; rule-based analysis feeds
+private Markdown/JSON findings. A separate uploader exports numeric measurements,
+controlled identifiers, and finding counts to Application Insights. Use the same
+trial IDs for retries and deduplicate in Workbook queries.
+
+The adapter must prove compatibility with the repository-pinned Vally/SDK versions.
+Do not assume upstream main's optional usage or billing fields exist in `0.7.0`.
+A capability gap must result in an explicit unsupported/partial measurement or a
+reviewed adapter/version decision, not invented numbers or a replacement engine.
+Use supported Azure Monitor instrumentation for new evaluation telemetry rather
+than expanding the existing legacy invocation sender's contract.
+
+Trust boundaries include reviewed skill code, allowed tools, disposable execution
+workspaces, private local evidence, explicit telemetry export, and explicit public
+publication. A worktree alone is not a security sandbox. Existing restrictions on
+unreviewed PR evaluation remain in force. The runner must not infer permission
+from design approval.
+
+Model comparison is a first-class use case, not just a provenance field. Define a
+reviewed catalog of lightweight, versatile, and powerful configurations. A
+configuration includes the exact model ID and reasoning effort, because changing
+effort changes quality, latency, and consumption. Evaluate scenarios labeled by
+reviewed complexity and report whether each configuration demonstrated all
+mandatory behavior. Resolve availability and current cost metadata at planning time; never substitute
+a model silently. A cross-provider "lowest-cost" result requires the same
+Copilot-account billing unit and semantics for every compared configuration.
+Otherwise show the lowest observed-fit capability tier and within-provider/native
+costs, with cross-provider cost marked not comparable.
+
+Use an evaluation-owned `COPILOT_HOME` or an equivalently proven isolated runtime
+profile. Place each trial workspace outside the repository/source checkout so
+parent-walk discovery cannot load project instructions or generated plugins.
+Populate only the reviewed skills/plugins/configuration required by the plan and
+verify user- and project-level discovery roots, effective inventory, and target
+content hash before execution. Do not temporarily delete, rename, or edit a
+maintainer's user-level plugin.
+If the pinned runtime cannot isolate every discovery source, use a disposable OS
+profile/container or block the run until an approved isolation mechanism exists.
+
+### Delivery checkpoints
+
+One primary implementer delivers three independently gated milestones:
+
+1. evaluation infrastructure and fixture-only validation;
+2. the `azure-functions-create` pilot and reviewed public/history outputs;
+3. the hosted-agents pilot after incorporating lessons from the create pilot.
+
+Each milestone may be implemented and reviewed without authorizing the next one.
+Obtain independent review at contract and output-boundary checkpoints. Follow the
+[implementation plan](../internal/skill-evaluation-implementation-plan.md), which
+owns scenario catalogs, trial counts, budgets, run-specific authorization, and
+later skill rollout order.
+
+### Open questions
+
+| Question | Owner / gate |
+| --- | --- |
+| Does the pinned Vally/SDK expose reliable per-call usage, end-of-agent timing, tool status, and isolation controls? | Implementer performs source/type inspection before finalizing adapter contracts; choose a compatible adapter or reviewed upgrade and append the decision |
+| How does a locally initiated paid run satisfy the existing reviewer-gated evaluation policy? | Repository maintainer must resolve before Finalized status; this FRD does not create a local bypass |
+| Which supported Azure Monitor SDK/exporter and authentication mode will the uploader use? | Implementer proposes the smallest supported Node-compatible option after source/docs inspection; architecture reviewer and human approve before Finalized |
+| Which exact model IDs are available for each approved capability-tier label, and what billing metadata is exposed? | Pilot owner resolves the catalog through the approved account at planning time; missing candidates remain visibly not evaluated |
+| Which budget, destination, retention, and Pages target apply to each run? | Evaluation owner; resolve in the milestone execution record, not implementation defaults |
+
+## 5. Decisions log
+
+| ID | Decision / options | Choice and rationale | Decided by | Date |
+| --- | --- | --- | --- | --- |
+| D-001 | Reuse Vally vs write a runner/agent engine from scratch | Propose a thin Vally adapter; existing specs and graders already express the core evaluation | GitHub Copilot (agent proposal) | 2026-09-08 |
+| D-002 | Cloud-first vs local result authority | Propose JSONL as the local source of truth; reporting/retry must not consume more model calls | GitHub Copilot (agent proposal) | 2026-09-08 |
+| D-003 | One report vs separate audiences | Propose public HTML and private improvement Markdown; disclosure needs and purposes differ | GitHub Copilot (agent proposal, reflecting maintainer preference) | 2026-09-08 |
+| D-004 | Always-on LLM analysis vs deterministic rules | Propose five bounded rule types with evidence and cautious suggestions; defer optional LLM analysis | GitHub Copilot (agent proposal) | 2026-09-08 |
+| D-005 | Reuse normal invocation events vs separate evaluation schema | Propose separate evaluation events and explicit destination; preserve current hook behavior | GitHub Copilot (agent proposal) | 2026-09-08 |
+| D-006 | Separate pilot FRDs vs one feature FRD with staged execution | Keep requirements in this FRD and place skill-specific scenarios, budgets, and execution gates in the implementation plan; adding a scenario does not create a new feature | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
+| D-007 | Two representative models vs capability-tier catalog | Replace the two-model proposal with lightweight, versatile, and powerful configurations, including separate Astra effort levels, so users can identify the least expensive observed-fit option per scenario | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
+| D-008 | Temporarily remove user plugins vs isolate evaluation state | Use an evaluation-owned home/profile, an external trial root, explicit user/project discovery roots, inventory/hash checks, and a disposable-profile fallback; never mutate user-level installations | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
+| D-009 | One broad run vs staged skill milestones | Run `azure-functions-create` first, then hosted agents under separate execution approvals; add doctor, diagnostics, setup, and help later through plan revisions based on evidence and usage priority | GitHub Copilot (agent proposal, reflecting maintainer feedback) | 2026-09-08 |
+
+## 6. Test plan
+
+Test names below are planned, not existing evidence. Use Vitest, strict TypeScript,
+and repository validation commands. No new test framework.
+
+| Requirement | Test / fixture / experiment | Expected evidence |
+| --- | --- | --- |
+| SE-001, SE-011 | `benchmark-runner.test.ts`: fake executor and isolation configuration | Exact matrix, independent session/workspace per trial, no personal tools, explicit model failure instead of fallback |
+| SE-002 | `benchmark-storage.test.ts`: termination, duplicate IDs, truncated line, unsupported schema | Durable partial results; explicit recovery/error; no silent loss or overwritten trials |
+| SE-003 | `benchmark-normalize.test.ts`: real-schema sanitized fixtures, nested usage, absent fields | No double-counting, correct units and timing boundaries, missing/partial coverage surfaced |
+| SE-004, SE-005 | `benchmark-aggregate.test.ts`: mixed status, mandatory failures, incompatible controls | Correct denominators and medians, no false skill uplift or invented percentages |
+| SE-006, SE-010 | `benchmark-report.test.ts`: hostile labels, paths, transcript fields | Standalone escaped HTML, exact public allowlist, no private content; browser walkthrough recorded |
+| SE-007, SE-008 | `benchmark-analyze.test.ts`: each detector and benign lookalikes | Stable evidence IDs and suggestions; rereads after writes and unknown progress do not become proven waste |
+| SE-009, SE-010 | `benchmark-upload.test.ts`: fake transport, flush timeout, ambiguous delivery, dedup fixture | Explicit opt-in, no credentials in artifacts, retry-safe IDs, truthful failure, correct unique-trial query results |
+| SE-011, SE-012 | `benchmark-cli.test.ts`: fixture-only subprocess flow and existing regression tests | Saved fixture to both reports and mocked telemetry; existing commands unchanged |
+| SE-013 | `benchmark-model-catalog.test.ts`: tier, effort, unavailable model, cost coverage and fit-label fixtures | Exact configuration identity; no fallback; lowest-cost observed-fit output only when quality and cost coverage permit it |
+| SE-014 | `benchmark-isolation.test.ts`: worktree plus external trial root, conflicting user/project/evaluation installs, duplicate names, personal/project instructions and target hash mismatch | Only approved roots load; conflicting user and checkout copies cannot affect output; mismatch fails before paid execution; user files remain byte-for-byte unchanged |
+
+Actual LLM runs and Azure ingestion/Workbook observations belong to the staged
+execution milestones in the implementation plan. Fixtures do not establish those
+results.
+
+## 7. Docs impact
+
+Create/update `docs/internal/skill-evaluation-design.md`,
+`docs/internal/skill-evaluation-implementation-plan.md`, this FRD, its index, and
+`evals/README.md`. Implementation adds `evals/benchmark/README.md` for runnable
+instructions and `docs/internal/skill-evaluation-workbook.json` for the Workbook.
+Document proposed npm commands in `docs/development.md` when implemented.
+No canonical skill behavior changes, generated plugin edits, or changes to
+`templates/agents/AGENTS.md` are required. Public reports are generated artifacts,
+reviewed for disclosure before publication, not automatically committed raw logs.
+
+## 8. Status & sign-off
+
+| Item | Evidence |
+| --- | --- |
+| Independent architecture review | Underlying revision 2 content reviewed on 2026-09-08 by Claude Opus 4.8 with no blockers; revision 3 consolidates the reviewed pilot content into this FRD and the implementation plan |
+| Human approval | Pending |
+| Approved revision and scope | Pending; record commit SHA or content hash |
+| Approval reference and date | Pending |
+| Implementation reference | Not started |
+| Acceptance evidence | Not collected; test plan is prospective |
+
+Status remains Draft. General agreement in the originating discussion is not
+approval of this identified FRD revision. No feature implementation before
+Finalized; no paid runs, telemetry delivery, or publication without a separate
+milestone execution authorization.

--- a/docs/frds/README.md
+++ b/docs/frds/README.md
@@ -10,10 +10,7 @@ framework or a requirement to launch multiple agents.
 
 | ID | Feature | Status | Depends on |
 | --- | --- | --- | --- |
-
-No FRDs have been authored yet. Use `_template.md` to write the first one as
-`0001-kebab-case-title.md`, add a row to the table above, and keep the index and
-the document's status in sync as it moves through the lifecycle below.
+| [FRD-0001](0001-local-skill-evaluation.md) | Local skill evaluation, model suitability, and improvement reporting | Draft | None |
 
 [Historical F1-F21 specifications](../prd-docs/README.md) remain in `docs/prd-docs/`.
 Do not move, renumber, or silently reinterpret them. Refer to old features as
@@ -94,9 +91,10 @@ If a contract changes after approval, identify the affected requirements, append
 the decision, and return that scope to review before implementing it.
 
 For multi-stage work, distinguish core implementation from sample development
-and experiments. Split dependent stages into separate FRDs (using `Depends on`)
-so that completing one stage cannot silently close a dependent experiment or
-follow-on stage.
+and experiments. Split stages into separate FRDs (using `Depends on`) when they
+have distinct user-facing contracts or independent acceptance criteria. Keep
+ordinary scenarios and rollout milestones in the owning FRD's implementation
+plan so that completing one milestone cannot silently close a follow-on stage.
 
 ## Delivery discipline
 
@@ -118,3 +116,11 @@ different gates. Confirm the approved code revision, target, identity, budget,
 repetition count, and cleanup policy. Existing reviewer-gated evaluation and
 untrusted-code restrictions still apply. An experiment is complete only when its
 required runs, measurements, report, and resource disposition are recorded.
+
+## Evaluation handoff
+
+Read FRD-0001, the [technical design](../internal/skill-evaluation-design.md), and the
+[implementation plan](../internal/skill-evaluation-implementation-plan.md), in
+that order. The FRD owns feature requirements and acceptance criteria. The design
+defines technical contracts, while the plan owns staged implementation and the
+`azure-functions-create` and hosted-agents evaluation scenarios.

--- a/docs/internal/skill-evaluation-design.md
+++ b/docs/internal/skill-evaluation-design.md
@@ -1,6 +1,6 @@
 # Local skill evaluation: technical design
 
-Status: proposed, revision 3, 2026-09-08. Requirements:
+Status: proposed, revision 4, 2026-09-08. Requirements:
 [FRD-0001](../frds/0001-local-skill-evaluation.md). Staged implementation and
 skill-specific evaluation scenarios are defined in the implementation plan.
 This document and all commands/types below describe future contracts, not existing
@@ -9,10 +9,13 @@ functionality. FRDs take precedence; incompatible changes require renewed review
 ## 1. Baseline and architecture
 
 Repository baseline: `4bfa24af92ee735dcd5fed377f27ee73ba9fa69b`.
-`package-lock.json` pins Vally CLI/core `0.7.0` and Copilot SDK `1.0.5`.
+`package-lock.json` currently pins Vally CLI/core `0.7.0` and Copilot SDK `1.0.5`.
 `evals/README.md` describes Node 22+ for Vally, existing specs and JSONL results.
-Recheck engine constraints of the locked tools before choosing a supported LTS;
-do not raise the published CLI's runtime minimum solely for development tooling.
+Treat these as the reproducible inspection baseline, not a requirement to retain
+Vally `0.7.0`. A Vally upgrade is acceptable after reviewing its changelog/source
+for material breaking changes and running targeted existing-suite regressions.
+Pin the approved version. Recheck engine constraints before choosing a supported
+LTS; do not raise the published CLI's runtime minimum solely for development tooling.
 
 ```text
 Matrix + existing Vally specs + reviewed fixture revisions
@@ -71,7 +74,8 @@ The manifest has a schema version, benchmark ID, stable skill ID, canonical/disp
 names and aliases, scenario complexity, capability-tier catalog, explicit
 executor/model IDs and reasoning settings, spec/stimulus references, fixture and
 skill-bundle revisions, variants, repetition count, deterministic order,
-concurrency (1 in v1), tool/MCP allowlist, timeout and limits. It references Vally
+instruction-set hashes, concurrency (1 in v1), tool/MCP allowlist, timeout and
+limits. It references Vally
 prompts/graders instead of creating a competing prompt DSL. Unknown selectors,
 automatic model aliases, unsupported effort, duplicate trials and unsupported
 executors fail preflight.
@@ -272,12 +276,16 @@ common unit exists, show lowest adequate tier and within-provider/native costs,
 mark cross-provider cost not comparable, and do not infer it from tier labels or
 external API token pricing.
 
-Match A/B on all controls except the declared skill bundle. Match historical
-comparisons on the same controls while allowing the explicitly compared skill
-revision to differ. Record changed controls (including tool/model/grader updates)
-and suppress direct regression claims when incompatible. Alternate A/B execution
-order to reduce warming/order bias. A zero baseline supports an absolute delta
-but not a percentage. Report association, not causal proof.
+Match A/B on all controls except the declared skill bundle. In particular, reuse
+the exact user task instruction and runtime/system instruction set, fixtures,
+tools/MCP endpoints, model/effort, limits, environment profile, and graders. Record
+their hashes in both variants; the without-skill variant removes only the declared
+bundle and must not rediscover it. Match historical comparisons on the same
+controls while allowing the explicitly compared skill revision to differ. Record
+changed controls (including instruction/tool/model/grader updates) and suppress
+direct regression claims when incompatible. Alternate A/B execution order to
+reduce warming/order bias. A zero baseline supports an absolute delta but not a
+percentage. Report association, not causal proof.
 
 ## 6. Improvement analysis
 
@@ -376,7 +384,10 @@ paid capability probe. Inspect how Vally isolates homes/skills, chooses models,
 allows tools and captures transcripts; enumerate every user/project/plugin/skill/
 instruction/memory discovery source and prove the isolated-home design. Default
 content policy must hold even for temporary files. Unsupported required
-capabilities block the plan or require a reviewed version/adapter decision.
+capabilities block the plan or require a reviewed version/adapter decision. A
+Vally upgrade may be that decision when existing suite configuration, grader
+behavior, result schemas, and CLI contracts have no material unmitigated breaking
+change and targeted regression tests pass.
 
 Current upstream references are discovery aids, not proof of locked-version support:
 

--- a/docs/internal/skill-evaluation-design.md
+++ b/docs/internal/skill-evaluation-design.md
@@ -1,0 +1,421 @@
+# Local skill evaluation: technical design
+
+Status: proposed, revision 3, 2026-09-08. Requirements:
+[FRD-0001](../frds/0001-local-skill-evaluation.md). Staged implementation and
+skill-specific evaluation scenarios are defined in the implementation plan.
+This document and all commands/types below describe future contracts, not existing
+functionality. FRDs take precedence; incompatible changes require renewed review.
+
+## 1. Baseline and architecture
+
+Repository baseline: `4bfa24af92ee735dcd5fed377f27ee73ba9fa69b`.
+`package-lock.json` pins Vally CLI/core `0.7.0` and Copilot SDK `1.0.5`.
+`evals/README.md` describes Node 22+ for Vally, existing specs and JSONL results.
+Recheck engine constraints of the locked tools before choosing a supported LTS;
+do not raise the published CLI's runtime minimum solely for development tooling.
+
+```text
+Matrix + existing Vally specs + reviewed fixture revisions
+  -> dry plan and authorization checks
+  -> Vally adapter -> isolated Copilot CLI/SDK trials
+  -> local normalized trials.jsonl + metadata events + optional private content
+       -> aggregate -> public-summary.json -> standalone index.html
+       -> deterministic detectors -> findings.json + improvement.md (private)
+       -> explicit upload -> Application Insights -> Workbook
+```
+
+Keep model execution, normalization, reporting, analysis and sending separate.
+Do not modify setup/chat commands or hook telemetry. Do not introduce a server,
+database, queue service or collector. Existing Vally reporting/trajectory APIs
+are the first choice; wrap missing capabilities only after inspecting pinned
+source/types and tests. Do not parse decorated console output or App UI logs.
+
+Proposed implementation ownership:
+
+| Location | Responsibility |
+| --- | --- |
+| `src/benchmark/cli.ts` | Development entry point and command validation |
+| `src/benchmark/contracts.ts` | Versioned manifest, result, event, finding and public-export contracts |
+| `src/benchmark/vally-adapter.ts` | Vally integration and capability/field mapping |
+| `src/benchmark/runner.ts`, `storage.ts` | Trial lifecycle, isolation, bounded execution and durable artifacts |
+| `src/benchmark/aggregate.ts`, `report.ts` | Comparable groups, public projection and HTML rendering |
+| `src/benchmark/analyze.ts` | Deterministic, versioned findings |
+| `src/benchmark/upload.ts` | Explicit allowlisted telemetry, delivery state and flush |
+| `tests/benchmark-*.test.ts`, `tests/fixtures/benchmark/` | Existing Vitest runner and synthetic/sanitized fixtures |
+| `evals/benchmark/` | Matrix manifest, runbook and benchmark-specific fixtures/checks |
+
+Search existing helpers before adding new ones. Evaluation-only dependencies
+remain development dependencies. Do not add package exports; since the package
+currently includes `lib/`, explicitly decide/test whether compiled benchmark
+files are excluded from the packed package without changing existing exports.
+
+## 2. Commands and matrix
+
+Add one proposed npm script, `benchmark`, pointing to `node lib/benchmark/cli.js`.
+Compile using the existing `npm run compile`. Command examples use PowerShell:
+
+```powershell
+npm run benchmark -- plan --manifest evals\benchmark\pilot.json --out results\benchmarks\pilot-plan
+npm run benchmark -- run --plan results\benchmarks\pilot-plan\plan.json --authorization C:\approved\pilot-authorization.json
+npm run benchmark -- report --run results\benchmarks\<run-id>
+npm run benchmark -- analyze --run results\benchmarks\<run-id> --baseline results\benchmarks\<previous-run-id>
+npm run benchmark -- upload --run results\benchmarks\<run-id> --destination <approved-resource-id>
+```
+
+Paths and resource IDs are placeholders. These commands do not exist yet.
+`plan`, `report` and `analyze` make no model or Azure calls. `run` never uploads or
+publishes. `upload` never runs a model. Missing commands/fields fail with actionable
+messages, not fallback to unrelated existing eval suites.
+
+The manifest has a schema version, benchmark ID, stable skill ID, canonical/display
+names and aliases, scenario complexity, capability-tier catalog, explicit
+executor/model IDs and reasoning settings, spec/stimulus references, fixture and
+skill-bundle revisions, variants, repetition count, deterministic order,
+concurrency (1 in v1), tool/MCP allowlist, timeout and limits. It references Vally
+prompts/graders instead of creating a competing prompt DSL. Unknown selectors,
+automatic model aliases, unsupported effort, duplicate trials and unsupported
+executors fail preflight.
+
+The pilot catalog has eight model/effort configurations:
+
+| Tier | Configurations |
+| --- | --- |
+| Powerful | GPT-6 Astra (`medium`), GPT-6 Astra (`low`), GPT-5.6 Sol, Claude Opus 5 |
+| Versatile | Claude Sonnet 5, GPT-5.6 Terra |
+| Lightweight | GPT-5.6 Luna, MAI-Code-1-Flash |
+
+These are versioned benchmark labels, not permanent rankings. Resolve exact model
+IDs, supported efforts, availability, and native billing metadata through the
+approved Copilot account before plan authorization. Preserve unavailable catalog
+slots as `not-evaluated`; do not substitute. Treat reasoning effort as part of
+configuration identity. Scenario complexity (`simple`, `moderate`, `complex`) is
+also reviewed/versioned catalog data.
+
+The plan resolves all references and stores hashes, a unique run ID, unique
+trial IDs, output root, and expected trial count before executing any trial.
+An authorization record binds the plan hash, reviewed code/skill/fixture revisions,
+reviewer-gate evidence, identity reference, exact models, limits and owner.
+It must not contain tokens or connection strings. It is evidence of an external
+human approval, not self-authorization by the runner or an editable JSON flag.
+Stop when approval cannot be established; local reviewer-gate mechanics are an
+explicit FRD blocker.
+
+Exit codes: `0` command completed without failed trials/delivery, `1` completed
+batch with task failures, `2` configuration/compatibility/storage/transport failure,
+`3` interruption or budget/timeout cancellation of the batch. Per-trial timeouts
+can coexist with a completed batch and return `1`. Always print artifact location
+and completion state. Offline reports on an incomplete run may return `0` when
+rendering succeeded but must prominently label incompleteness.
+
+## 3. Isolation and lifecycle
+
+Create a new session and disposable workspace for each trial. Place trial
+workspaces in an evaluation-owned root outside the source repository and its
+ancestors so normal parent walking cannot discover the checkout's `AGENTS.md`,
+`.github` plugins/instructions, or canonical `templates/skills`. Create a fresh
+evaluation-owned `COPILOT_HOME` (or a runtime profile proven to be equivalent)
+for each run, separate from the user's normal home. Populate it only with the
+approved settings, plugin and skill bundle. Explicitly control every skill/plugin
+discovery root, MCP server, instruction source and memory source; merely changing
+cwd, setting one environment variable, or using a worktree is insufficient.
+Reuse legitimate Copilot authentication through the supported credential path
+without copying credentials into the evaluation home or workspace.
+
+Before paid execution, enumerate the effective plugin/skill inventory and all
+user/project discovery roots, resolve each approved skill to its canonical source
+and content hash, and store safe inventory evidence. Fail closed on unexpected copies,
+duplicate names, hash mismatches, personal instructions/memory, or a baseline that
+can rediscover the removed bundle. The isolation acceptance test deliberately
+provides a conflicting user-level Azure Functions Skills version and a conflicting
+project-level copy/instruction tree while the evaluation home contains the
+reviewed version; only the latter may activate.
+Snapshot the user configuration tree before and after and prove it is unchanged.
+
+Never delete, rename, edit, disable in place, or temporarily move the user's
+plugin/configuration. If the pinned runtime reads an unavoidable user discovery
+root, use a disposable OS user/profile or container that still meets authentication
+and execution policy. If neither mechanism is proven, block the run.
+
+Keep deterministic graders and expected answers outside agent-writable roots;
+grade artifacts using trusted runner code, not the agent's self-reported success.
+Fresh workspace state includes public fixtures, not scorer source or answers.
+Use least-privilege tool and network allowlists. Explicitly pin executable/MCP
+versions; forbid unrelated personal tools and ARM writes in the pilot.
+Workspace isolation is a reproducibility measure, not an OS security boundary.
+Only reviewed code may execute, under the repository's evaluation gate.
+
+Persist the plan and a `running` marker, then append terminal results as trials
+finish; atomically finalize batch metadata. On crash, preserve complete lines and
+report pending/running trials as interrupted using the plan. A malformed complete
+record is an error, not skipped input. A truncated final line may be quarantined
+with an explicit diagnostic and incomplete status; never silently count it.
+
+Do not resume agent sessions or silently retry failed trials in v1. Additional
+attempts require a new authorized plan/run ID. Retry of telemetry retains the
+original IDs. Output roots must be new or owned by the same run; reject accidental
+overwrite, path escape and symlink traversal. Stop only owned child PIDs; record
+cleanup failures and manual remediation, never delete unrelated directories.
+
+Set wall-clock and model-call limits for every trial. Enforce the batch budget
+before starting subsequent trials; record actual consumption where available.
+Provider usage can arrive late, so a spend ceiling is a soft operational limit,
+not a guaranteed hard cap. If monetary/credit usage is unavailable, require explicit
+authorization of count/time limits instead; never claim currency enforcement.
+Flush partial observations on cancellation when possible.
+
+## 4. Local artifact contracts
+
+```text
+results\benchmarks\<run-id>\
+  plan.json
+  run.json
+  trials.jsonl
+  events\<trial-id>.jsonl
+  findings.json
+  improvement.md
+  private\                         # only with explicit content-capture opt-in
+  upload-state.json
+  public\
+    public-summary.json
+    index.html
+```
+
+`results/` is already ignored. Never publish the parent directory. Preserve
+normalized data as the source of truth; raw Vally trajectories may contain
+content and must follow private-capture policy, including temporary files.
+
+| Contract | Required information |
+| --- | --- |
+| Run | Schema version, run/plan identity, UTC timestamps, lifecycle state, expected/finished counts, exact versions, external trial-root and isolated-home/profile evidence, effective user/project inventory hashes, OS/runtime/tool profile, policy/authorization references, detector config/version and capability coverage |
+| Trial | Run/trial ID, scenario/version/complexity, stable/canonical/display skill identity and aliases, actual enabled bundle/hash, executor, capability tier, requested and observed models, reasoning settings, variant, repetition/order, status, grader outcomes, metrics and coverage |
+| Observation | Stable event ID, trial/session/parent/call IDs when available, monotonic sequence, timestamp, phase, event type, controlled tool/skill identifiers, duration/status and nullable usage values |
+| Finding | Detector ID/version, trial/event references, measured evidence, hypothesis, confidence, suggestion, validation criterion, affected metric and optional comparison trial |
+| Public summary | Explicit projection of approved benchmark labels, versions/date, scenario criteria, counts/statuses, metric summaries/coverage, comparison deltas and limitations |
+
+Trial status is one of `passed`, `failed`, `error`, `timeout`, `skipped`,
+`cancelled`, `interrupted`. Do not infer task success from a completed process.
+Treat malformed/version-unsupported inputs as errors. Schema adapters must be
+explicit; no structural casts that silently accept a newer upstream format.
+
+Each nullable measurement has `coverage: complete | partial | unavailable` and
+a machine-readable reason. Observed zero is distinct from unavailable.
+Keep integer token/call counts and milliseconds. Preserve provider cost in
+its native unit with source/version; serialize large integers losslessly.
+No freeform provider field is trusted as a currency label.
+
+Default metadata evidence must exclude prompt/response text, raw arguments,
+outputs, absolute paths and untrusted freeform error strings. For repeated
+operations, generate run-scoped keyed fingerprints of normalized arguments and
+file state in memory, not unsalted hashes of potentially secret inputs.
+Keep read range, revision relationship and status only where safe and available.
+When obtaining this metadata would require unsupported instrumentation, expose
+the detector as unavailable rather than retaining raw content by default.
+
+Optional `--capture-content` on `run` requires explicit approval and captures only
+needed fields into `private/`. Apply redaction, restrictive access and a recorded
+retention deadline. Redaction is defense-in-depth, not permission to publish.
+Do not retain model hidden reasoning. Reports include only observed actions.
+
+## 5. Metric semantics and comparison
+
+| Metric | Definition and caveats |
+| --- | --- |
+| Input/output tokens | Sum deduplicated per-model-call reported usage during agent execution; distinguish partial observations |
+| Cache read/write tokens | Separate provider-reported fields; do not add to input tokens without proving the provider semantics |
+| Model calls | Count uniquely identified inference calls, not user prompts or tool calls; if only usage events are available, label as observed usage-call count |
+| Tool calls | Count actual tool invocations; parallel tools remain separate calls; expose failed calls separately |
+| Agent duration | Monotonic elapsed time from submitting the prompt to terminal agent completion/cancellation; excludes setup, trusted grading, reporting and telemetry; includes tools and agent-run builds |
+| Other durations | Setup, grading, reporting and upload tracked separately; never substitute Vally total trial time for agent duration without proving boundaries |
+| Skill activation | Observed target skill loading; not inferred from output mentioning the name |
+| Subagent consumption | Included exactly once if the executor reports it; optional disjoint breakdown by parent/session; do not add nested totals to an already inclusive total |
+| Copilot cost | One account-wide Copilot billing unit selected in the authorized plan and reported with identical semantics across configurations; native/provider units remain secondary; unknown is not free and token count times vendor API price is not Copilot billing |
+
+If the provider has only cumulative session totals, do not sum snapshots as
+per-call usage. Choose a documented final total or deltas and report unavailable
+call-level attribution. Do not mix summary RPC totals with the same event totals.
+Requested and observed model mismatch is a protocol error, not a valid comparison.
+
+Accuracy is the number of trials satisfying all mandatory quality checks divided
+by attempted trials. Attempted includes passed/failed/error/timeout and started
+cancelled/interrupted trials; exclude never-started trials but show planned and
+unattempted counts. Show scored-only outcomes separately when useful. Activation
+rate uses trials with observable activation data and displays that denominator;
+never count missing activation telemetry as a failure to activate.
+Missing quality checks cannot produce a pass. Partial mandatory failures cannot
+be hidden by a weighted average from the original Vally grader.
+
+Aggregate by stable skill ID and content lineage, skill bundle, scenario
+version/complexity, capability tier, executor/model/effort, variant and environment
+profile. Show n, passed/attempted, planned/unattempted, missing/partial counts,
+median and min/max of complete observations. Show complete-observation statistics
+for all attempted trials and a separately labeled successful-only view; label
+timeout durations as censored, not completed execution latencies. No p95 in a
+three-repeat scenario/configuration group.
+
+For each scenario/configuration, publish one of:
+
+| Label | Rule |
+| --- | --- |
+| `observed-fit` | All three authorized repetitions pass every mandatory check with no critical safety/error condition |
+| `mixed` | One or two repetitions pass every mandatory check |
+| `not-demonstrated` | No repetition passes every mandatory check |
+| `not-evaluated` | The model/effort, execution, or required capability is unavailable/unauthorized |
+
+Call these measured outcomes, not recommendations or model guarantees. Identify
+the lowest capability tier with an observed-fit configuration. Identify the
+lowest-cost observed-fit configuration only when the same Copilot account-wide
+billing metric (for example, the runtime's AI-credit or premium-request consumption
+under the active billing model) covers every compared configuration with identical
+semantics. Show median/range of that metric and cost per successful trial alongside
+quality, latency, tokens and calls. Native/provider units are diagnostics. If no
+common unit exists, show lowest adequate tier and within-provider/native costs,
+mark cross-provider cost not comparable, and do not infer it from tier labels or
+external API token pricing.
+
+Match A/B on all controls except the declared skill bundle. Match historical
+comparisons on the same controls while allowing the explicitly compared skill
+revision to differ. Record changed controls (including tool/model/grader updates)
+and suppress direct regression claims when incompatible. Alternate A/B execution
+order to reduce warming/order bias. A zero baseline supports an absolute delta
+but not a percentage. Report association, not causal proof.
+
+## 6. Improvement analysis
+
+`analyze` is deterministic and offline in v1. It can run without `--baseline`;
+only matched-regression detection then reports unavailable. Store thresholds in
+run metadata and a versioned detector config. Proposed defaults are investigation
+heuristics, not product quality gates:
+
+| Detector | Candidate condition | Suppression / evidence requirement | Suggested direction |
+| --- | --- | --- | --- |
+| repeated-read | Same target/range and unchanged revision read at least 3 times in a trial | Require known file-state identity; suppress rereads after mutation; report unknown revision as insufficient evidence | Clarify reference order and scope; avoid redundant navigation |
+| repeated-failure | Same operation fingerprint and normalized failure category at least 3 consecutive times | Separate transient retryable failures; unknown category/state change prevents a strong claim | Document prerequisites or error-specific recovery |
+| search-without-progress | At least 5 consecutive search/list operations | Candidate only; absence of a subsequent material action/completion must be observable; research tasks may legitimately search | Add a direct reference or decision table |
+| input-growth | Adjacent comparable model calls increase input by at least 50% and 4,000 tokens | Require complete per-call data, same model/context lineage, no unexplained compaction; do not claim a specific file caused growth | Narrow read ranges, reduce tool verbosity or split long references |
+| matched-regression | Matched group median model calls or input tokens increases by at least 25%, with at least 3 complete trials per side | Compare only compatible groups; show absolute delta, spread and quality changes; zero baseline has no percentage | Inspect added trajectory segments before modifying skill guidance |
+
+Confidence describes evidence completeness, not statistical certainty. Every
+finding separates observation, hypothesis and proposed remediation, includes
+stable trial/event evidence references, and ends with a concrete re-evaluation
+criterion (for example, fewer repeat reads without reduced task success).
+Do not allocate all later input tokens to one read, claim guaranteed savings,
+or label deliberate verification as proven waste.
+
+`improvement.md` contains scope/control metadata, metric deltas, coverage,
+findings ordered by observed impact, limitations, and maintainer disposition
+fields (`accepted`, `false-positive`, `needs-evidence`, `deferred`). A no-finding
+report distinguishes "no candidates in observed data" from unavailable detectors.
+Stable finding IDs allow a separate disposition file to survive regeneration.
+Private evidence links are local and never copied into public HTML.
+
+## 7. Public HTML and telemetry
+
+Produce a self-contained HTML file from the public projection, using escaped
+text and safe JSON serialization (including script-closing payloads). No CDN,
+external chart library, API queries or live App Insights credentials. Filtering
+uses bundled data so `file://` works. Display stable skill/display name,
+capability tier, model/effort, scenario/complexity and variant filters, four-state
+fit labels, counts, accuracy, activation, comparable Copilot consumption,
+provider-native diagnostics, agent/tool activity, median/range and coverage, with
+measured environment and limitations. Do not embed freeform raw findings or
+transcript excerpts. Public labels/criteria are reviewed catalog text, not
+arbitrary model output.
+
+Publication is manual in v1: generate, review the exact public directory and hash,
+then publish only that artifact to the authorized Pages repository/path using
+the repository's permitted static-site mechanism. Preserve an immutable
+run-specific page; update a latest link only deliberately. Existing Pages
+deployment plumbing is acceptable; no new evaluation workflow is in scope.
+Record artifact hash and URL. No automatic git push or publication command.
+
+Proposed telemetry event: `SkillEvaluationCompleted` (also used for failed trials,
+with explicit status). One event carries `schemaVersion`, run/trial ID, controlled
+benchmark/stable-skill/scenario/complexity/tier/model/effort/executor/variant
+identifiers, revisions, status, coverage and rule version, with complete numeric
+measurements, the plan-selected comparable Copilot billing unit, provider-native
+diagnostics and per-rule counts.
+Include `attempted` and duration-censoring indicators for truthful queries.
+Do not send error text, argument fingerprints, transcripts, local paths, prompts,
+code, model reasoning, or authentication/account identifiers.
+
+Use a dedicated evaluation destination configured at upload time. Keep connection
+or credential material in the process environment/approved credential provider,
+never in reports or manifests; remove it from child agent environments. Read and
+honor applicable telemetry opt-outs. Explicit invocation does not override an
+opt-out silently. Do not reuse the package's build-time telemetry placeholder.
+The supported Azure Monitor transport/authentication choice is pending FRD review.
+The existing sender uses the legacy Classic `applicationinsights@1.8.10` API;
+its presence is not evidence of a suitable transport for this new component.
+Evaluate a currently supported Azure Monitor integration without migrating the
+unrelated invocation sender as a side effect.
+
+Uploader sends only fixed-schema projections. Fail invalid destination/payload
+before sending; flush and return explicit failure on timeout. Track per-trial
+delivery attempts and payload hashes locally. Ambiguous delivery can be retried,
+but has at-least-once semantics, not exactly-once. For v1, once uploading starts,
+freeze the telemetry projection (including rule version); changed projections
+require an explicit future revision contract, not silently different duplicate IDs.
+
+Workbook queries select the event name/schema, deduplicate by run ID + trial ID,
+then aggregate by stable skill ID/content lineage, comparable
+scenario/complexity/tier/model/effort/variant/revision/time. Keep numerator,
+attempted/planned counts and metric coverage distinct. Export no sampled trial
+events; confirm ingestion sampling settings before the pilot. Any sampling or
+missing data must be visible, not interpreted as zero. Set retention explicitly.
+The Workbook provides model suitability/economics, outcome,
+consumption/latency/activity trends, detector counts and data-quality views. Its
+exact table/column mapping must follow the approved transport and be verified
+during the pilot, not guessed from legacy SDK examples.
+
+## 8. Compatibility evidence and unresolved gates
+
+Before implementation approval, inspect the installed/locked Vally and SDK types
+and record the source fields for tokens, cache, billing, call identity, tool
+status, activation and agent end time. Distinguish static inspection from a
+paid capability probe. Inspect how Vally isolates homes/skills, chooses models,
+allows tools and captures transcripts; enumerate every user/project/plugin/skill/
+instruction/memory discovery source and prove the isolated-home design. Default
+content policy must hold even for temporary files. Unsupported required
+capabilities block the plan or require a reviewed version/adapter decision.
+
+Current upstream references are discovery aids, not proof of locked-version support:
+
+- [Vally](https://aka.ms/vally)
+- [Copilot SDK usage/billing](https://github.com/github/copilot-sdk/blob/main/docs/features/usage-and-billing.md)
+- [Copilot SDK authentication](https://github.com/github/copilot-sdk/blob/main/docs/auth/authenticate.md)
+- [Copilot SDK OpenTelemetry](https://github.com/github/copilot-sdk/blob/main/docs/observability/opentelemetry.md)
+- [Azure Monitor Workbooks](https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview)
+
+Do not run evals, upgrade dependencies, provision Azure or publish as part of
+resolving this documentation task. Execution policy, adapter feasibility and
+supported telemetry transport are unresolved FRD gates, not permission to improvise.
+
+## 9. Independent architecture review record
+
+On 2026-09-08, a separate Claude Opus 4.8 agent performed a read-only architecture
+review of revision 1 of the first two FRDs, the provisional index, this design, the
+implementation plan, and the evals README introduction. It reported no blocking
+findings, confirmed the eight-section governance structure and the distinction
+between proposed capabilities, human approval and experiment authorization.
+The author applied these suggested clarifications after review:
+
+| Finding | Resolution |
+| --- | --- |
+| Governance merge gate was implicit | Index and handoff explicitly require merged PR #244, final-policy recheck and ID deconfliction before Finalized |
+| Legacy telemetry transport context could be clearer | Section 7 names the locked Classic SDK and requires a supported evaluation transport decision without migrating unrelated hooks |
+| General HTML filter list omitted skill | Section 7 now includes the skill filter required by SE-006 |
+| Development-command documentation must remain in delivery scope | Implementation slice F explicitly includes `docs/development.md` |
+
+This review does not resolve the open capability, local execution-policy or
+telemetry-transport decisions. Those require evidence and further review before
+human sign-off.
+
+On the same date, a separate Claude Opus 4.8 agent reviewed revision 2 and the
+create and hosted-agents pilot proposals. It reported no blockers and identified
+three important clarifications:
+trial workspaces must also avoid checkout-level discovery, cross-provider
+"cheapest" requires a common Copilot billing unit, and rename history should use
+an opaque stable ID. Those changes are incorporated in the FRD, design, and
+implementation plan. FRD-0001 remains Draft; no implementation, paid-run,
+publication or telemetry
+authorization was granted.

--- a/docs/internal/skill-evaluation-implementation-plan.md
+++ b/docs/internal/skill-evaluation-implementation-plan.md
@@ -1,0 +1,215 @@
+# Local skill evaluation: implementation and agent handoff
+
+Status: proposed, 2026-09-08. No feature implementation or experiment has started.
+This plan can be followed by another coding agent without the originating chat.
+
+## 1. Read first and respect gates
+
+Read [AGENTS.md](../../AGENTS.md), the [FRD index](../frds/README.md),
+[FRD-0001](../frds/0001-local-skill-evaluation.md),
+and the [technical design](skill-evaluation-design.md).
+Read scoped TypeScript/testing/CLI/skill instructions before editing those areas.
+Check git status and preserve unrelated work.
+
+The user requested planning/design files, not execution. FRD-0001 is Draft.
+Do not implement until the FRD is Finalized with explicit human approval
+of a commit SHA or content hash. Do not treat approval of this plan or an earlier
+conversation as approval of an unwritten/changed contract.
+
+Before merging these documents with governance PR #244, retain its full process,
+merge the provisional index rows, check FRD number collisions, and update all
+links/statuses together. Do not modify historical F1-F21 numbering.
+Do not set FRD-0001 to Finalized before PR #244 is merged and its final
+governance text has been rechecked.
+
+Use one primary implementer, not a fleet. A separate reviewer should inspect
+contracts and output boundaries. At each checkpoint report requirement IDs
+completed, actual evidence, blockers and changed decisions; append decisions
+instead of overwriting earlier ones. Return changed contracts to review.
+
+## 2. Pre-implementation design closure
+
+These activities are source/document inspection, not permission for paid probes:
+
+| Task | Deliverable / exit condition |
+| --- | --- |
+| Recheck repository baseline | Record HEAD, lockfile versions, current eval specs and relevant helper locations; design baseline is `4bfa24af92ee735dcd5fed377f27ee73ba9fa69b` |
+| Inspect Vally/SDK compatibility | Field/capability map with pinned source references for usage, calls, tool status, timing, content capture, all user/project discovery roots and parent walking, isolated homes/profiles, explicit model/effort, account-wide comparable billing metadata and cancellation; label unavailable vs unverified |
+| Resolve compatibility gaps | Choose supported adapter paths or propose a narrowly scoped upgrade; do not start a second engine or assume upstream main matches the lockfile |
+| Resolve local authorization policy | Maintainer explains how the existing reviewer-gated policy applies to local execution; no PR-code evals or implicit waiver |
+| Resolve telemetry transport | Supported Azure Monitor Node integration, auth, event mapping, sampling and flush semantics; keep new telemetry separate from legacy hooks |
+| Independent architecture review | Review the FRD, design, and staged plan; document findings/resolutions; leave human approval pending |
+| Human sign-off | Record approver, date, scope, revision hash and reference; only then set corresponding FRD/index status to Finalized |
+
+If paid evidence is needed to resolve a capability, pause and obtain separate
+probe authorization for reviewed code, exact targets, trial count and budget.
+Do not install dependencies for this documentation phase merely to inspect types;
+use locked package/source references first.
+
+## 3. Implementation slices
+
+All test filenames and npm benchmark commands below are proposed. Create code
+tests first using existing Vitest. Tests use fake executors/transports unless an
+experiment is explicitly authorized. Do not change canonical skill behavior as
+a side effect of building evaluation infrastructure.
+
+| Slice | Requirements | Work and deliverables | Exit evidence / checkpoint |
+| --- | --- | --- | --- |
+| A. Contracts and saved artifacts | SE-002, SE-003, SE-004, SE-010 | Versioned contracts/validators; sanitized pinned-format fixtures; normalization, coverage, durable plan/results, protected public projection | Storage/normalize tests cover malformed/missing/partial usage, duplicate/nested counts and interrupted files; reviewer accepts field semantics |
+| B. Matrix and isolated execution | SE-001, SE-002, SE-011, SE-014 | Matrix selector and dry plan; Vally adapter; explicit auth gate and limits; trial root outside checkout; isolated evaluation home/profile, session/workspace/tools/user/project discovery roots; effective inventory/hash evidence; statuses and owned-process cleanup | Fake-executor plus conflicting user/project install tests prove the approved hash is loaded and user config is unchanged; unauthorized, contaminated or unsupported runs stop before model calls |
+| C. Quality, model suitability and comparison | SE-004, SE-005, SE-013 | Mandatory task checks independent of activation; scenario complexity/model tier/effort catalog; four fit labels; attempted/scored/coverage denominators; shared Copilot billing unit and cost per success; matched A/B/history grouping and censored durations | Aggregation tests cover failures, unavailable models, effort mismatch, no common cost basis, unstarted trials, zero baseline, incompatible environments and small samples |
+| D. Two reports and analysis | SE-006, SE-007, SE-008, SE-010 | Standalone public HTML/JSON; five deterministic detector types; private Markdown/findings/dispositions | Fixture reports expose coverage and evidence; benign lookalikes suppressed; hostile HTML/content cannot cross projections; independent review |
+| E. Telemetry and history | SE-009, SE-010 | Approved transport; explicit upload and opt-outs; frozen projection/retry state; Workbook with dedup/coverage | Fake transport covers ambiguous delivery/flush failure; query fixtures show unique counts; no live send without pilot approval |
+| F. Commands and maintainer docs | SE-011, SE-012 | Proposed npm entry point, runbook, `docs/development.md` command documentation, existing helper integration, packaging decision, fixture-only end-to-end flow | Existing eval/hooks/exports remain unchanged; reviewer maps evidence to all SE IDs; infrastructure completion does not authorize paid evaluation |
+
+Prefer the proposed `src/benchmark/` boundary; search before adding helpers.
+Add no production exports and no npm lifecycle script. Use supported existing
+Node/TypeScript tooling, and keep evaluation-only dependencies development-only.
+If adding new compiled paths changes npm package contents, explicitly inspect
+the pack file list and preserve the current package contract.
+
+Expected targeted validation during implementation:
+
+```powershell
+npm test -- tests\benchmark-storage.test.ts tests\benchmark-normalize.test.ts tests\benchmark-model-catalog.test.ts tests\benchmark-isolation.test.ts tests\benchmark-runner.test.ts tests\benchmark-aggregate.test.ts tests\benchmark-report.test.ts tests\benchmark-analyze.test.ts tests\benchmark-upload.test.ts tests\benchmark-cli.test.ts
+npm run lint
+npm run typecheck
+```
+
+Run selectors only after their tests exist. Expand validation when affected
+existing behavior warrants it and follow all repository before-commit rules.
+If modifying published CLI commands despite the intended scope, obtain contract
+approval and perform the required isolated-workspace CLI E2E flow.
+Do not execute existing paid `eval:smoke`/`eval:full` commands as ordinary tests.
+Template changes, if separately approved, must use canonical generation and
+payload verification; never hand-edit generated payloads.
+
+## 4. Staged rollout and evaluation execution
+
+Do not start a milestone solely because the preceding implementation or experiment
+completed. Each milestone has its own reviewed inputs, execution limits, evidence,
+and explicit authorization.
+
+| Milestone | Scope | Exit condition |
+| --- | --- | --- |
+| M1. Evaluation infrastructure | Contracts, isolated fake executor, fixture reports, deterministic analysis, fake telemetry transport, maintainer docs | SE-001 through SE-014 have synthetic/test evidence and output-boundary review; no claim of real model quality |
+| M2. Create pilot | Evaluate `azure-functions-create` across the approved model catalog and three scenario complexities | Reviewed public/private reports, authorized history evidence, actual cost/coverage, isolation proof, and dispositions are recorded |
+| M3. Hosted-agents pilot | After M2 lessons, evaluate `azure-functions-agents` (planned name `azure-functions-hosted-skills`) | Same evidence class as M2, with stable identity/rename mapping and no live connector side effects |
+
+Later doctor, diagnostics, setup, and help evaluations are revisions to this plan
+and its scenario catalog. A separate FRD is needed only when they introduce a new
+user-facing capability or change FRD-0001 requirements.
+
+### 4.1 Shared model and result contract
+
+The initial catalog is:
+
+| Capability tier | Candidate configurations |
+| --- | --- |
+| Powerful | GPT-6 Astra (`medium`), GPT-6 Astra (`low`), GPT-5.6 Sol, Claude Opus 5 |
+| Versatile | Claude Sonnet 5, GPT-5.6 Terra |
+| Lightweight | GPT-5.6 Luna, MAI-Code-1-Flash |
+
+Resolve exact model IDs, supported effort, availability, runtime version, and
+billing metadata in each authorized plan. Do not substitute unavailable models.
+For every configuration/scenario, classify three repetitions as `observed-fit`
+(3/3 mandatory passes), `mixed` (1/3 or 2/3), `not-demonstrated` (0/3), or
+`not-evaluated` (unavailable, unauthorized, or unsupported). These are measured
+observations, not universal recommendations.
+
+### 4.2 M2: `azure-functions-create` scenario catalog
+
+The enabled bundle is `azure-functions-create`, `azure-functions-common`, and
+`azure-functions-setup`. The control removes that bundle while holding prompts,
+fixtures, tools, MCP endpoints, limits, and graders constant.
+
+| Complexity | Scenario ID | Task | Mandatory evidence |
+| --- | --- | --- | --- |
+| Simple | create-ts-http | Create a new TypeScript HTTP function | Correct registration/route, successful build, host readiness, and real localhost HTTP response |
+| Moderate | add-ts-http | Add an HTTP function to an existing TypeScript project without reinitializing it | Existing files preserved except permitted additions, successful build, and real HTTP response |
+| Complex | create-go-http | Create a Go HTTP function using the supported native worker path | Correct module/runtime conventions, no authored `function.json`, and successful `go build` |
+
+With all candidates available, suitability uses
+`3 scenarios x 8 configurations x 3 repetitions = 72` trials. Without-skill
+controls use one predeclared representative per tier:
+`3 scenarios x 3 representatives x 3 repetitions = 27`, for a maximum of 99.
+
+### 4.3 M3: hosted-agents scenario catalog
+
+Use opaque stable skill ID `afs-skill-0002` provisionally, separate from canonical
+and display names. Finalize it only after reviewing the rename work. Store the
+current `azure-functions-agents` name, planned `azure-functions-hosted-skills`
+name, aliases, and content hash separately so a rename does not split history.
+The initial enabled-bundle candidate is `azure-functions-agents`,
+`azure-functions-common`, and `azure-functions-deploy`; resolve the actual
+dependency graph before authorization.
+
+| Complexity | Scenario ID | Task | Mandatory evidence |
+| --- | --- | --- | --- |
+| Simple | built-in-mcp-session | Expose an agent as a built-in MCP tool and explain chat session IDs | Correct endpoint configuration and route/session semantics; no unrelated surface |
+| Moderate | scheduled-teams-briefing | Create a weekday email-to-Teams briefing agent without a chat surface | Correct timer/background configuration, connector/MCP files and timeouts; interactive endpoints omitted; static checks pass |
+| Complex | outlook-trigger-drafts | Add an Outlook connector-triggered agent that drafts replies | Correct Connector Namespace resources, trigger schema, MCP config, draft-only safety, and second-step guidance; no live side effect |
+
+Use the same maximum 99-trial shape as M2 unless M2 evidence leads to an approved
+plan revision. Do not provision Azure, read private mail, or send email/Teams
+messages. A rename or content change during a batch requires freezing one revision
+or restarting under a new authorized plan.
+
+### 4.4 Per-milestone execution gates
+
+| Step | Requirements | Action and evidence |
+| --- | --- | --- |
+| P1. Freeze milestone contract | SE-001, SE-004, SE-013 | Resolve scenarios, bundle/controls, catalog, mandatory graders, and stable identity; independently review an identified plan revision |
+| P2. Author reviewed inputs | SE-004, SE-010, SE-013, SE-014 | Create deterministic graders/fixtures and conflicting user/project-install cases; lint statically; review exact revisions |
+| P3. Authorize execution | SE-001, SE-009, SE-014 | Record account/policy, gate evidence, exact models/efforts, shared Copilot billing unit or non-comparability, trial count, numeric budget, time/call caps, external root, isolated profile ownership, retention, and cleanup |
+| P4. Inspect dry plan | SE-001 through SE-005, SE-013, SE-014 | Account for every catalog slot; confirm trial arithmetic, concurrency 1, balanced order, controls, bundle/hash, external root, and isolation; hash the plan |
+| P5. Execute bounded batch | SE-001 through SE-005, SE-013, SE-014 | Retain every unavailable/terminal/interrupted trial, actual usage/coverage, effective inventory/hash, and before/after user-state evidence; no invisible retries |
+| P6. Review improvement report | SE-007, SE-008 | Resolve evidence links, distinguish missing telemetry from no findings, and record maintainer dispositions; do not automatically edit skills |
+| P7. Approve and publish | SE-006, SE-010 | Review exact public artifact, fit/cost presentation, and disclosure; publish only public files; record URL/hash and rendered-page evidence |
+| P8. Approve and send telemetry | SE-009, SE-010 | Approve tenant/resource/auth/retention, confirm sampling, upload/flush, inspect Workbook, and confirm replay does not inflate unique counts |
+| P9. Close or record blockers | SE-001 through SE-014 | Map requirements to evidence, actual spend, unavailable models, user-state integrity, limitations, and resource disposition; keep incomplete milestones open |
+| P10. Gate the next milestone | SE-012 | Incorporate prior findings, update shared contracts if needed, and independently approve the next plan revision and budget |
+
+Required authorization record fields (values intentionally unset): human owner,
+approval reference/date, FRD revision hash, reviewed runner and skill SHAs,
+fixture/manifest/plan hashes, execution-gate reference, credential source reference,
+exact model IDs, capability tiers and reasoning settings, a common account-wide
+Copilot billing metric or explicit cross-provider non-comparability,
+repetitions/trial count, numeric
+credit/currency budget or explicitly approved count/time-only mode when spend is
+unobservable, timeout/model-call/batch limits, approved tools/network endpoints,
+external trial root, isolated home/profile and workspace/process ownership,
+effective user/project discovery roots, user-state integrity and cleanup,
+evidence retention/deletion date,
+telemetry resource/identity/sampling/retention, and Pages repository/path.
+No credentials belong in that record.
+
+If the batch stops early, save a visibly incomplete report and account for all
+planned IDs. A new attempt requires renewed scope/budget authorization. If Pages
+or ingestion permissions are unavailable, keep the local artifacts and mark the
+affected SE requirements blocked for that milestone, rather than claiming
+publication or delivery.
+
+## 5. Evidence and continuation protocol
+
+Update the owning FRD sign-off table with implementation PR/commit references and
+stable evidence paths/URLs. A fixture artifact is labeled synthetic; a benchmark
+artifact identifies the measured revision. Private evidence stays in the approved
+local/private store; link only safe references from committed documents.
+
+Suggested completion record:
+
+| Field | Required content |
+| --- | --- |
+| Scope | FRD ID, requirement IDs, approved revision and implementation commit |
+| Evidence | Tests/fixtures or actual run ID, report hash/URL and Workbook observation |
+| Coverage | Complete/partial/unavailable metrics and detector availability |
+| Outcomes | Success/attempted/planned counts, limitations and maintainer findings |
+| Cost and cleanup | Authorized vs observed consumption, owned-resource/process disposition |
+| Remaining work | Blocked requirements, owner, next gate and append-only decision references |
+
+Do not mark FRD-0001 Implemented from sample code, dry plans, or fixture reports.
+Execute `azure-functions-create` before the hosted-agents milestone. After those
+results, revise this plan to add doctor, diagnostics, setup, then help based on
+observed usage and value. Do not add Codex/Claude Code, CI, LLM
+analysis, automatic remediation, or broader scenarios without approved scope.

--- a/docs/internal/skill-evaluation-implementation-plan.md
+++ b/docs/internal/skill-evaluation-implementation-plan.md
@@ -34,8 +34,8 @@ These activities are source/document inspection, not permission for paid probes:
 | Task | Deliverable / exit condition |
 | --- | --- |
 | Recheck repository baseline | Record HEAD, lockfile versions, current eval specs and relevant helper locations; design baseline is `4bfa24af92ee735dcd5fed377f27ee73ba9fa69b` |
-| Inspect Vally/SDK compatibility | Field/capability map with pinned source references for usage, calls, tool status, timing, content capture, all user/project discovery roots and parent walking, isolated homes/profiles, explicit model/effort, account-wide comparable billing metadata and cancellation; label unavailable vs unverified |
-| Resolve compatibility gaps | Choose supported adapter paths or propose a narrowly scoped upgrade; do not start a second engine or assume upstream main matches the lockfile |
+| Inspect Vally/SDK compatibility | Field/capability map with pinned source references for usage, calls, tool status, timing, content capture, all user/project discovery roots and parent walking, isolated homes/profiles, explicit model/effort, account-wide comparable billing metadata and cancellation; compare the current pin with candidate Vally releases; label unavailable vs unverified |
+| Resolve compatibility gaps | Choose supported adapter paths or a reviewed Vally upgrade; inspect changelog/source for material breaking changes, run targeted existing-suite regressions, and pin the selected version; do not start a second engine or assume upstream main matches a released version |
 | Resolve local authorization policy | Maintainer explains how the existing reviewer-gated policy applies to local execution; no PR-code evals or implicit waiver |
 | Resolve telemetry transport | Supported Azure Monitor Node integration, auth, event mapping, sampling and flush semantics; keep new telemetry separate from legacy hooks |
 | Independent architecture review | Review the FRD, design, and staged plan; document findings/resolutions; leave human approval pending |
@@ -120,8 +120,11 @@ observations, not universal recommendations.
 ### 4.2 M2: `azure-functions-create` scenario catalog
 
 The enabled bundle is `azure-functions-create`, `azure-functions-common`, and
-`azure-functions-setup`. The control removes that bundle while holding prompts,
-fixtures, tools, MCP endpoints, limits, and graders constant.
+`azure-functions-setup`. The without-skill control removes only that bundle while
+holding the exact user task instruction, runtime/system instructions, fixtures,
+tools, MCP endpoints, model/effort, limits, environment profile, and graders
+constant. Store matching instruction-set hashes for both variants and fail the
+comparison if the baseline rediscovers any removed skill.
 
 | Complexity | Scenario ID | Task | Mandatory evidence |
 | --- | --- | --- | --- |
@@ -162,7 +165,7 @@ or restarting under a new authorized plan.
 | P1. Freeze milestone contract | SE-001, SE-004, SE-013 | Resolve scenarios, bundle/controls, catalog, mandatory graders, and stable identity; independently review an identified plan revision |
 | P2. Author reviewed inputs | SE-004, SE-010, SE-013, SE-014 | Create deterministic graders/fixtures and conflicting user/project-install cases; lint statically; review exact revisions |
 | P3. Authorize execution | SE-001, SE-009, SE-014 | Record account/policy, gate evidence, exact models/efforts, shared Copilot billing unit or non-comparability, trial count, numeric budget, time/call caps, external root, isolated profile ownership, retention, and cleanup |
-| P4. Inspect dry plan | SE-001 through SE-005, SE-013, SE-014 | Account for every catalog slot; confirm trial arithmetic, concurrency 1, balanced order, controls, bundle/hash, external root, and isolation; hash the plan |
+| P4. Inspect dry plan | SE-001 through SE-005, SE-013, SE-014 | Account for every catalog slot; confirm trial arithmetic, concurrency 1, balanced order, identical with-skill/without-skill instruction-set hashes and controls, bundle/hash as the only treatment difference, external root, and isolation; hash the plan |
 | P5. Execute bounded batch | SE-001 through SE-005, SE-013, SE-014 | Retain every unavailable/terminal/interrupted trial, actual usage/coverage, effective inventory/hash, and before/after user-state evidence; no invisible retries |
 | P6. Review improvement report | SE-007, SE-008 | Resolve evidence links, distinguish missing telemetry from no findings, and record maintainer dispositions; do not automatically edit skills |
 | P7. Approve and publish | SE-006, SE-010 | Review exact public artifact, fit/cost presentation, and disclosure; publish only public files; record URL/hash and rendered-page evidence |

--- a/evals/README.md
+++ b/evals/README.md
@@ -6,6 +6,15 @@ single skill and contains an `eval.yaml` defining stimuli, graders, and configur
 
 > Source / docs: <https://aka.ms/vally> · npm: [`@microsoft/vally-cli`](https://www.npmjs.com/package/@microsoft/vally-cli)
 
+## Proposed local benchmark workflow
+
+The [draft evaluation FRDs](../docs/frds/README.md), [technical design](../docs/internal/skill-evaluation-design.md),
+and [implementation plan](../docs/internal/skill-evaluation-implementation-plan.md)
+describe a proposed local benchmark workflow with public HTML summaries, separate
+private improvement reports, and optional Application Insights history.
+The proposed `benchmark` commands are not implemented. Existing commands below
+are unchanged; the draft documents do not authorize paid evaluations.
+
 ## Prerequisites
 
 - **Node.js 22+** (required by Vally; the rest of the repo targets Node 18+ but Vally


### PR DESCRIPTION
## Summary

- define a single draft FRD for local skill evaluation, model suitability, public reporting, private improvement analysis, and optional Application Insights history
- document technical contracts for isolated execution, durable results, deterministic inefficiency detection, reporting, and telemetry
- stage delivery as M1 infrastructure, M2 `azure-functions-create`, and M3 hosted-agents evaluation milestones
- protect evaluations from user- and project-level skill installations without modifying user configuration

## Scope

This PR contains design and planning documents only. It does not implement benchmark commands, run paid evaluations, publish GitHub Pages, or send telemetry.

The FRD follows the draft governance proposed in #244 and remains Draft until that governance is merged, rechecked, and explicitly approved.

## Validation

- checked the eight-section FRD structure
- checked relative Markdown links and whitespace
- independently reviewed the underlying design with Claude Opus 4.8; no blockers found