### PR TITLE
docs: propose Azure deployment observation telemetry FRD

### DIFF
--- a/docs/frds/0003-azure-contribution-telemetry.md
+++ b/docs/frds/0003-azure-contribution-telemetry.md
@@ -3,9 +3,9 @@
 | Metadata | Value |
 | --- | --- |
 | Status | Draft |
-| Revision | 2 |
+| Revision | 3 |
 | Created | 2026-09-08 |
-| Updated | 2026-09-08 |
+| Updated | 2026-09-09 |
 | Author | GitHub Copilot, based on the user's requirements and scope feedback |
 | Depends on | [FRD governance, PR #244](https://github.com/Azure/azure-functions-skills/pull/244), revision `aff24690ae7dae787ad521b4bce718121647ffa7` |
 | Component | Shared infrastructure: contribution telemetry and narrow skill integration |
@@ -65,14 +65,14 @@ attempt would obscure the management question.
 | --- | --- | --- |
 | AC-001 | Add one contribution event while preserving existing usage event names and application properties. | One accepted contribution emits `azure_contribution`; existing custom properties remain compatible. Removing hostname-derived SDK envelope context is an intentional privacy change shared by both event paths. |
 | AC-002 | Limit attribution to the two supported canonical skills and azd/Bicep provisioning. | Delegated Functions and direct agents paths can call the collector; plain CLI create, Terraform, and unrelated skill use do not emit. |
-| AC-003 | Require successful command completion and current ARM deployment success. | Failed/cancelled commands, nonterminal/failed ARM states, missing evidence, preview, validation, and code-only deploy produce no event. |
+| AC-003 | Require successful command completion and current ARM deployment success. | Failed/cancelled commands, nonterminal/failed ARM states, no qualifying recent successful deployment, preview, validation, and code-only deploy produce no event. |
 | AC-004 | Count one supported successful command, not its resources or modules. | A single-layer azd invocation with multiple nested modules emits at most one event per collector call; failed attempts emit zero. |
 | AC-005 | Collect types from the exact ARM deployment and its nested operations. | Subscription and resource-group roots, pagination, and nested modules yield a sorted, distinct resource-type set, without deployment-wrapper types. |
 | AC-006 | Send only the categorical event contract and nonidentifying SDK metadata. | The captured HTTP envelope contains no customer names, identifiers, secrets, logs, source, host identity, or inherited correlation identifiers. |
 | AC-007 | Honor opt-out before extra collection or transmission. | Either existing opt-out environment variable or the applicable installed telemetry config disables ARM telemetry queries and sending. |
-| AC-008 | Do not change deployment outcomes for telemetry-only failures. | Query denial, timeout, malformed evidence, missing package, and ingestion failure never trigger a deployment retry or change the captured deployment exit status. |
+| AC-008 | Do not change deployment outcomes for telemetry-only failures. | Query denial, timeout, malformed input, missing package, and ingestion failure never trigger a deployment retry or change the deployment result the agent already observed. |
 | AC-009 | Preserve truthful client/version attribution. | Client values are normalized, not guessed; Skills version comes from the executing asset's metadata or is `unknown`, never inferred from a newer sender. |
-| AC-010 | Keep delivery deliberately best-effort. | Documentation discloses unsupported paths, skipped observations, possible duplicate collector calls, and absence of exact-once/funnel guarantees. |
+| AC-010 | Keep delivery deliberately best-effort. | Documentation discloses unsupported paths, deployment-selection imprecision, skipped observations, possible duplicate collector calls, and absence of exact-once/funnel guarantees. |
 | AC-011 | Keep integration small and nonpersistent. | No installed customer `azure.yaml` telemetry hooks, durable operation database, ARM tags, new server, or global tool interception is introduced. |
 
 ### Non-goals
@@ -113,89 +113,86 @@ do not send. This is flow discipline, not durable deduplication. Repeated
 collector calls, separate successful reprovisioning, or ambiguous delivery can
 duplicate observations; that limitation is accepted for Phase 1.
 
-If a retry skips provisioning from azd's cache, there is no new deployment
-evidence and no event. Do not search older attempts for a success. Types describe
-qualifying operations in the final observed deployment, not a union of all
-resources touched by failed attempts or a full workload inventory.
+If a retry skips provisioning from azd's cache, no new successful deployment
+appears in the recency window and no event is emitted. Do not search older
+attempts for a success. Types describe qualifying operations in the selected
+deployment, not a union of all resources touched by failed attempts or a full
+workload inventory.
 
-### 4.2 Explicit capture and post-command collection
+### 4.2 Post-command collection
 
-Keep azd execution with the existing agent/deployment workflow. Add a small
-internal collector, provisionally:
+Keep azd execution exactly as both skills perform it today. Do not wrap,
+re-run, intercept, or re-order the deployment. After a supported command reports
+success, the executing agent invokes one small internal collector, provisionally:
 
 ```text
-azure-functions-skills telemetry contribution --dir <workspace>
+azure-functions-skills telemetry contribution
 ```
 
-The new subcommand accepts a bounded JSON object on stdin with:
-`skill`, `operation`, `agent`, `skillsVersion`, `deploymentIdFile`, and `exitCode`.
-`operation` is `deploy` for azd up and `provision` for standalone azd provision.
-This local evidence object is NOT the outbound telemetry event. Reject unknown
-fields; do not accept a template, environment dump, arbitrary executable, or
-tool transcript. The original `telemetry` stdin contract remains unchanged.
+The subcommand accepts a bounded JSON object on stdin, limited to 16 KiB, with
+`skill`, `operation`, `agent`, `skillsVersion`, and optional `environmentName`.
+`operation` is `deploy` for `azd up` and `provision` for standalone
+`azd provision`. `environmentName` is the local azd environment name, used only
+to choose which deployment to inspect. Reject unknown fields; do not accept
+templates, environment dumps, transcripts, tool output, or executable paths.
+The original `telemetry` stdin contract stays unchanged.
 
-The invocation recipe belongs to the canonical skill instructions and uses the
-same package-resolution convention as existing telemetry. It must:
+Phase 1 deliberately drops the earlier capture-recipe design
+(`AZD_DEPLOYMENT_ID_FILE`, per-attempt temporary files, exit-code plumbing, and a
+process-scoped wrapper). That design gave exact per-attempt attribution but
+required owning the azd process, which `azure-functions-deploy` cannot do because
+it delegates execution to the external Azure Skills executor. Removing it makes
+both skills supportable through the same one-line post-success call, deletes the
+delegated-capture gate, and keeps the change small. The cost is deployment
+selection precision, addressed in section 4.3.
 
-1. Resolve telemetry preference before capture. If disabled or the collector
-   is unavailable, run the original deployment without telemetry instrumentation.
-2. Create a fresh, private temporary directory outside the project, with a new
-   deployment-ID file path for this attempt. Do not reuse a previous attempt's
-   file or commit it to the workspace.
-3. Set `AZD_DEPLOYMENT_ID_FILE` only for the azd process. Do not persist it in
-   `azure.yaml`, azd environment state, or global shell configuration.
-4. Run the original approved azd command, preserving arguments, interactive
-   behavior, and working directory. Capture its actual exit code immediately.
-5. After termination, invoke the collector with that exit code and file path.
-   The collector performs independent ARM verification, not stdout parsing.
-6. Clean up the temporary directory in the capture recipe's `finally`/trap path
-   and preserve the deployment result. The collector must not recursively delete
-   arbitrary paths supplied on stdin. Abrupt host termination can leave local
-   scratch data; no durable recovery or startup scan is added.
+Because the collector runs only after a reported success, there is no exit code
+to plumb and no failed-attempt bookkeeping. Section 4.4's independent ARM check
+remains the authoritative success signal, so a mistaken invocation after a
+failure still emits nothing.
 
-Use native PowerShell/Bash process-scoped capture recipes, with the substantive
-validation, ARM traversal, and sender logic in TypeScript. Do not build a generic
-azd wrapper or retry engine. Capture failures must fall back to the original
-deployment before it starts, or skip collection after it finishes; never rerun
-an already-started deployment to repair telemetry.
+Call the collector once per successful supported command: once after `azd up`,
+or once after a standalone `azd provision`, and never in both the delegating and
+the delegated skill. This is flow discipline, not durable deduplication.
+Repeated calls, separate successful reprovisioning, or ambiguous delivery can
+duplicate observations; that limitation is accepted for Phase 1.
 
-For `azure-functions-deploy`, pass the recipe as deployment context to the
-external Azure Skills executor; that executor owns command completion and the
-single collection call. The parent does not call it again. If the host or
-external skill cannot preserve this context, skip rather than guess.
-For agents, the executing agent uses the same recipe directly.
+If a retry completes without provisioning because azd reuses cached
+infrastructure, ARM shows no new successful deployment in the recency window and
+no event is emitted.
 
-Delegated capture feasibility is an M0 gate, not assumed support. Before
-Finalized status, identify a concrete host/tool handoff that can preserve the
-process-scoped variable, actual exit code, and single collector ownership without
-modifying the external plugin. If that cannot be established, obtain human
-approval to narrow AC-002 to the direct agents path and mark the Functions
-deployment path deferred. Do not claim both paths delivered from recipe fixtures
-alone; actual host coverage evidence remains an M3 acceptance requirement.
+This is trusted local workflow evidence, not attested attribution: a caller able
+to invoke the internal CLI can supply misleading input. Phase 1 does not attempt
+anti-fraud or hostile-local-user protection.
 
-This is trusted local workflow evidence, not cryptographically attested
-attribution: a caller able to invoke the internal CLI can supply misleading
-evidence. Phase 1 does not attempt anti-fraud or hostile-local-user protection.
+### 4.3 Deployment selection
 
-### 4.3 Exact azd evidence
+The collector chooses the deployment to inspect from Azure Resource Manager
+itself, reusing the Azure CLI authentication already available to the workflow:
 
-azd added `AZD_DEPLOYMENT_ID_FILE` in 1.25.1. During Bicep provisioning it emits
-NDJSON records with `deploymentId` and `layer`. Evidence:
-[release history](https://github.com/Azure/azure-dev/blob/5455d41a91625569182d168d5eacac2e79d02b68/cli/azd/CHANGELOG.md),
-[file implementation](https://github.com/Azure/azure-dev/blob/5455d41a91625569182d168d5eacac2e79d02b68/cli/azd/pkg/infra/provisioning/bicep/deployment_id_file.go).
+1. List deployments at the current subscription scope through a structured,
+   injectable query adapter. Never parse azd or CLI human-readable output.
+2. Keep only entries whose `provisioningState` is `Succeeded` and whose
+   completion timestamp falls inside a bounded recency window of 30 minutes.
+3. If `environmentName` is supplied, prefer entries whose deployment name
+   contains it; azd derives its subscription-scope deployment name from the
+   environment name.
+4. Select the single most recent remaining entry. No candidate means no event.
 
-File creation occurs before completion and is not proof of success. The
-collector requires `exitCode = 0`, one record from a fresh attempt file, an empty
-layer name, and a supported deployment resource ID. Missing/empty evidence,
-multiple records, a named layer, unsupported azd, and malformed input all skip
-collection. Unknown additional NDJSON fields are ignored locally, never sent.
-Do not infer deployment names from timestamps, environment names, a latest
-deployment listing, or human-readable logs.
+Accepted imprecision: an unrelated successful deployment running concurrently in
+the same subscription can be selected, and a deployment that finished before the
+window opened is skipped. Both affect which resource-type breakdown is attached
+to an observation rather than whether Skills-driven deployment activity is
+broadly visible, which is why section 1 uses an "observed", non-exact reporting
+label. Exact per-attempt attribution is a deferred Phase 2 option.
 
-Use a 64 KiB evidence-file limit and a 16 KiB stdin limit. Do not print the
-records. Although IDs are temporarily needed locally to query ARM, they are not
-analytics properties and are never forwarded to Application Insights.
+Deployment names, deployment IDs, subscription, and resource-group values are
+needed locally to run these queries. They are never analytics properties, are
+never forwarded to Application Insights, and are not printed by the collector.
 
+Out of scope for Phase 1: management-group and tenant roots, custom Azure
+clouds, deployment stacks, Terraform, and any root scope azd does not create for
+these two skills.
 ### 4.4 ARM verification and type extraction
 
 Use Azure CLI authentication already available to the workflow and structured
@@ -203,15 +200,15 @@ ARM JSON responses, with a small injectable query adapter. No new Azure SDK or
 credential store is needed. Invoke Azure CLI with an argument array, not a
 shell-interpolated command. Query only the supported public Azure ARM endpoint.
 
-The adapter reads the exact root's `provisioningState`, then its deployment
-operations. Do not read deployment parameters, outputs, request/response bodies,
-or error details into the event model. CLI subprocess output is consumed locally
-and not printed by the collector. Query failure bodies are discarded, not logged.
+The adapter reads the selected root's deployment operations. Do not read
+deployment parameters, outputs, request/response bodies, or error details into
+the event model. CLI subprocess output is consumed locally and not printed by
+the collector. Query failure bodies are discarded, not logged.
 
 Walk subscription/resource-group nested deployment IDs returned by ARM; handle
 every page and keep an in-memory visited set. Follow only valid ARM deployment
 IDs and same-origin ARM pagination URLs. Do not query arbitrary URLs supplied
-through an evidence file or response.
+through stdin or a response body.
 
 Include `targetResource.resourceType` for successful `Create` operations.
 ARM's provisioning-operation enum does not provide a separate `Update` value;
@@ -275,7 +272,7 @@ only to eliminate `unknown`. A newer npx sender version is not the Skills
 version. Derive deploymentKind in code rather than accepting a free-text label.
 
 The telemetry boundary constructs a new allowlisted object; never spread local
-evidence or ARM responses into it. No subscription/tenant/resource/deployment
+input or ARM responses into it. No subscription/tenant/resource/deployment
 IDs, names, user/email/session IDs, absolute paths, environment values, source,
 prompts, endpoints, keys, logs, or errors are sent, even hashed.
 
@@ -301,13 +298,13 @@ service-side metadata.
 
 Reuse the two existing opt-out environment variables. Resolve the applicable
 installed plugin/workspace `telemetry.config.json` using the executing host and
-asset location, not arbitrary ancestor scanning. Both capture recipe and
-collector check preference. If its location or contents cannot be safely
+asset location, not arbitrary ancestor scanning. The collector checks preference
+before any ARM query or send. If its location or contents cannot be safely
 resolved, skip collection rather than bypass an opt-out.
 
 The collector returns a local categorical result: `sent`, `disabled`,
 `not-configured`, `skipped`, or `failed`, with a fixed reason code when relevant.
-Neither result nor diagnostics includes evidence values or raw exception text.
+Neither result nor diagnostics includes input values or raw exception text.
 Do not introduce another diagnostics subsystem; use PR #235's bounded diagnostics
 if available, otherwise a short local categorical notice.
 
@@ -320,11 +317,11 @@ permissions, or trigger reprovisioning. If ARM read access is absent, skip.
 
 | Surface | Planned responsibility |
 | --- | --- |
-| `src/telemetry/contribution.ts` (new) | Local evidence validation, success policy, normalized event construction |
+| `src/telemetry/contribution.ts` (new) | Stdin input validation, deployment selection policy, normalized event construction |
 | `src/telemetry/arm-deployments.ts` (new) | Injectable bounded structured ARM query/traversal |
-| Existing sender and `src/telemetry/index.ts` | Reuse transport and privacy-safe client; keep raw ARM evidence out of the package's telemetry-event API |
+| Existing sender and `src/telemetry/index.ts` | Reuse transport and privacy-safe client; keep raw ARM responses out of the package's telemetry-event API |
 | `bin/azure-functions-skills.js` | Small internal subcommand dispatcher; no deployment orchestration |
-| Two canonical skill instructions / one shared reference | Capture recipe and delegation ownership, not generic PostToolUse detection |
+| Two canonical skill instructions | One post-success collection step each, not generic PostToolUse detection |
 
 Report event count over time and by skill/deploymentKind. Expand resourceTypes
 only for the breakdown; expanding the array must not inflate the headline count.
@@ -337,10 +334,10 @@ or attempt denominator from success-only events.
 
 | Slice | Requirements / planned work | Review boundary |
 | --- | --- | --- |
-| M0: Design approval | Reconcile #244, number allocation, related PRs, and open questions; resolve independent review and delegated capture feasibility | Approve a concrete delegation contract or explicitly defer that path, then obtain human approval of the identified revision; no implementation before Finalized |
+| M0: Design approval | Reconcile #244, number allocation, related PRs, and open questions; resolve independent review findings | Obtain human approval of the identified revision; no implementation before Finalized |
 | M1: Event and privacy contract | AC-001, AC-006, AC-007, AC-009; tests first, narrow sender/schema changes | Inspect an entirely local captured envelope and confirm compatibility/privacy scope |
-| M2: Collector | AC-003 through AC-005, AC-008, AC-010; fixtures first, evidence/ARM adapter/CLI | Review counting, bounds, skip behavior, and lack of durable tracking |
-| M3: Skill wiring and documentation | AC-002, AC-007, AC-009 through AC-011; recipe, delegation, local install/plugin assets | Review both host/script paths, limitations, and requirement-linked acceptance evidence |
+| M2: Collector | AC-003 through AC-005, AC-008, AC-010; fixtures first, selection/ARM adapter/CLI | Review counting, bounds, skip behavior, and lack of durable tracking |
+| M3: Skill wiring and documentation | AC-002, AC-007, AC-009 through AC-011; post-success step, delegation ownership, local install/plugin assets | Review both skill paths, limitations, and requirement-linked acceptance evidence |
 
 Use one primary implementer and separate review at these checkpoints. Prefer one
 small implementation PR if these slices remain reviewable. If telemetry
@@ -362,10 +359,7 @@ or Azure resource is created by this documentation task.
   resource breakdown. These are proposed implementation details, not an already
   approved contract.
 - Implementer/reviewer at M0: recheck which of #218, #235, and #240 have merged,
-  select the concrete canonical paths and metadata/preference resolver, and
-  identify how the direct and delegated execution flows preserve capture context.
-  The delegated flow is the explicit M0 gate in section 4.2; if it cannot do this,
-  revise AC-002 with human approval rather than promising unsupported coverage.
+  then select the concrete canonical paths and metadata/preference resolver.
 
 ## 5. Decisions log
 
@@ -373,13 +367,14 @@ or Azure resource is created by this documentation task.
 | --- | --- | --- | --- | --- |
 | D-001 | Overview versus exact accounting | User accepted a small Phase 1 focused on contribution trends; defer strict deduplication and broad coverage. This is direction approval, not FRD sign-off. | User, conversation scope agreement | 2026-09-08 |
 | D-002 | Existing transport versus new service | Reuse Application Insights sender; no SDK migration, backend, or new credential. | Copilot (proposal) | 2026-09-08 |
-| D-003 | Generic hook inference, persistent azd hooks, wrapper engine, or explicit collection | Explicit fresh-file capture plus post-command collector; preserve deployment ownership and avoid command/log parsing. | Copilot (proposal) | 2026-09-08 |
+| D-003 | Generic hook inference, persistent azd hooks, wrapper engine, or explicit collection | Explicit post-success collector call; preserve deployment ownership and avoid command/log parsing. | Copilot (proposal) | 2026-09-08 |
 | D-004 | Global workload identity versus per-command observation | No durable ID; one successful supported invocation is one observation. Failed attempts emit nothing; exact-once remains out of scope. | Copilot (proposal) | 2026-09-08 |
 | D-005 | Provision success alone versus full azd up result | Require full up success for up, provision success for standalone provision; always verify current ARM evidence. | Copilot (proposal) | 2026-09-08 |
 | D-006 | Top-level-only versus nested resource types | Keep bounded nested traversal because Bicep modules are normal, not an optional precision enhancement. | Copilot (proposal) | 2026-09-08 |
 | D-007 | Properties-only filtering versus full envelope privacy | Full outbound-envelope filtering is mandatory even in the small PR. | Copilot (proposal) | 2026-09-08 |
 | D-008 | Reuse 0001/0002 versus next unused number | Use FRD-0003 after checking open PR filenames; leave the existing 0001 collision to its owners. | Copilot (allocation proposal) | 2026-09-08 |
 | D-009 | Architecture review: compatibility and delegated feasibility | Clarify that hostname removal intentionally affects SDK envelopes, not usage application properties; make delegated capture an M0 gate with human-approved scope reduction if needed. | Copilot (revision 2 proposal, responding to independent review) | 2026-09-08 |
+| D-010 | Exact per-attempt capture (`AZD_DEPLOYMENT_ID_FILE` recipe) versus post-success ARM deployment selection | Choose post-success selection. The recipe required owning the azd process, which the delegating deploy skill cannot do, so it would have covered only one skill while adding a wrapper, temporary files, and exit-code plumbing. Selection covers both skills with a one-line call and accepts bounded misattribution of the resource-type breakdown, consistent with the "observed", non-exact reporting label. Exact capture is deferred to Phase 2. | User (scope decision), Copilot (revision 3 proposal) | 2026-09-09 |
 
 ## 6. Test plan
 
@@ -389,15 +384,15 @@ CLI fixture, local HTTP capture, and isolated install/update infrastructure.
 | Requirement | Test / fixture / experiment | Expected evidence |
 | --- | --- | --- |
 | AC-001 | Extend `tests/telemetry.test.ts` and `tests/simplified-cli.test.ts` | New event exact shape; unchanged legacy stdin/event behavior |
-| AC-002, AC-011 | Skill contract fixtures and isolated capture recipes with fake azd/az/package commands | Only supported explicit entry points collect; external delegation has one owner; no customer azure.yaml modifications |
-| AC-003 | New contribution fixtures: exit failure/cancel, ARM Running/Failed, missing/fresh empty/stale-looking file, preview, publish failure | Zero contribution sends and no fallback to deployment history |
+| AC-002, AC-011 | Skill contract fixtures and isolated CLI invocation with a fake ARM query adapter | Only supported explicit entry points collect; external delegation has one owner; no customer `azure.yaml` modifications |
+| AC-003 | New contribution fixtures: no recent successful deployment, ARM Running/Failed, stale timestamp outside the window, preview, validation-only | Zero contribution sends and no fallback to unrelated deployment history |
 | AC-004 | Failed attempt then successful attempt; nested modules; deliberate double collector call | 0 then 1 for normal retry; one event for nested modules; duplicate-call limitation documented, not falsely claimed solved |
-| AC-005 | New ARM fixtures: subscription root, RG root, nested modules/pages, Create/Read/Delete, malformed type, repeated type, unsupported child/layer, empty type set | Complete normalized type set or explicit skip, never wrapper-type counting or partial silent success |
+| AC-005 | New ARM fixtures: subscription root, RG root, nested modules/pages, Create/Read/Delete, malformed type, repeated type, unsupported child, empty type set | Complete normalized type set or explicit skip, never wrapper-type counting or partial silent success |
 | AC-005, AC-008 | Deadline/request/depth/type caps, cycle, denied read, invalid pagination origin | Bounded termination, no arbitrary URL request, no raw diagnostic data |
-| AC-006 | Local HTTP server captures/decompresses the entire serialized SDK request; seed evidence with sentinel names/secrets | No forbidden sentinel, hostname, environment-derived tag, source, endpoint, or correlation identity anywhere in the envelope |
+| AC-006 | Local HTTP server captures/decompresses the entire serialized SDK request; seed input with sentinel names/secrets | No forbidden sentinel, hostname, environment-derived tag, source, endpoint, or correlation identity anywhere in the envelope |
 | AC-006, AC-009 | Invalid skill/client/version, unknown fields, oversized input/type set | Reject or normalize per contract; no free-text outbound dimensions |
 | AC-007 | Both environment opt-outs; each host's local and plugin config; missing/malformed preference context | No additional ARM read or send when disabled/unresolved; original deployment still runs |
-| AC-008 | Fake azd exit codes, missing collector, query/send failures, cleanup failure, interrupted capture | No cloud retry caused by telemetry; preserve original deployment result; delete only caller-owned temporary data when possible |
+| AC-008 | Missing Azure CLI, denied or failing ARM query, send failure, malformed stdin | No cloud retry caused by telemetry; the deployment result the agent already observed is never reclassified |
 | AC-009 | Installed version differs from npx sender; missing metadata; rename variant | Correct asset version or unknown; one canonical skill name, no double emission |
 | AC-010 | Documented query examples against a small synthetic dataset | Resource expansion does not change headline event count; no success-rate or full-inventory claim |
 | AC-011 | Canonical payload generation and isolated workspace CLI integration | No durable ledger, global hook interception, Azure tags, or new service introduced |
@@ -422,13 +417,12 @@ Implementation would update:
   simple reporting examples; preserve the existing release destination model.
 - `docs/cli-reference.md`: clarify internal telemetry behavior and privacy
   without advertising the collector as a supported deployment command.
-- `templates/skills/azure-functions-deploy/SKILL.md`: delegation capture context
-  and a single post-command collection owner.
+- `templates/skills/azure-functions-deploy/SKILL.md`: a single post-success
+  collection owner after the delegated deployment completes.
 - `templates/skills/azure-functions-agents/SKILL.md` and its
   `references/infra-and-deployment.md`, or the renamed equivalents from #218:
-  direct capture flow and explicit exclusions for connector follow-up work.
-- `templates/skills/azure-functions-common/references/contribution-telemetry.md`
-  (new): shared small PowerShell/Bash recipes and failure/opt-out behavior.
+  the same post-success collection step and explicit exclusions for connector
+  follow-up work.
 - `docs/frds/README.md` and this FRD: synchronized lifecycle, reviews, decision
   changes, and requirement-linked implementation evidence.
 
@@ -459,7 +453,12 @@ recommended human design review after two clarifications. Revision 2 addresses:
 | Finding | Resolution |
 | --- | --- |
 | AC-001 could be read to prohibit shared hostname suppression | AC-001 and section 4.5 explicitly distinguish preserved application properties from intentionally removed SDK hostname context. |
-| Delegated capture was only a general open question | Section 4.2 and M0 now require a concrete delegation contract or an explicitly approved narrowing of AC-002 before Finalized status. |
+| Delegated capture was only a general open question | Superseded in revision 3: D-010 replaces per-attempt capture with post-success ARM deployment selection, so the delegated path needs no process ownership and the M0 capture gate is removed. |
+
+Revision 3 records the user's scope decision to prefer breadth and simplicity
+over exact per-attempt attribution. It changes sections 4.1 through 4.4, AC-003,
+AC-010, D-003, the M0 boundary, the open questions, the test plan, and the docs
+impact list. It has not been re-reviewed independently.
 
 This records independent advice and the author's disposition, not reviewer or
 human approval of revision 2. M0 questions and human sign-off remain pending.

--- a/docs/frds/0003-azure-contribution-telemetry.md
+++ b/docs/frds/0003-azure-contribution-telemetry.md
@@ -1,0 +1,470 @@
+# FRD-0003: Azure contribution telemetry
+
+| Metadata | Value |
+| --- | --- |
+| Status | Draft |
+| Revision | 2 |
+| Created | 2026-09-08 |
+| Updated | 2026-09-08 |
+| Author | GitHub Copilot, based on the user's requirements and scope feedback |
+| Depends on | [FRD governance, PR #244](https://github.com/Azure/azure-functions-skills/pull/244), revision `aff24690ae7dae787ad521b4bce718121647ffa7` |
+| Component | Shared infrastructure: contribution telemetry and narrow skill integration |
+
+## 1. Summary
+
+Propose one new Application Insights event, `azure_contribution`, to show the
+approximate volume and resource-type breakdown of successful Azure deployment
+work observed through Azure Functions Skills. Phase 1 covers azd with Bicep from
+the Functions deployment and hosted-agents skills. Reuse the current telemetry
+transport and deployment workflows; do not build a deployment engine, durable
+tracking system, or exact attribution service.
+
+The reporting label is **Observed successful Azure deployment operations**.
+This is an adoption/contribution trend, not a complete inventory, an exact
+conversion rate, proof of net-new Azure resources, or a billing metric.
+This document includes the implementation plan and technical design. No feature
+implementation or live experiment is authorized by this draft.
+
+## 2. Motivation / problem
+
+Existing telemetry shows skill/tool usage but cannot establish that a deployment
+succeeded. A user can invoke a skill, cancel, run validation, or fail provisioning
+without creating a successful workload.
+
+Current repository evidence:
+
+| Surface | Existing behavior / consequence |
+| --- | --- |
+| [Telemetry sender](../../src/telemetry/sender.ts) | Validates an allowlist and sends `AzureFunctionsSkillsPluginExecuted`; usage categories are `Plugin_EventType`, not separate event names. |
+| [Hidden CLI](../../bin/azure-functions-skills.js) | `telemetry` reads one sanitized JSON event from stdin; reuse this command family without changing that contract. |
+| [Hook scripts](../../templates/hooks/scripts) | PostToolUse records skill reads/invocations and MCP usage, not deployment success. Do not add shell-output inference here. |
+| [Deployment skill](../../templates/skills/azure-functions-deploy/SKILL.md) | Delegates to external `azure-prepare`, `azure-validate`, and `azure-deploy`. This repository does not control that deployment engine. |
+| [Agents skill](../../templates/skills/azure-functions-agents/SKILL.md) | Uses azd directly; integrate separately with the same collector. |
+| [Workspace preferences](../../src/setup/workspace-assets.ts) | Local installs retain per-host telemetry opt-out settings, in addition to environment-variable opt-out. |
+| [Release transport](../internal/telemetry-release.md) | The existing release pipeline injects the destination into the npm runtime. No new destination, credential, or service is needed. |
+
+For example, failed provisioning followed by a successful retry should normally
+produce one event, with a resource-type set such as Functions, Storage, and
+Application Insights. Counting each resource, nested deployment, or failed
+attempt would obscure the management question.
+
+### Related unmerged work
+
+| PR | Integration rule |
+| --- | --- |
+| [#235: telemetry reliability](https://github.com/Azure/azure-functions-skills/pull/235) | Reuse its sender, diagnostics, package resolution, and version metadata if merged. Do not reproduce its delivery retry, doctor, canary, or hook overhaul here. |
+| [#240: Application Insights SDK update](https://github.com/Azure/azure-functions-skills/pull/240) | Do not bundle an SDK migration. Verify the actual outbound envelope against whichever version is merged. |
+| [#218: hosted skills rename](https://github.com/Azure/azure-functions-skills/pull/218) | Current canonical name is `azure-functions-agents`; if the rename lands, integrate `azure-functions-hosted-skills` instead and update paths/allowlists. Never emit both for one operation. |
+| [#241](https://github.com/Azure/azure-functions-skills/pull/241), [#245](https://github.com/Azure/azure-functions-skills/pull/245) | Reserve FRD numbers 0001 and 0002. No dependency on their workflow runner, evaluation framework, or telemetry events. |
+
+## 3. Goals / non-goals
+
+### Requirements and acceptance criteria
+
+| ID | Requirement | Observable acceptance criterion |
+| --- | --- | --- |
+| AC-001 | Add one contribution event while preserving existing usage event names and application properties. | One accepted contribution emits `azure_contribution`; existing custom properties remain compatible. Removing hostname-derived SDK envelope context is an intentional privacy change shared by both event paths. |
+| AC-002 | Limit attribution to the two supported canonical skills and azd/Bicep provisioning. | Delegated Functions and direct agents paths can call the collector; plain CLI create, Terraform, and unrelated skill use do not emit. |
+| AC-003 | Require successful command completion and current ARM deployment success. | Failed/cancelled commands, nonterminal/failed ARM states, missing evidence, preview, validation, and code-only deploy produce no event. |
+| AC-004 | Count one supported successful command, not its resources or modules. | A single-layer azd invocation with multiple nested modules emits at most one event per collector call; failed attempts emit zero. |
+| AC-005 | Collect types from the exact ARM deployment and its nested operations. | Subscription and resource-group roots, pagination, and nested modules yield a sorted, distinct resource-type set, without deployment-wrapper types. |
+| AC-006 | Send only the categorical event contract and nonidentifying SDK metadata. | The captured HTTP envelope contains no customer names, identifiers, secrets, logs, source, host identity, or inherited correlation identifiers. |
+| AC-007 | Honor opt-out before extra collection or transmission. | Either existing opt-out environment variable or the applicable installed telemetry config disables ARM telemetry queries and sending. |
+| AC-008 | Do not change deployment outcomes for telemetry-only failures. | Query denial, timeout, malformed evidence, missing package, and ingestion failure never trigger a deployment retry or change the captured deployment exit status. |
+| AC-009 | Preserve truthful client/version attribution. | Client values are normalized, not guessed; Skills version comes from the executing asset's metadata or is `unknown`, never inferred from a newer sender. |
+| AC-010 | Keep delivery deliberately best-effort. | Documentation discloses unsupported paths, skipped observations, possible duplicate collector calls, and absence of exact-once/funnel guarantees. |
+| AC-011 | Keep integration small and nonpersistent. | No installed customer `azure.yaml` telemetry hooks, durable operation database, ARM tags, new server, or global tool interception is introduced. |
+
+### Non-goals
+
+- Unique subscriptions, users, tenants, workloads, or pseudonymous customer IDs.
+- Durable operation/session tracking, exactly-once delivery, persistent retry
+  aggregation, offline queues, and server-side deduplication.
+- Direct `az deployment` entry points, CLI resource create/update, Terraform,
+  deployment stacks, azd multiple provisioning layers, tenant/management-group
+  roots, or custom Azure clouds in Phase 1.
+- Code-only `azd deploy`, Core Tools publishing, workload health/authorization,
+  connector post-provisioning stages, or the create skill's fallback path.
+- Parsing Bicep source, human-readable azd logs, arbitrary shell commands, or
+  deployment error bodies to infer contribution.
+- Exact changed-resource/new-resource counting, revenue estimates, retry/failure
+  dashboards, detailed agent taxonomy, or a new dashboard deployment.
+- Refactoring existing usage hooks, adding a skill execution framework, or
+  writing lifecycle FRDs for every existing skill.
+
+## 4. Proposed design
+
+### 4.1 Measurement boundary
+
+The unit is one supported `azd up` or standalone `azd provision` invocation that
+finishes successfully and has one current successful ARM root with qualifying
+resource operations. Nested ARM deployments belong to that root and never count
+separately. Two independently successful later updates count twice.
+
+For `azd up`, wait for the entire command: successful infrastructure followed by
+failed application publishing produces no event. Standalone `azd provision`
+does not require an application publish. Runtime smoke-test failures after a
+successful command do not retroactively retract an event; runtime availability
+is not this metric.
+
+Call the collector once at the supported command's completion, not both after
+provisioning and after up, and not once in each delegating skill. Failed attempts
+do not send. This is flow discipline, not durable deduplication. Repeated
+collector calls, separate successful reprovisioning, or ambiguous delivery can
+duplicate observations; that limitation is accepted for Phase 1.
+
+If a retry skips provisioning from azd's cache, there is no new deployment
+evidence and no event. Do not search older attempts for a success. Types describe
+qualifying operations in the final observed deployment, not a union of all
+resources touched by failed attempts or a full workload inventory.
+
+### 4.2 Explicit capture and post-command collection
+
+Keep azd execution with the existing agent/deployment workflow. Add a small
+internal collector, provisionally:
+
+```text
+azure-functions-skills telemetry contribution --dir <workspace>
+```
+
+The new subcommand accepts a bounded JSON object on stdin with:
+`skill`, `operation`, `agent`, `skillsVersion`, `deploymentIdFile`, and `exitCode`.
+`operation` is `deploy` for azd up and `provision` for standalone azd provision.
+This local evidence object is NOT the outbound telemetry event. Reject unknown
+fields; do not accept a template, environment dump, arbitrary executable, or
+tool transcript. The original `telemetry` stdin contract remains unchanged.
+
+The invocation recipe belongs to the canonical skill instructions and uses the
+same package-resolution convention as existing telemetry. It must:
+
+1. Resolve telemetry preference before capture. If disabled or the collector
+   is unavailable, run the original deployment without telemetry instrumentation.
+2. Create a fresh, private temporary directory outside the project, with a new
+   deployment-ID file path for this attempt. Do not reuse a previous attempt's
+   file or commit it to the workspace.
+3. Set `AZD_DEPLOYMENT_ID_FILE` only for the azd process. Do not persist it in
+   `azure.yaml`, azd environment state, or global shell configuration.
+4. Run the original approved azd command, preserving arguments, interactive
+   behavior, and working directory. Capture its actual exit code immediately.
+5. After termination, invoke the collector with that exit code and file path.
+   The collector performs independent ARM verification, not stdout parsing.
+6. Clean up the temporary directory in the capture recipe's `finally`/trap path
+   and preserve the deployment result. The collector must not recursively delete
+   arbitrary paths supplied on stdin. Abrupt host termination can leave local
+   scratch data; no durable recovery or startup scan is added.
+
+Use native PowerShell/Bash process-scoped capture recipes, with the substantive
+validation, ARM traversal, and sender logic in TypeScript. Do not build a generic
+azd wrapper or retry engine. Capture failures must fall back to the original
+deployment before it starts, or skip collection after it finishes; never rerun
+an already-started deployment to repair telemetry.
+
+For `azure-functions-deploy`, pass the recipe as deployment context to the
+external Azure Skills executor; that executor owns command completion and the
+single collection call. The parent does not call it again. If the host or
+external skill cannot preserve this context, skip rather than guess.
+For agents, the executing agent uses the same recipe directly.
+
+Delegated capture feasibility is an M0 gate, not assumed support. Before
+Finalized status, identify a concrete host/tool handoff that can preserve the
+process-scoped variable, actual exit code, and single collector ownership without
+modifying the external plugin. If that cannot be established, obtain human
+approval to narrow AC-002 to the direct agents path and mark the Functions
+deployment path deferred. Do not claim both paths delivered from recipe fixtures
+alone; actual host coverage evidence remains an M3 acceptance requirement.
+
+This is trusted local workflow evidence, not cryptographically attested
+attribution: a caller able to invoke the internal CLI can supply misleading
+evidence. Phase 1 does not attempt anti-fraud or hostile-local-user protection.
+
+### 4.3 Exact azd evidence
+
+azd added `AZD_DEPLOYMENT_ID_FILE` in 1.25.1. During Bicep provisioning it emits
+NDJSON records with `deploymentId` and `layer`. Evidence:
+[release history](https://github.com/Azure/azure-dev/blob/5455d41a91625569182d168d5eacac2e79d02b68/cli/azd/CHANGELOG.md),
+[file implementation](https://github.com/Azure/azure-dev/blob/5455d41a91625569182d168d5eacac2e79d02b68/cli/azd/pkg/infra/provisioning/bicep/deployment_id_file.go).
+
+File creation occurs before completion and is not proof of success. The
+collector requires `exitCode = 0`, one record from a fresh attempt file, an empty
+layer name, and a supported deployment resource ID. Missing/empty evidence,
+multiple records, a named layer, unsupported azd, and malformed input all skip
+collection. Unknown additional NDJSON fields are ignored locally, never sent.
+Do not infer deployment names from timestamps, environment names, a latest
+deployment listing, or human-readable logs.
+
+Use a 64 KiB evidence-file limit and a 16 KiB stdin limit. Do not print the
+records. Although IDs are temporarily needed locally to query ARM, they are not
+analytics properties and are never forwarded to Application Insights.
+
+### 4.4 ARM verification and type extraction
+
+Use Azure CLI authentication already available to the workflow and structured
+ARM JSON responses, with a small injectable query adapter. No new Azure SDK or
+credential store is needed. Invoke Azure CLI with an argument array, not a
+shell-interpolated command. Query only the supported public Azure ARM endpoint.
+
+The adapter reads the exact root's `provisioningState`, then its deployment
+operations. Do not read deployment parameters, outputs, request/response bodies,
+or error details into the event model. CLI subprocess output is consumed locally
+and not printed by the collector. Query failure bodies are discarded, not logged.
+
+Walk subscription/resource-group nested deployment IDs returned by ARM; handle
+every page and keep an in-memory visited set. Follow only valid ARM deployment
+IDs and same-origin ARM pagination URLs. Do not query arbitrary URLs supplied
+through an evidence file or response.
+
+Include `targetResource.resourceType` for successful `Create` operations.
+ARM's provisioning-operation enum does not provide a separate `Update` value;
+do not invent one. Exclude Read, EvaluateDeploymentOutput, waiting, delete, and
+cleanup operations. For `Microsoft.Resources/deployments`, traverse the child
+and omit the wrapper type from the result. Any referenced child not confirmed
+successful makes the observation incomplete and suppresses the event.
+
+Validate type syntax and length, reject IDs/names or malformed values, normalize
+case consistently, deduplicate, and sort. Only Microsoft resource-provider
+types are included in Phase 1; unknown/custom providers are outside scope.
+The value is read from `resourceType`, never reconstructed from resource IDs.
+No qualifying types means no event.
+
+Bound collection to 15 seconds overall, 50 ARM requests, nesting depth 10, and
+100 distinct types. A denied query, unsupported child scope, exhausted bound,
+or malformed required field skips the whole observation rather than emitting
+a silently truncated breakdown. These are collector safety limits, not limits
+on what the user can deploy.
+
+Operations indicate provisioning activity, not proof that every resource
+materially changed. Idempotent ARM reapplication can count. Conversely, cached
+operations can be omitted. Do not label this set "new resources."
+
+Reference: [ARM deployment operations contract](https://learn.microsoft.com/en-us/rest/api/resources/deployment-operations/list?view=rest-resources-2025-04-01).
+
+### 4.5 Outbound event and privacy boundary
+
+Emit one event named `azure_contribution`, with exactly these application
+properties:
+
+| Property | Source / allowed values |
+| --- | --- |
+| `skill` | Executing canonical skill allowlist: deploy or agents/hosted-skills, depending on the merged rename |
+| `operation` | `deploy` or `provision` |
+| `result` | Constant `success`, constructed only after verification |
+| `resourceTypes` | JSON-encoded array of normalized resource types; string-valued Application Insights custom property |
+| `deploymentKind` | Fixed mapping: deploy skill -> `function-app`; agents/hosted-skills -> `hosted-agent` |
+| `agent` | Existing normalized client categories, plus explicit `codex`; otherwise `unknown` |
+| `skillsVersion` | Version of executing installed Skills assets, or `unknown` |
+
+Example of the actual string-valued properties contract:
+
+```json
+{
+  "name": "azure_contribution",
+  "properties": {
+    "skill": "azure-functions-deploy",
+    "operation": "deploy",
+    "result": "success",
+    "resourceTypes": "[\"microsoft.storage/storageaccounts\",\"microsoft.web/sites\"]",
+    "deploymentKind": "function-app",
+    "agent": "copilot-cli",
+    "skillsVersion": "unknown"
+  }
+}
+```
+
+Use existing installed metadata when available; do not overhaul distribution
+only to eliminate `unknown`. A newer npx sender version is not the Skills
+version. Derive deploymentKind in code rather than accepting a free-text label.
+
+The telemetry boundary constructs a new allowlisted object; never spread local
+evidence or ARM responses into it. No subscription/tenant/resource/deployment
+IDs, names, user/email/session IDs, absolute paths, environment values, source,
+prompts, endpoints, keys, logs, or errors are sent, even hashed.
+
+Envelope-level privacy is mandatory, not deferred. The currently pinned
+Application Insights 1.8.10 [Context implementation](https://github.com/microsoft/ApplicationInsights-node.js/blob/1.8.10/Library/Context.ts)
+adds the hostname as cloudRoleInstance. Suppress customer/host-derived tags and
+automatic collection; permit only transport-required fields, event timestamp,
+and fixed/nonidentifying SDK metadata. Do not inherit operation/session/user
+correlation from usage telemetry. Cover the full serialized HTTP envelope, not
+just trackEvent arguments. Remove hostname context in the shared client without
+redesigning existing usage properties. This intentionally removes hostname from
+existing usage envelopes too; AC-001 preserves their event names and application
+properties, not that privacy-sensitive SDK tag. Recheck this against PR #240 if
+it merges.
+
+This contract governs application telemetry content. HTTPS necessarily exposes
+the client's network address to the receiving service; do not promise anonymous
+transport. Document the existing ingestion service's applicable privacy policy
+and IP handling rather than claiming that categorical properties eliminate all
+service-side metadata.
+
+### 4.6 Preferences, failures, and transport
+
+Reuse the two existing opt-out environment variables. Resolve the applicable
+installed plugin/workspace `telemetry.config.json` using the executing host and
+asset location, not arbitrary ancestor scanning. Both capture recipe and
+collector check preference. If its location or contents cannot be safely
+resolved, skip collection rather than bypass an opt-out.
+
+The collector returns a local categorical result: `sent`, `disabled`,
+`not-configured`, `skipped`, or `failed`, with a fixed reason code when relevant.
+Neither result nor diagnostics includes evidence values or raw exception text.
+Do not introduce another diagnostics subsystem; use PR #235's bounded diagnostics
+if available, otherwise a short local categorical notice.
+
+The existing sender owns delivery timeout and any bounded transport retry.
+There is no contribution-specific retry or persistent queue. A telemetry
+failure cannot reclassify the deployment, prompt a cloud login, elevate Azure
+permissions, or trigger reprovisioning. If ARM read access is absent, skip.
+
+### 4.7 Module ownership and reporting
+
+| Surface | Planned responsibility |
+| --- | --- |
+| `src/telemetry/contribution.ts` (new) | Local evidence validation, success policy, normalized event construction |
+| `src/telemetry/arm-deployments.ts` (new) | Injectable bounded structured ARM query/traversal |
+| Existing sender and `src/telemetry/index.ts` | Reuse transport and privacy-safe client; keep raw ARM evidence out of the package's telemetry-event API |
+| `bin/azure-functions-skills.js` | Small internal subcommand dispatcher; no deployment orchestration |
+| Two canonical skill instructions / one shared reference | Capture recipe and delegation ownership, not generic PostToolUse detection |
+
+Report event count over time and by skill/deploymentKind. Expand resourceTypes
+only for the breakdown; expanding the array must not inflate the headline count.
+A type's count means "observations containing this type," not resource count.
+Document disabled/unsupported paths and delivery loss. Existing usage counts
+can be displayed alongside contributions, but do not compute an exact funnel
+or attempt denominator from success-only events.
+
+### Delivery checkpoints
+
+| Slice | Requirements / planned work | Review boundary |
+| --- | --- | --- |
+| M0: Design approval | Reconcile #244, number allocation, related PRs, and open questions; resolve independent review and delegated capture feasibility | Approve a concrete delegation contract or explicitly defer that path, then obtain human approval of the identified revision; no implementation before Finalized |
+| M1: Event and privacy contract | AC-001, AC-006, AC-007, AC-009; tests first, narrow sender/schema changes | Inspect an entirely local captured envelope and confirm compatibility/privacy scope |
+| M2: Collector | AC-003 through AC-005, AC-008, AC-010; fixtures first, evidence/ARM adapter/CLI | Review counting, bounds, skip behavior, and lack of durable tracking |
+| M3: Skill wiring and documentation | AC-002, AC-007, AC-009 through AC-011; recipe, delegation, local install/plugin assets | Review both host/script paths, limitations, and requirement-linked acceptance evidence |
+
+Use one primary implementer and separate review at these checkpoints. Prefer one
+small implementation PR if these slices remain reviewable. If telemetry
+compatibility or delegation requires a larger framework, stop and revise scope
+instead of importing that framework into Phase 1.
+
+Live Azure validation is a separate optional authorization gate: reviewed code,
+subscription/identity, budget, repetition count, resource ownership, and cleanup
+must be approved. No deployment, Vally evaluation, production event, dashboard,
+or Azure resource is created by this documentation task.
+
+### Open questions
+
+- Maintainer: confirm that narrow invocation instrumentation is owned by this
+  shared-infrastructure FRD under the final #244 policy. It does not redefine
+  either skill's purpose or general deployment contract; if lifecycle FRDs are
+  required for the tool-chain addition, link those before implementing M3.
+- Maintainer: approve the draft's single-layer azd boundary and skip-on-incomplete
+  resource breakdown. These are proposed implementation details, not an already
+  approved contract.
+- Implementer/reviewer at M0: recheck which of #218, #235, and #240 have merged,
+  select the concrete canonical paths and metadata/preference resolver, and
+  identify how the direct and delegated execution flows preserve capture context.
+  The delegated flow is the explicit M0 gate in section 4.2; if it cannot do this,
+  revise AC-002 with human approval rather than promising unsupported coverage.
+
+## 5. Decisions log
+
+| ID | Decision / options | Choice and rationale | Decided by | Date |
+| --- | --- | --- | --- | --- |
+| D-001 | Overview versus exact accounting | User accepted a small Phase 1 focused on contribution trends; defer strict deduplication and broad coverage. This is direction approval, not FRD sign-off. | User, conversation scope agreement | 2026-09-08 |
+| D-002 | Existing transport versus new service | Reuse Application Insights sender; no SDK migration, backend, or new credential. | Copilot (proposal) | 2026-09-08 |
+| D-003 | Generic hook inference, persistent azd hooks, wrapper engine, or explicit collection | Explicit fresh-file capture plus post-command collector; preserve deployment ownership and avoid command/log parsing. | Copilot (proposal) | 2026-09-08 |
+| D-004 | Global workload identity versus per-command observation | No durable ID; one successful supported invocation is one observation. Failed attempts emit nothing; exact-once remains out of scope. | Copilot (proposal) | 2026-09-08 |
+| D-005 | Provision success alone versus full azd up result | Require full up success for up, provision success for standalone provision; always verify current ARM evidence. | Copilot (proposal) | 2026-09-08 |
+| D-006 | Top-level-only versus nested resource types | Keep bounded nested traversal because Bicep modules are normal, not an optional precision enhancement. | Copilot (proposal) | 2026-09-08 |
+| D-007 | Properties-only filtering versus full envelope privacy | Full outbound-envelope filtering is mandatory even in the small PR. | Copilot (proposal) | 2026-09-08 |
+| D-008 | Reuse 0001/0002 versus next unused number | Use FRD-0003 after checking open PR filenames; leave the existing 0001 collision to its owners. | Copilot (allocation proposal) | 2026-09-08 |
+| D-009 | Architecture review: compatibility and delegated feasibility | Clarify that hostname removal intentionally affects SDK envelopes, not usage application properties; make delegated capture an M0 gate with human-approved scope reduction if needed. | Copilot (revision 2 proposal, responding to independent review) | 2026-09-08 |
+
+## 6. Test plan
+
+All entries are planned, not completed acceptance evidence. Use existing Vitest,
+CLI fixture, local HTTP capture, and isolated install/update infrastructure.
+
+| Requirement | Test / fixture / experiment | Expected evidence |
+| --- | --- | --- |
+| AC-001 | Extend `tests/telemetry.test.ts` and `tests/simplified-cli.test.ts` | New event exact shape; unchanged legacy stdin/event behavior |
+| AC-002, AC-011 | Skill contract fixtures and isolated capture recipes with fake azd/az/package commands | Only supported explicit entry points collect; external delegation has one owner; no customer azure.yaml modifications |
+| AC-003 | New contribution fixtures: exit failure/cancel, ARM Running/Failed, missing/fresh empty/stale-looking file, preview, publish failure | Zero contribution sends and no fallback to deployment history |
+| AC-004 | Failed attempt then successful attempt; nested modules; deliberate double collector call | 0 then 1 for normal retry; one event for nested modules; duplicate-call limitation documented, not falsely claimed solved |
+| AC-005 | New ARM fixtures: subscription root, RG root, nested modules/pages, Create/Read/Delete, malformed type, repeated type, unsupported child/layer, empty type set | Complete normalized type set or explicit skip, never wrapper-type counting or partial silent success |
+| AC-005, AC-008 | Deadline/request/depth/type caps, cycle, denied read, invalid pagination origin | Bounded termination, no arbitrary URL request, no raw diagnostic data |
+| AC-006 | Local HTTP server captures/decompresses the entire serialized SDK request; seed evidence with sentinel names/secrets | No forbidden sentinel, hostname, environment-derived tag, source, endpoint, or correlation identity anywhere in the envelope |
+| AC-006, AC-009 | Invalid skill/client/version, unknown fields, oversized input/type set | Reject or normalize per contract; no free-text outbound dimensions |
+| AC-007 | Both environment opt-outs; each host's local and plugin config; missing/malformed preference context | No additional ARM read or send when disabled/unresolved; original deployment still runs |
+| AC-008 | Fake azd exit codes, missing collector, query/send failures, cleanup failure, interrupted capture | No cloud retry caused by telemetry; preserve original deployment result; delete only caller-owned temporary data when possible |
+| AC-009 | Installed version differs from npx sender; missing metadata; rename variant | Correct asset version or unknown; one canonical skill name, no double emission |
+| AC-010 | Documented query examples against a small synthetic dataset | Resource expansion does not change headline event count; no success-rate or full-inventory claim |
+| AC-011 | Canonical payload generation and isolated workspace CLI integration | No durable ledger, global hook interception, Azure tags, or new service introduced |
+
+At implementation time, run the targeted tests first, then the repository's
+required lint/typecheck/tests and canonical build/payload verification before
+commit. Use isolated workspaces for CLI flows. Real-agent/live evaluation, if
+needed to establish delegation behavior beyond fixtures, must use reviewed code
+and the required reviewer gate; mocks alone are not evidence of live coverage.
+Record any unevaluated host as unverified, not supported by assertion.
+
+## 7. Docs impact
+
+This documentation change adds only this FRD and its provisional index.
+Do not copy or modify #244's governance files in this branch.
+
+Implementation would update:
+
+- `README.md`, Telemetry: new categorical event, opt-out, local transient ARM
+  identifiers, contribution scope, IP/service metadata caveat, and best-effort limits.
+- `docs/internal/telemetry-release.md`: actual event/property contract and
+  simple reporting examples; preserve the existing release destination model.
+- `docs/cli-reference.md`: clarify internal telemetry behavior and privacy
+  without advertising the collector as a supported deployment command.
+- `templates/skills/azure-functions-deploy/SKILL.md`: delegation capture context
+  and a single post-command collection owner.
+- `templates/skills/azure-functions-agents/SKILL.md` and its
+  `references/infra-and-deployment.md`, or the renamed equivalents from #218:
+  direct capture flow and explicit exclusions for connector follow-up work.
+- `templates/skills/azure-functions-common/references/contribution-telemetry.md`
+  (new): shared small PowerShell/Bash recipes and failure/opt-out behavior.
+- `docs/frds/README.md` and this FRD: synchronized lifecycle, reviews, decision
+  changes, and requirement-linked implementation evidence.
+
+Regenerate derived plugin payloads with `npm run build:plugin-payload` if
+canonical skills change; never hand-edit generated copies. Do not modify
+`templates/agents/AGENTS.md`. Changing skill content later requires the
+applicable skill-authoring instructions; this draft does not execute the skills.
+
+## 8. Status & sign-off
+
+| Item | Evidence |
+| --- | --- |
+| Independent architecture review | Claude Opus 4.8 read-only review of revision 1 on 2026-09-08; two clarification findings addressed by the author in revision 2 below |
+| Human approval | Pending; prior scope agreement is not approval of this written revision |
+| Approved revision and scope | Pending; record commit SHA or content hash after explicit approval |
+| Approval reference and date | Pending |
+| Governance integration | Pending PR #244 and reconciliation of its final process |
+| Number allocation | FRD-0003 unused among remote main and all open PRs checked on 2026-09-08; recheck before publication/merge |
+| Implementation reference | Not started; explicitly excluded from this task |
+| Acceptance evidence | Not collected; section 6 contains planned evidence only |
+| Live execution authorization | Not requested or granted |
+
+### Independent review disposition
+
+The reviewer found the direct capture/collector split appropriately small and
+recommended human design review after two clarifications. Revision 2 addresses:
+
+| Finding | Resolution |
+| --- | --- |
+| AC-001 could be read to prohibit shared hostname suppression | AC-001 and section 4.5 explicitly distinguish preserved application properties from intentionally removed SDK hostname context. |
+| Delegated capture was only a general open question | Section 4.2 and M0 now require a concrete delegation contract or an explicitly approved narrowing of AC-002 before Finalized status. |
+
+This records independent advice and the author's disposition, not reviewer or
+human approval of revision 2. M0 questions and human sign-off remain pending.
+
+Status remains Draft. Resolve open questions and review findings, identify the
+reviewed revision, obtain explicit human sign-off, and update this document and
+the index to Finalized before implementing. This proposal does not authorize
+live resources, production telemetry sends, or paid evaluations.

--- a/docs/frds/0003-azure-contribution-telemetry.md
+++ b/docs/frds/0003-azure-contribution-telemetry.md
@@ -453,8 +453,8 @@ applicable skill-authoring instructions; this draft does not execute the skills.
 | Approval reference and date | Pending |
 | Governance integration | Follows merged FRD governance (`a430a5b`); index row added in `docs/frds/README.md` |
 | Number allocation | FRD-0003 unused among remote main and all open PRs checked on 2026-09-08; rechecked against the merged governance index on 2026-09-10 |
-| Implementation reference | Not started; explicitly excluded from this task |
-| Acceptance evidence | Not collected; section 6 contains planned evidence only |
+| Implementation reference | Phase 1 implemented as stacked draft PRs at the user's direction while this document is still Draft: #259 (telemetry core) and #260 (skill and docs wiring), stacked above this document's PR #247 |
+| Acceptance evidence | Partial: automated coverage from section 6 exists in the implementation PRs and passes locally. No live Azure deployment or production telemetry send has been exercised. |
 | Live execution authorization | Not requested or granted |
 
 ### Independent review disposition
@@ -485,7 +485,10 @@ weakens no acceptance criterion. It has not been re-reviewed independently.
 This records independent advice and the author's disposition, not reviewer or
 human approval of revision 2. M0 questions and human sign-off remain pending.
 
-Status remains Draft. Resolve open questions and review findings, identify the
-reviewed revision, obtain explicit human sign-off, and update this document and
-the index to Finalized before implementing. This proposal does not authorize
-live resources, production telemetry sends, or paid evaluations.
+Status remains Draft, deliberately: the user chose to keep it Draft because
+review may still change the content. Implementation proceeded in parallel as
+draft PRs rather than waiting, so the sign-off gate applies before merge rather
+than before writing code. Resolve open questions and review findings, identify
+the reviewed revision, obtain explicit human sign-off, and update this document
+and the index to Finalized before merging the stack. This proposal does not
+authorize live resources, production telemetry sends, or paid evaluations.

--- a/docs/frds/0003-azure-contribution-telemetry.md
+++ b/docs/frds/0003-azure-contribution-telemetry.md
@@ -3,11 +3,11 @@
 | Metadata | Value |
 | --- | --- |
 | Status | Draft |
-| Revision | 3 |
+| Revision | 4 |
 | Created | 2026-09-08 |
-| Updated | 2026-09-09 |
+| Updated | 2026-09-10 |
 | Author | GitHub Copilot, based on the user's requirements and scope feedback |
-| Depends on | [FRD governance, PR #244](https://github.com/Azure/azure-functions-skills/pull/244), revision `aff24690ae7dae787ad521b4bce718121647ffa7` |
+| Depends on | [FRD governance](README.md), merged as `a430a5b` (PR #244) |
 | Component | Shared infrastructure: contribution telemetry and narrow skill integration |
 
 ## 1. Summary
@@ -39,7 +39,7 @@ Current repository evidence:
 | [Hidden CLI](../../bin/azure-functions-skills.js) | `telemetry` reads one sanitized JSON event from stdin; reuse this command family without changing that contract. |
 | [Hook scripts](../../templates/hooks/scripts) | PostToolUse records skill reads/invocations and MCP usage, not deployment success. Do not add shell-output inference here. |
 | [Deployment skill](../../templates/skills/azure-functions-deploy/SKILL.md) | Delegates to external `azure-prepare`, `azure-validate`, and `azure-deploy`. This repository does not control that deployment engine. |
-| [Agents skill](../../templates/skills/azure-functions-agents/SKILL.md) | Uses azd directly; integrate separately with the same collector. |
+| [Hosted skills skill](../../templates/skills/azure-functions-hosted-skills/SKILL.md) | Uses azd directly; integrate separately with the same collector. |
 | [Workspace preferences](../../src/setup/workspace-assets.ts) | Local installs retain per-host telemetry opt-out settings, in addition to environment-variable opt-out. |
 | [Release transport](../internal/telemetry-release.md) | The existing release pipeline injects the destination into the npm runtime. No new destination, credential, or service is needed. |
 
@@ -48,13 +48,14 @@ produce one event, with a resource-type set such as Functions, Storage, and
 Application Insights. Counting each resource, nested deployment, or failed
 attempt would obscure the management question.
 
-### Related unmerged work
+### Related work
 
 | PR | Integration rule |
 | --- | --- |
-| [#235: telemetry reliability](https://github.com/Azure/azure-functions-skills/pull/235) | Reuse its sender, diagnostics, package resolution, and version metadata if merged. Do not reproduce its delivery retry, doctor, canary, or hook overhaul here. |
-| [#240: Application Insights SDK update](https://github.com/Azure/azure-functions-skills/pull/240) | Do not bundle an SDK migration. Verify the actual outbound envelope against whichever version is merged. |
-| [#218: hosted skills rename](https://github.com/Azure/azure-functions-skills/pull/218) | Current canonical name is `azure-functions-agents`; if the rename lands, integrate `azure-functions-hosted-skills` instead and update paths/allowlists. Never emit both for one operation. |
+| [#244: FRD governance](https://github.com/Azure/azure-functions-skills/pull/244) | Merged as `a430a5b`. This document follows its index, lifecycle, and sign-off rules; do not restate or fork that process here. |
+| [#218: hosted skills rename](https://github.com/Azure/azure-functions-skills/pull/218) | Merged as `b173701`. The canonical name is `azure-functions-hosted-skills`; all paths, allowlists, and `deploymentKind` mappings use it. Never emit both names for one operation. |
+| [#235: telemetry reliability](https://github.com/Azure/azure-functions-skills/pull/235) | Still open. Reuse its sender, diagnostics, package resolution, and version metadata if merged. Do not reproduce its delivery retry, doctor, canary, or hook overhaul here. |
+| [#240: Application Insights SDK update](https://github.com/Azure/azure-functions-skills/pull/240) | Still open. Do not bundle an SDK migration. Verify the actual outbound envelope against whichever version is merged. |
 | [#241](https://github.com/Azure/azure-functions-skills/pull/241), [#245](https://github.com/Azure/azure-functions-skills/pull/245) | Reserve FRD numbers 0001 and 0002. No dependency on their workflow runner, evaluation framework, or telemetry events. |
 
 ## 3. Goals / non-goals
@@ -242,11 +243,11 @@ properties:
 
 | Property | Source / allowed values |
 | --- | --- |
-| `skill` | Executing canonical skill allowlist: deploy or agents/hosted-skills, depending on the merged rename |
+| `skill` | Executing canonical skill allowlist: `azure-functions-deploy` or `azure-functions-hosted-skills` |
 | `operation` | `deploy` or `provision` |
 | `result` | Constant `success`, constructed only after verification |
 | `resourceTypes` | JSON-encoded array of normalized resource types; string-valued Application Insights custom property |
-| `deploymentKind` | Fixed mapping: deploy skill -> `function-app`; agents/hosted-skills -> `hosted-agent` |
+| `deploymentKind` | Fixed mapping: `azure-functions-deploy` -> `function-app`; `azure-functions-hosted-skills` -> `hosted-agent` |
 | `agent` | Existing normalized client categories, plus explicit `codex`; otherwise `unknown` |
 | `skillsVersion` | Version of executing installed Skills assets, or `unknown` |
 
@@ -334,7 +335,7 @@ or attempt denominator from success-only events.
 
 | Slice | Requirements / planned work | Review boundary |
 | --- | --- | --- |
-| M0: Design approval | Reconcile #244, number allocation, related PRs, and open questions; resolve independent review findings | Obtain human approval of the identified revision; no implementation before Finalized |
+| M0: Design approval | Reconcile governance, number allocation, related PRs, and open questions; resolve independent review findings | Obtain human approval of the identified revision; no implementation before Finalized |
 | M1: Event and privacy contract | AC-001, AC-006, AC-007, AC-009; tests first, narrow sender/schema changes | Inspect an entirely local captured envelope and confirm compatibility/privacy scope |
 | M2: Collector | AC-003 through AC-005, AC-008, AC-010; fixtures first, selection/ARM adapter/CLI | Review counting, bounds, skip behavior, and lack of durable tracking |
 | M3: Skill wiring and documentation | AC-002, AC-007, AC-009 through AC-011; post-success step, delegation ownership, local install/plugin assets | Review both skill paths, limitations, and requirement-linked acceptance evidence |
@@ -352,14 +353,15 @@ or Azure resource is created by this documentation task.
 ### Open questions
 
 - Maintainer: confirm that narrow invocation instrumentation is owned by this
-  shared-infrastructure FRD under the final #244 policy. It does not redefine
+  shared-infrastructure FRD under the merged governance policy. It does not redefine
   either skill's purpose or general deployment contract; if lifecycle FRDs are
   required for the tool-chain addition, link those before implementing M3.
 - Maintainer: approve the draft's single-layer azd boundary and skip-on-incomplete
   resource breakdown. These are proposed implementation details, not an already
   approved contract.
-- Implementer/reviewer at M0: recheck which of #218, #235, and #240 have merged,
-  then select the concrete canonical paths and metadata/preference resolver.
+- Implementer/reviewer at M0: #218 and #244 have merged and revision 4 reflects
+  them; recheck #235 and #240 before publication and re-verify the outbound
+  envelope against whichever Application Insights SDK version is then in the tree.
 
 ## 5. Decisions log
 
@@ -375,6 +377,7 @@ or Azure resource is created by this documentation task.
 | D-008 | Reuse 0001/0002 versus next unused number | Use FRD-0003 after checking open PR filenames; leave the existing 0001 collision to its owners. | Copilot (allocation proposal) | 2026-09-08 |
 | D-009 | Architecture review: compatibility and delegated feasibility | Clarify that hostname removal intentionally affects SDK envelopes, not usage application properties; make delegated capture an M0 gate with human-approved scope reduction if needed. | Copilot (revision 2 proposal, responding to independent review) | 2026-09-08 |
 | D-010 | Exact per-attempt capture (`AZD_DEPLOYMENT_ID_FILE` recipe) versus post-success ARM deployment selection | Choose post-success selection. The recipe required owning the azd process, which the delegating deploy skill cannot do, so it would have covered only one skill while adding a wrapper, temporary files, and exit-code plumbing. Selection covers both skills with a one-line call and accepts bounded misattribution of the resource-type breakdown, consistent with the "observed", non-exact reporting label. Exact capture is deferred to Phase 2. | User (scope decision), Copilot (revision 3 proposal) | 2026-09-09 |
+| D-011 | Rebase onto merged `main` versus keep the pre-merge naming | Rebase and adopt the merged state. PR #244's governance index replaces the provisional index, and PR #218's rename makes `azure-functions-hosted-skills` the only canonical name. Keeping both names or a forked index would create ambiguity in the allowlist and `deploymentKind` mapping. | Copilot (revision 4 maintenance) | 2026-09-10 |
 
 ## 6. Test plan
 
@@ -406,8 +409,8 @@ Record any unevaluated host as unverified, not supported by assertion.
 
 ## 7. Docs impact
 
-This documentation change adds only this FRD and its provisional index.
-Do not copy or modify #244's governance files in this branch.
+This documentation change adds this FRD and one index row to the merged
+governance index. Do not otherwise modify the governance files.
 
 Implementation would update:
 
@@ -419,10 +422,9 @@ Implementation would update:
   without advertising the collector as a supported deployment command.
 - `templates/skills/azure-functions-deploy/SKILL.md`: a single post-success
   collection owner after the delegated deployment completes.
-- `templates/skills/azure-functions-agents/SKILL.md` and its
-  `references/infra-and-deployment.md`, or the renamed equivalents from #218:
-  the same post-success collection step and explicit exclusions for connector
-  follow-up work.
+- `templates/skills/azure-functions-hosted-skills/SKILL.md` and its
+  `references/infra-and-deployment.md`: the same post-success collection step and
+  explicit exclusions for connector follow-up work.
 - `docs/frds/README.md` and this FRD: synchronized lifecycle, reviews, decision
   changes, and requirement-linked implementation evidence.
 
@@ -439,8 +441,8 @@ applicable skill-authoring instructions; this draft does not execute the skills.
 | Human approval | Pending; prior scope agreement is not approval of this written revision |
 | Approved revision and scope | Pending; record commit SHA or content hash after explicit approval |
 | Approval reference and date | Pending |
-| Governance integration | Pending PR #244 and reconciliation of its final process |
-| Number allocation | FRD-0003 unused among remote main and all open PRs checked on 2026-09-08; recheck before publication/merge |
+| Governance integration | Follows merged FRD governance (`a430a5b`); index row added in `docs/frds/README.md` |
+| Number allocation | FRD-0003 unused among remote main and all open PRs checked on 2026-09-08; rechecked against the merged governance index on 2026-09-10 |
 | Implementation reference | Not started; explicitly excluded from this task |
 | Acceptance evidence | Not collected; section 6 contains planned evidence only |
 | Live execution authorization | Not requested or granted |
@@ -459,6 +461,11 @@ Revision 3 records the user's scope decision to prefer breadth and simplicity
 over exact per-attempt attribution. It changes sections 4.1 through 4.4, AC-003,
 AC-010, D-003, the M0 boundary, the open questions, the test plan, and the docs
 impact list. It has not been re-reviewed independently.
+
+Revision 4 rebases the document onto merged `main`: it adopts the merged FRD
+governance index instead of a provisional one and replaces every
+`azure-functions-agents` reference with `azure-functions-hosted-skills` (D-011).
+It has not been re-reviewed independently.
 
 This records independent advice and the author's disposition, not reviewer or
 human approval of revision 2. M0 questions and human sign-off remain pending.

--- a/docs/frds/0003-azure-contribution-telemetry.md
+++ b/docs/frds/0003-azure-contribution-telemetry.md
@@ -3,7 +3,7 @@
 | Metadata | Value |
 | --- | --- |
 | Status | Draft |
-| Revision | 5 |
+| Revision | 6 |
 | Created | 2026-09-08 |
 | Updated | 2026-09-10 |
 | Author | GitHub Copilot, based on the user's requirements and scope feedback |
@@ -66,7 +66,7 @@ attempt would obscure the management question.
 | --- | --- | --- |
 | AC-001 | Add one contribution event while preserving existing usage event names and application properties. | One accepted contribution emits `azure_contribution`; existing custom properties remain compatible. Removing hostname-derived SDK envelope context is an intentional privacy change shared by both event paths. |
 | AC-002 | Limit attribution to the two supported canonical skills and azd/Bicep provisioning. | Delegated Functions and direct agents paths can call the collector; plain CLI create, Terraform, and unrelated skill use do not emit. |
-| AC-003 | Require successful command completion and current ARM deployment success. | Failed/cancelled commands, nonterminal/failed ARM states, no qualifying recent successful deployment, preview, validation, and code-only deploy produce no event. |
+| AC-003 | Require successful command completion and current ARM deployment success. | Failed/cancelled commands, nonterminal/failed ARM states, a named deployment that is absent or outside the recency window, preview, validation, and code-only deploy produce no event. |
 | AC-004 | Count one supported successful command, not its resources or modules. | A single-layer azd invocation with multiple nested modules emits at most one event per collector call; failed attempts emit zero. |
 | AC-005 | Collect types from the exact ARM deployment and its nested operations. | Subscription and resource-group roots, pagination, and nested modules yield a sorted, distinct resource-type set, without deployment-wrapper types. |
 | AC-006 | Send only the categorical event contract and nonidentifying SDK metadata. | The captured HTTP envelope contains no customer names, identifiers, secrets, logs, source, host identity, or inherited correlation identifiers. |
@@ -131,10 +131,14 @@ azure-functions-skills telemetry contribution
 ```
 
 The subcommand accepts a bounded JSON object on stdin, limited to 16 KiB, with
-`skill`, `operation`, `agent`, `skillsVersion`, and optional `environmentName`.
+`skill`, `operation`, `agent`, `skillsVersion`, and `environmentName`.
 `operation` is `deploy` for `azd up` and `provision` for standalone
-`azd provision`. `environmentName` is the local azd environment name, used only
-to choose which deployment to inspect. Reject unknown fields; do not accept
+`azd provision`. `environmentName` is the local azd environment name. It is
+required for a usable observation because it identifies the deployment to
+inspect (section 4.3), and that requirement is enforced at collection time
+rather than at parse time: input without it parses, then skips before any Azure
+query, so the caller gets the precise skip reason instead of a generic failure.
+Reject unknown fields; do not accept
 templates, environment dumps, transcripts, tool output, or executable paths.
 The original `telemetry` stdin contract stays unchanged.
 
@@ -168,24 +172,39 @@ anti-fraud or hostile-local-user protection.
 
 ### 4.3 Deployment selection
 
-The collector chooses the deployment to inspect from Azure Resource Manager
+The collector identifies the deployment to inspect from Azure Resource Manager
 itself, reusing the Azure CLI authentication already available to the workflow:
 
-1. List deployments at the current subscription scope through a structured,
-   injectable query adapter. Never parse azd or CLI human-readable output.
-2. Keep only entries whose `provisioningState` is `Succeeded` and whose
+1. Require `environmentName`. azd derives its subscription-scope deployment name
+   from the environment name, so the name is the deployment identifier. Validate
+   it against the ARM deployment-name shape before use. A missing or invalid
+   value skips the observation before any Azure query is issued.
+2. Look the deployment up directly by that name at the current subscription
+   scope through a structured, injectable query adapter. Never list the
+   subscription's deployment history, and never parse azd or CLI human-readable
+   output.
+3. Accept the deployment only when `provisioningState` is `Succeeded` and its
    completion timestamp falls inside a bounded recency window of 30 minutes.
-3. If `environmentName` is supplied, prefer entries whose deployment name
-   contains it; azd derives its subscription-scope deployment name from the
-   environment name.
-4. Select the single most recent remaining entry. No candidate means no event.
+   Anything else means no event.
 
-Accepted imprecision: an unrelated successful deployment running concurrently in
-the same subscription can be selected, and a deployment that finished before the
-window opened is skipped. Both affect which resource-type breakdown is attached
-to an observation rather than whether Skills-driven deployment activity is
-broadly visible, which is why section 1 uses an "observed", non-exact reporting
-label. Exact per-attempt attribution is a deferred Phase 2 option.
+Lookup by name replaced an earlier design that listed subscription deployments
+and selected the most recent successful entry. Live measurement showed the
+listing approach is not merely slow but incorrect: ARM does not return
+deployments newest-first, and `$top` acts as a per-page hint rather than a global
+cap, so a bounded first page can omit the deployment that just completed.
+Exhaustive pagination is not a viable substitute. See D-013.
+
+Accepted imprecision: re-running the collector after a later deployment reusing
+the same environment name refers to the newest deployment of that name, and a
+deployment that finished before the window opened is skipped. Both affect which
+resource-type breakdown is attached to an observation rather than whether
+Skills-driven deployment activity is broadly visible, which is why section 1 uses
+an "observed", non-exact reporting label. Exact per-attempt attribution is a
+deferred Phase 2 option.
+
+Scope limitation: the lookup resolves subscription-scope deployments, which is
+what `azd provision` creates. A resource-group-scope deployment is not found and
+is skipped rather than misattributed.
 
 Deployment names, deployment IDs, subscription, and resource-group values are
 needed locally to run these queries. They are never analytics properties, are
@@ -224,8 +243,9 @@ types are included in Phase 1; unknown/custom providers are outside scope.
 The value is read from `resourceType`, never reconstructed from resource IDs.
 No qualifying types means no event.
 
-Bound collection to 15 seconds overall, 50 ARM requests, nesting depth 10, and
-100 distinct types. The request bound counts every ARM HTTP request, including
+Bound collection to 20 seconds overall, 50 ARM requests, nesting depth 10, and
+100 distinct types. The time bound is injectable so it can be tightened in tests
+and by callers. The request bound counts every ARM HTTP request, including
 each pagination page, not one per deployment. The time bound covers subprocess
 execution, so a stalled CLI invocation must be terminated rather than awaited.
 A denied query, unsupported child scope, exhausted bound, or malformed required
@@ -389,16 +409,20 @@ or Azure resource is created by this documentation task.
 | D-010 | Exact per-attempt capture (`AZD_DEPLOYMENT_ID_FILE` recipe) versus post-success ARM deployment selection | Choose post-success selection. The recipe required owning the azd process, which the delegating deploy skill cannot do, so it would have covered only one skill while adding a wrapper, temporary files, and exit-code plumbing. Selection covers both skills with a one-line call and accepts bounded misattribution of the resource-type breakdown, consistent with the "observed", non-exact reporting label. Exact capture is deferred to Phase 2. | User (scope decision), Copilot (revision 3 proposal) | 2026-09-09 |
 | D-011 | Rebase onto merged `main` versus keep the pre-merge naming | Rebase and adopt the merged state. PR #244's governance index replaces the provisional index, and PR #218's rename makes `azure-functions-hosted-skills` the only canonical name. Keeping both names or a forked index would create ambiguity in the allowlist and `deploymentKind` mapping. | Copilot (revision 4 maintenance) | 2026-09-10 |
 | D-012 | Disposition of the independent implementation review | Fix all seven findings in the implementation rather than relax the specification. Six were drifts from contract text this document already stated (fail-closed bounds, fail-closed malformed fields, derived deploymentKind, opt-out that must not be bypassed, subprocess time bound). Only the envelope allowlist needed a specification clarification, because removing four known SDK tags was verified insufficient on Application Insights 1.8.10. Sections 4.4 and 4.5 are clarified accordingly; no acceptance criterion is weakened. | Copilot (revision 5), GPT-5.6 independent review | 2026-09-10 |
+| D-013 | Deployment selection by recency scan versus lookup by name | Switch to direct lookup by deployment name. A live run against a real subscription showed the recency scan is incorrect, not just slow: ARM does not return deployments newest-first (a deployment completed seconds earlier appeared at index 51 of the first page), and `$top` behaves as a per-page hint rather than a global cap (`$top=100` returned 9 entries and excluded that deployment), so a bounded scan silently drops real contributions. Exhaustive pagination measured 58 s over 20 pages for 151 deployments and cannot fit any acceptable bound, whereas lookup by name is one request at 2.4 s and does not degrade as history grows. The cost is that `environmentName` becomes required and resource-group-scope deployments are out of scope; both are acceptable because azd names its subscription-scope deployment after the environment. | Copilot (revision 6), live execution evidence | 2026-09-10 |
+| D-014 | Disposition of defects found only by live execution | Fix in the implementation; keep the specification's intent unchanged. Live execution exposed three defects that injected-dependency tests structurally could not catch: the Azure CLI could not be spawned at all on Windows (`execFile` does not resolve PATHEXT, and Node refuses to spawn `.cmd` without a shell), a successful Application Insights ingestion response was classified as a delivery failure in a helper shared with the pre-existing usage path, and the deployment selection defect recorded in D-013. Section 4.4's time bound moves from 15 s to 20 s and becomes injectable. This is why section 8 now requires live-execution evidence, not only automated tests, before sign-off. | Copilot (revision 6), live execution evidence | 2026-09-10 |
 ## 6. Test plan
 
-All entries are planned, not completed acceptance evidence. Use existing Vitest,
+All entries were planned before implementation. Automated entries now exist and
+pass in the implementation PRs, and a live execution has been performed; see
+section 8. Use existing Vitest,
 CLI fixture, local HTTP capture, and isolated install/update infrastructure.
 
 | Requirement | Test / fixture / experiment | Expected evidence |
 | --- | --- | --- |
 | AC-001 | Extend `tests/telemetry.test.ts` and `tests/simplified-cli.test.ts` | New event exact shape; unchanged legacy stdin/event behavior |
 | AC-002, AC-011 | Skill contract fixtures and isolated CLI invocation with a fake ARM query adapter | Only supported explicit entry points collect; external delegation has one owner; no customer `azure.yaml` modifications |
-| AC-003 | New contribution fixtures: no recent successful deployment, ARM Running/Failed, stale timestamp outside the window, preview, validation-only | Zero contribution sends and no fallback to unrelated deployment history |
+| AC-003 | New contribution fixtures: missing or invalid `environmentName`, deployment not found, ARM Running/Failed, stale timestamp outside the window, preview, validation-only | Zero contribution sends; a missing or invalid environment name skips before any Azure query is issued |
 | AC-004 | Failed attempt then successful attempt; nested modules; deliberate double collector call | 0 then 1 for normal retry; one event for nested modules; duplicate-call limitation documented, not falsely claimed solved |
 | AC-005 | New ARM fixtures: subscription root, RG root, nested modules/pages, Create/Read/Delete, malformed type, repeated type, unsupported child, empty type set | Complete normalized type set or explicit skip, never wrapper-type counting or partial silent success |
 | AC-005, AC-008 | Deadline/request/depth/type caps, cycle, denied read, invalid pagination origin | Bounded termination, no arbitrary URL request, no raw diagnostic data |
@@ -409,6 +433,7 @@ CLI fixture, local HTTP capture, and isolated install/update infrastructure.
 | AC-009 | Installed version differs from npx sender; missing metadata; rename variant | Correct asset version or unknown; one canonical skill name, no double emission |
 | AC-010 | Documented query examples against a small synthetic dataset | Resource expansion does not change headline event count; no success-rate or full-inventory claim |
 | AC-011 | Canonical payload generation and isolated workspace CLI integration | No durable ledger, global hook interception, Azure tags, or new service introduced |
+| AC-003, AC-005, AC-006, AC-008 | Live execution against a real Azure subscription and a real Application Insights resource, exercising the published command path rather than injected fakes | Successful send and event arrival with the specified properties; skip and opt-out paths return a single categorical word and exit 0 without querying Azure; the ingested envelope carries no host, user, correlation, or application-version identity. This class of evidence is required because injected-dependency tests cannot exercise process spawning, real ARM response ordering, or ingestion responses (D-014). |
 
 At implementation time, run the targeted tests first, then the repository's
 required lint/typecheck/tests and canonical build/payload verification before
@@ -454,8 +479,8 @@ applicable skill-authoring instructions; this draft does not execute the skills.
 | Governance integration | Follows merged FRD governance (`a430a5b`); index row added in `docs/frds/README.md` |
 | Number allocation | FRD-0003 unused among remote main and all open PRs checked on 2026-09-08; rechecked against the merged governance index on 2026-09-10 |
 | Implementation reference | Phase 1 implemented as stacked draft PRs at the user's direction while this document is still Draft: #259 (telemetry core) and #260 (skill and docs wiring), stacked above this document's PR #247 |
-| Acceptance evidence | Partial: automated coverage from section 6 exists in the implementation PRs and passes locally. No live Azure deployment or production telemetry send has been exercised. |
-| Live execution authorization | Not requested or granted |
+| Acceptance evidence | Automated coverage from section 6 exists in the implementation PRs and passes locally, plus a live end-to-end run against real Azure Resource Manager and a real Application Insights resource on 2026-09-10. The live run confirmed a `sent` result, arrival of a single `azure_contribution` custom event with the specified properties, and the section 4.5 privacy boundary on the actual ingested envelope. It also exposed three defects invisible to automated tests, recorded as D-013 and D-014. |
+| Live execution authorization | Granted by the user on 2026-09-10 for a dedicated test subscription. Test resources are retained by the user for verification queries. |
 
 ### Independent review disposition
 

--- a/docs/frds/0003-azure-contribution-telemetry.md
+++ b/docs/frds/0003-azure-contribution-telemetry.md
@@ -3,7 +3,7 @@
 | Metadata | Value |
 | --- | --- |
 | Status | Draft |
-| Revision | 4 |
+| Revision | 5 |
 | Created | 2026-09-08 |
 | Updated | 2026-09-10 |
 | Author | GitHub Copilot, based on the user's requirements and scope feedback |
@@ -225,10 +225,13 @@ The value is read from `resourceType`, never reconstructed from resource IDs.
 No qualifying types means no event.
 
 Bound collection to 15 seconds overall, 50 ARM requests, nesting depth 10, and
-100 distinct types. A denied query, unsupported child scope, exhausted bound,
-or malformed required field skips the whole observation rather than emitting
-a silently truncated breakdown. These are collector safety limits, not limits
-on what the user can deploy.
+100 distinct types. The request bound counts every ARM HTTP request, including
+each pagination page, not one per deployment. The time bound covers subprocess
+execution, so a stalled CLI invocation must be terminated rather than awaited.
+A denied query, unsupported child scope, exhausted bound, or malformed required
+field skips the whole observation rather than emitting a silently truncated
+breakdown. These are collector safety limits, not limits on what the user can
+deploy.
 
 Operations indicate provisioning activity, not proof that every resource
 materially changed. Idempotent ARM reapplication can count. Conversely, cached
@@ -270,7 +273,10 @@ Example of the actual string-valued properties contract:
 
 Use existing installed metadata when available; do not overhaul distribution
 only to eliminate `unknown`. A newer npx sender version is not the Skills
-version. Derive deploymentKind in code rather than accepting a free-text label.
+version. Validate `skillsVersion` against an expected short version shape and
+substitute `unknown` otherwise, so the field cannot become a free-text channel.
+Derive deploymentKind from the skill in code rather than accepting a free-text
+label, and reject a skill/kind pair that contradicts the fixed mapping.
 
 The telemetry boundary constructs a new allowlisted object; never spread local
 input or ARM responses into it. No subscription/tenant/resource/deployment
@@ -279,9 +285,13 @@ prompts, endpoints, keys, logs, or errors are sent, even hashed.
 
 Envelope-level privacy is mandatory, not deferred. The currently pinned
 Application Insights 1.8.10 [Context implementation](https://github.com/microsoft/ApplicationInsights-node.js/blob/1.8.10/Library/Context.ts)
-adds the hostname as cloudRoleInstance. Suppress customer/host-derived tags and
-automatic collection; permit only transport-required fields, event timestamp,
-and fixed/nonidentifying SDK metadata. Do not inherit operation/session/user
+adds the hostname as cloudRoleInstance. Removing individual known tags is not
+sufficient: on that version the SDK also derives `ai.application.ver` from the
+host package and injects `ai.operation.*` correlation tags when the envelope is
+built, after client-level cleanup runs. Apply an explicit allowlist to the
+finished envelope instead. Suppress customer/host-derived tags and automatic
+collection; permit only transport-required fields, event timestamp, and
+fixed/nonidentifying SDK metadata. Do not inherit operation/session/user
 correlation from usage telemetry. Cover the full serialized HTTP envelope, not
 just trackEvent arguments. Remove hostname context in the shared client without
 redesigning existing usage properties. This intentionally removes hostname from
@@ -378,7 +388,7 @@ or Azure resource is created by this documentation task.
 | D-009 | Architecture review: compatibility and delegated feasibility | Clarify that hostname removal intentionally affects SDK envelopes, not usage application properties; make delegated capture an M0 gate with human-approved scope reduction if needed. | Copilot (revision 2 proposal, responding to independent review) | 2026-09-08 |
 | D-010 | Exact per-attempt capture (`AZD_DEPLOYMENT_ID_FILE` recipe) versus post-success ARM deployment selection | Choose post-success selection. The recipe required owning the azd process, which the delegating deploy skill cannot do, so it would have covered only one skill while adding a wrapper, temporary files, and exit-code plumbing. Selection covers both skills with a one-line call and accepts bounded misattribution of the resource-type breakdown, consistent with the "observed", non-exact reporting label. Exact capture is deferred to Phase 2. | User (scope decision), Copilot (revision 3 proposal) | 2026-09-09 |
 | D-011 | Rebase onto merged `main` versus keep the pre-merge naming | Rebase and adopt the merged state. PR #244's governance index replaces the provisional index, and PR #218's rename makes `azure-functions-hosted-skills` the only canonical name. Keeping both names or a forked index would create ambiguity in the allowlist and `deploymentKind` mapping. | Copilot (revision 4 maintenance) | 2026-09-10 |
-
+| D-012 | Disposition of the independent implementation review | Fix all seven findings in the implementation rather than relax the specification. Six were drifts from contract text this document already stated (fail-closed bounds, fail-closed malformed fields, derived deploymentKind, opt-out that must not be bypassed, subprocess time bound). Only the envelope allowlist needed a specification clarification, because removing four known SDK tags was verified insufficient on Application Insights 1.8.10. Sections 4.4 and 4.5 are clarified accordingly; no acceptance criterion is weakened. | Copilot (revision 5), GPT-5.6 independent review | 2026-09-10 |
 ## 6. Test plan
 
 All entries are planned, not completed acceptance evidence. Use existing Vitest,
@@ -466,6 +476,11 @@ Revision 4 rebases the document onto merged `main`: it adopts the merged FRD
 governance index instead of a provisional one and replaces every
 `azure-functions-agents` reference with `azure-functions-hosted-skills` (D-011).
 It has not been re-reviewed independently.
+
+Revision 5 records the disposition of an independent implementation review of
+the telemetry core (D-012). It clarifies the request/time bounds in section 4.4
+and the envelope allowlist and `skillsVersion` validation in section 4.5. It
+weakens no acceptance criterion. It has not been re-reviewed independently.
 
 This records independent advice and the author's disposition, not reviewer or
 human approval of revision 2. M0 questions and human sign-off remain pending.

--- a/docs/frds/0003-azure-deployment-observation-telemetry.md
+++ b/docs/frds/0003-azure-deployment-observation-telemetry.md
@@ -1,27 +1,40 @@
-# FRD-0003: Azure contribution telemetry
+# FRD-0003: Azure deployment observation telemetry
 
 | Metadata | Value |
 | --- | --- |
 | Status | Draft |
-| Revision | 6 |
+| Revision | 7 |
 | Created | 2026-09-08 |
-| Updated | 2026-09-10 |
+| Updated | 2026-09-11 |
 | Author | GitHub Copilot, based on the user's requirements and scope feedback |
 | Depends on | [FRD governance](README.md), merged as `a430a5b` (PR #244) |
-| Component | Shared infrastructure: contribution telemetry and narrow skill integration |
+| Component | Shared infrastructure: deployment observation telemetry and narrow skill integration |
 
 ## 1. Summary
 
-Propose one new Application Insights event, `azure_contribution`, to show the
-approximate volume and resource-type breakdown of successful Azure deployment
-work observed through Azure Functions Skills. Phase 1 covers azd with Bicep from
-the Functions deployment and hosted-agents skills. Reuse the current telemetry
-transport and deployment workflows; do not build a deployment engine, durable
-tracking system, or exact attribution service.
+Propose one new Application Insights event, `azure_deployment_observed`, to show
+the approximate volume and resource-type breakdown of successful Azure deployment
+operations observed through Azure Functions Skills. Phase 1 covers azd with Bicep
+from the `azure-functions-deploy` and `azure-functions-hosted-skills` skills.
+Reuse the current telemetry transport and deployment workflows; do not build a
+deployment engine, durable tracking system, or exact attribution service.
 
-The reporting label is **Observed successful Azure deployment operations**.
-This is an adoption/contribution trend, not a complete inventory, an exact
-conversion rate, proof of net-new Azure resources, or a billing metric.
+The reporting label is **Observed successful Azure deployment operations**, and
+the event name matches that label exactly. This feature observes and reports
+deployment operations; it does not establish causal attribution, and no wording
+in this document, in code, or in any derived report may imply that it does
+(D-015).
+
+This metric must never be presented as any of the following:
+
+| Prohibited interpretation | Why it is invalid |
+| --- | --- |
+| A conversion rate, funnel stage, or success rate | Only successes are emitted, so there is no attempt denominator (section 4.7). |
+| Total Azure deployment volume or a deployment inventory | Only two skills, azd/Bicep provisioning, and subscription-scope roots are in scope (sections 3 and 4.3). |
+| Proof that a Skills invocation created the observed workload | Selection correlates by deployment name and a bounded time window, not by command identity (section 4.2). |
+| Proof of net-new Azure resources | Idempotent ARM reapplication is indistinguishable from first creation (section 4.4). |
+| A billing, revenue, or capacity metric | No cost, quantity, subscription, or customer identity data is collected (section 4.5). |
+
 This document includes the implementation plan and technical design. No feature
 implementation or live experiment is authorized by this draft.
 
@@ -64,17 +77,18 @@ attempt would obscure the management question.
 
 | ID | Requirement | Observable acceptance criterion |
 | --- | --- | --- |
-| AC-001 | Add one contribution event while preserving existing usage event names and application properties. | One accepted contribution emits `azure_contribution`; existing custom properties remain compatible. Removing hostname-derived SDK envelope context is an intentional privacy change shared by both event paths. |
-| AC-002 | Limit attribution to the two supported canonical skills and azd/Bicep provisioning. | Delegated Functions and direct agents paths can call the collector; plain CLI create, Terraform, and unrelated skill use do not emit. |
-| AC-003 | Require successful command completion and current ARM deployment success. | Failed/cancelled commands, nonterminal/failed ARM states, a named deployment that is absent or outside the recency window, preview, validation, and code-only deploy produce no event. |
-| AC-004 | Count one supported successful command, not its resources or modules. | A single-layer azd invocation with multiple nested modules emits at most one event per collector call; failed attempts emit zero. |
-| AC-005 | Collect types from the exact ARM deployment and its nested operations. | Subscription and resource-group roots, pagination, and nested modules yield a sorted, distinct resource-type set, without deployment-wrapper types. |
+| AC-001 | Add one deployment observation event while preserving existing usage event names and application properties. | One accepted observation emits `azure_deployment_observed`; existing custom properties remain compatible. Removing hostname-derived SDK envelope context is an intentional privacy change shared by both event paths. |
+| AC-002 | Limit collection to the two supported canonical skills and azd/Bicep provisioning. | The `azure-functions-deploy` (delegated) and `azure-functions-hosted-skills` (direct azd) paths can call the collector; plain CLI create, Terraform, and unrelated skill use do not emit. |
+| AC-003 | Require successful command completion and current ARM deployment success. | Failed/cancelled commands, nonterminal/failed ARM states, a named deployment that is absent, that completed before the caller-supplied start time, or that falls outside the recency window, plus preview, validation, and code-only deploy, produce no event. |
+| AC-004 | Count one supported successful command that ARM reports as having done qualifying provisioning work, not its resources or modules. | A single-layer azd invocation with multiple nested modules emits at most one event per collector call; failed attempts emit zero; a deployment whose operations contain no successful `Create` is skipped rather than emitted with an empty breakdown. |
+| AC-005 | Collect types from the exact ARM deployment and its nested operations. | A subscription-scope root, pagination, and nested modules yield a sorted, distinct resource-type set, without deployment-wrapper types. Resource-group-scope roots are out of scope for Phase 1 and are skipped, not misattributed. |
 | AC-006 | Send only the categorical event contract and nonidentifying SDK metadata. | The captured HTTP envelope contains no customer names, identifiers, secrets, logs, source, host identity, or inherited correlation identifiers. |
 | AC-007 | Honor opt-out before extra collection or transmission. | Either existing opt-out environment variable or the applicable installed telemetry config disables ARM telemetry queries and sending. |
 | AC-008 | Do not change deployment outcomes for telemetry-only failures. | Query denial, timeout, malformed input, missing package, and ingestion failure never trigger a deployment retry or change the deployment result the agent already observed. |
 | AC-009 | Preserve truthful client/version attribution. | Client values are normalized, not guessed; Skills version comes from the executing asset's metadata or is `unknown`, never inferred from a newer sender. |
-| AC-010 | Keep delivery deliberately best-effort. | Documentation discloses unsupported paths, deployment-selection imprecision, skipped observations, possible duplicate collector calls, and absence of exact-once/funnel guarantees. |
+| AC-010 | Keep delivery deliberately best-effort, and make the scope limits travel with the metric. | Documentation discloses unsupported paths, deployment-selection imprecision, skipped observations, possible duplicate collector calls, and absence of exact-once/funnel guarantees. Every dashboard, report, or query example that publishes this metric displays the section 4.7 scope disclaimer alongside the number. |
 | AC-011 | Keep integration small and nonpersistent. | No installed customer `azure.yaml` telemetry hooks, durable operation database, ARM tags, new server, or global tool interception is introduced. |
+| AC-012 | Record the data governance that applies to this event before sign-off. | Section 4.5 names the data owner, retention period, access control, applicable privacy/security review reference, service-side metadata handling, and the disablement/rollback procedure, with no unresolved placeholder. |
 
 ### Non-goals
 
@@ -87,7 +101,7 @@ attempt would obscure the management question.
 - Code-only `azd deploy`, Core Tools publishing, workload health/authorization,
   connector post-provisioning stages, or the create skill's fallback path.
 - Parsing Bicep source, human-readable azd logs, arbitrary shell commands, or
-  deployment error bodies to infer contribution.
+  deployment error bodies to infer deployment success.
 - Exact changed-resource/new-resource counting, revenue estimates, retry/failure
   dashboards, detailed agent taxonomy, or a new dashboard deployment.
 - Refactoring existing usage hooks, adding a skill execution framework, or
@@ -100,7 +114,20 @@ attempt would obscure the management question.
 The unit is one supported `azd up` or standalone `azd provision` invocation that
 finishes successfully and has one current successful ARM root with qualifying
 resource operations. Nested ARM deployments belong to that root and never count
-separately. Two independently successful later updates count twice.
+separately.
+
+A qualifying operation is a successful ARM `Create` operation. There is no
+create-versus-update axis to choose between: ARM's provisioning-operation enum
+has no `Update` value, and an ARM PUT is a create-or-update, so a redeployment
+that actually provisions a resource is still reported as `Create`. The real axis
+is whether ARM reports any qualifying operation. A later redeployment that ARM
+reports as having performed qualifying operations is a separate observation and
+counts again. A redeployment whose operations contain no successful `Create`,
+including a fully cached or no-op reapplication, yields no qualifying types and
+is skipped with no event rather than emitting an empty breakdown (section 4.4,
+D-017). Update-only activity is therefore excluded from this metric by
+construction, which undercounts real maintenance work. That undercount is
+accepted for Phase 1 and must be disclosed alongside the metric.
 
 For `azd up`, wait for the entire command: successful infrastructure followed by
 failed application publishing produces no event. Standalone `azd provision`
@@ -127,18 +154,21 @@ re-run, intercept, or re-order the deployment. After a supported command reports
 success, the executing agent invokes one small internal collector, provisionally:
 
 ```text
-azure-functions-skills telemetry contribution
+azure-functions-skills telemetry deployment-observed
 ```
 
 The subcommand accepts a bounded JSON object on stdin, limited to 16 KiB, with
-`skill`, `operation`, `agent`, `skillsVersion`, and `environmentName`.
+`skill`, `operation`, `agent`, `skillsVersion`, `environmentName`, and the
+optional `startedAt`.
 `operation` is `deploy` for `azd up` and `provision` for standalone
 `azd provision`. `environmentName` is the local azd environment name. It is
 required for a usable observation because it identifies the deployment to
 inspect (section 4.3), and that requirement is enforced at collection time
 rather than at parse time: input without it parses, then skips before any Azure
 query, so the caller gets the precise skip reason instead of a generic failure.
-Reject unknown fields; do not accept
+`startedAt` is an ISO-8601 UTC instant the agent captures immediately before it
+starts the deployment command; it bounds deployment selection from below
+(section 4.3, D-016). Reject unknown fields; do not accept
 templates, environment dumps, transcripts, tool output, or executable paths.
 The original `telemetry` stdin contract stays unchanged.
 
@@ -150,6 +180,14 @@ it delegates execution to the external Azure Skills executor. Removing it makes
 both skills supportable through the same one-line post-success call, deletes the
 delegated-capture gate, and keeps the change small. The cost is deployment
 selection precision, addressed in section 4.3.
+
+Reliable per-command correlation remains rejected for Phase 1 for that
+structural reason, not for convenience: any mechanism that yields a real command
+identity must observe the azd process itself, and the delegating skill does not
+own it. Phase 1 instead narrows the correlation window with `startedAt` and
+relabels the metric to match what it can actually prove (D-015, D-016). The
+result is a lower bound on a time window, not a command identity, and this
+document does not describe it as one.
 
 Because the collector runs only after a reported success, there is no exit code
 to plumb and no failed-attempt bookkeeping. Section 4.4's independent ARM check
@@ -170,6 +208,26 @@ This is trusted local workflow evidence, not attested attribution: a caller able
 to invoke the internal CLI can supply misleading input. Phase 1 does not attempt
 anti-fraud or hostile-local-user protection.
 
+#### Execution model, latency, and failure behavior
+
+| Property | Phase 1 contract |
+| --- | --- |
+| Synchronicity | Synchronous. The agent runs the collector after the deployment reports success and waits for it to exit. The collector never runs concurrently with the deployment. |
+| Ordering | Strictly after the deployment command has already produced its result. The collector cannot influence, delay, retry, or reclassify that result. |
+| Azure work bound | At most 20 seconds and 50 ARM requests overall, enforced by an injectable deadline (section 4.4). A live run measured 2.4 seconds for the deployment lookup. |
+| Package resolution bound | Unbounded and outside this design. The documented invocation resolves the published package through `npx`, so a cold package cache can dominate total wall time. Callers that need a bounded step must use an already-installed asset. |
+| Disabled or unconfigured | Returns before any Azure query or network send, so the opt-out and unconfigured paths add no measurable latency. |
+| Process exit during collection | Nothing is sent. There is no durable queue, no resume, and no partial event. The observation is lost, which is an accepted best-effort loss (section 4.6). |
+| Failure | Always exits 0 and prints one categorical word. A telemetry failure is never surfaced as a deployment failure (AC-008). |
+
+Backgrounding the collector is deliberately rejected. Detaching it would create
+an orphan process whose lifetime, output, and opt-out behavior outlive the
+command the user is watching, would make the categorical result unobservable to
+the agent that invoked it, and would complicate audit of the opt-out path. The
+bounded synchronous call is small enough that the added latency does not justify
+that complexity. If measured latency later proves unacceptable, reduce the
+Azure work bound or require a preinstalled asset; do not detach the process.
+
 ### 4.3 Deployment selection
 
 The collector identifies the deployment to inspect from Azure Resource Manager
@@ -185,7 +243,25 @@ itself, reusing the Azure CLI authentication already available to the workflow:
    output.
 3. Accept the deployment only when `provisioningState` is `Succeeded` and its
    completion timestamp falls inside a bounded recency window of 30 minutes.
+   When the caller supplied `startedAt`, additionally require the completion
+   timestamp to be at or after it, within a small clock-skew tolerance.
    Anything else means no event.
+
+The `startedAt` lower bound exists because the recency window alone admits a
+deployment that finished before the skill ran. Without it, a user who deployed
+manually twenty minutes earlier and then invoked the skill on a run that
+provisioned nothing, because azd reused cached infrastructure, would still match
+that earlier deployment by name and emit an event for work the invocation did
+not perform. Requiring the deployment to have completed after the caller started
+the command removes that class of false positive and removes the matching
+duplicate on a cache-only retry.
+
+`startedAt` is optional and degrades gracefully: when it is absent or malformed,
+selection falls back to the 30-minute window and behaves exactly as it did
+without the field, so an agent that fails to capture it loses precision rather
+than the observation. It narrows a time window and is explicitly not a command
+identity; it does not make the metric causal, and section 1's prohibitions still
+apply in full (D-016).
 
 Lookup by name replaced an earlier design that listed subscription deployments
 and selected the most recent successful entry. Live measurement showed the
@@ -196,7 +272,8 @@ Exhaustive pagination is not a viable substitute. See D-013.
 
 Accepted imprecision: re-running the collector after a later deployment reusing
 the same environment name refers to the newest deployment of that name, and a
-deployment that finished before the window opened is skipped. Both affect which
+deployment that finished before the window opened, or before `startedAt`, is
+skipped. Both affect which
 resource-type breakdown is attached to an observation rather than whether
 Skills-driven deployment activity is broadly visible, which is why section 1 uses
 an "observed", non-exact reporting label. Exact per-attempt attribution is a
@@ -232,7 +309,8 @@ through stdin or a response body.
 
 Include `targetResource.resourceType` for successful `Create` operations.
 ARM's provisioning-operation enum does not provide a separate `Update` value;
-do not invent one. Exclude Read, EvaluateDeploymentOutput, waiting, delete, and
+do not invent one, and do not treat its absence as a gap to be filled. Exclude
+Read, EvaluateDeploymentOutput, waiting, delete, and
 cleanup operations. For `Microsoft.Resources/deployments`, traverse the child
 and omit the wrapper type from the result. Any referenced child not confirmed
 successful makes the observation incomplete and suppresses the event.
@@ -241,7 +319,11 @@ Validate type syntax and length, reject IDs/names or malformed values, normalize
 case consistently, deduplicate, and sort. Only Microsoft resource-provider
 types are included in Phase 1; unknown/custom providers are outside scope.
 The value is read from `resourceType`, never reconstructed from resource IDs.
-No qualifying types means no event.
+No qualifying types means no event: a successful deployment whose operations
+contain no successful `Create` is skipped, and the collector never emits an
+event carrying an empty `resourceTypes` array. Emitting one would create a
+second, ambiguous event class that cannot be distinguished from a collection
+defect, and would let no-op reapplications inflate the headline count (D-017).
 
 Bound collection to 20 seconds overall, 50 ARM requests, nesting depth 10, and
 100 distinct types. The time bound is injectable so it can be tightened in tests
@@ -254,14 +336,18 @@ breakdown. These are collector safety limits, not limits on what the user can
 deploy.
 
 Operations indicate provisioning activity, not proof that every resource
-materially changed. Idempotent ARM reapplication can count. Conversely, cached
-operations can be omitted. Do not label this set "new resources."
+materially changed. Idempotent ARM reapplication can count, so the set must
+never be labeled "new resources." Conversely, a deployment that ARM satisfies
+entirely from cached state reports no qualifying operation and is not counted at
+all, so genuine maintenance and update activity is systematically undercounted.
+Both directions of error are accepted for Phase 1 and must be disclosed with the
+metric (section 4.7).
 
 Reference: [ARM deployment operations contract](https://learn.microsoft.com/en-us/rest/api/resources/deployment-operations/list?view=rest-resources-2025-04-01).
 
 ### 4.5 Outbound event and privacy boundary
 
-Emit one event named `azure_contribution`, with exactly these application
+Emit one event named `azure_deployment_observed`, with exactly these application
 properties:
 
 | Property | Source / allowed values |
@@ -278,7 +364,7 @@ Example of the actual string-valued properties contract:
 
 ```json
 {
-  "name": "azure_contribution",
+  "name": "azure_deployment_observed",
   "properties": {
     "skill": "azure-functions-deploy",
     "operation": "deploy",
@@ -325,6 +411,29 @@ transport. Document the existing ingestion service's applicable privacy policy
 and IP handling rather than claiming that categorical properties eliminate all
 service-side metadata.
 
+#### Data governance
+
+This event introduces no new destination, credential, or service (D-002). It is
+written to the same Application Insights resource, through the same
+release-injected connection string, as the existing
+`AzureFunctionsSkillsPluginExecuted` usage event. Its governance is therefore
+the governance already applying to that resource, not a new regime invented
+here. Record the concrete values in
+[`docs/internal/telemetry-release.md`](../internal/telemetry-release.md) and
+keep this table as the pointer.
+
+| Governance item | Phase 1 position |
+| --- | --- |
+| Data owner | The maintainer team that already owns the Application Insights resource carrying the existing usage event. Name the owning team and contact before sign-off (AC-012). |
+| Categories collected | Categorical strings only: skill, operation, result, deployment kind, agent, Skills version, and normalized Azure resource-type names. No customer, subscription, tenant, resource, deployment, path, or free-text values (section 4.5). |
+| Retention | The retention configured on that existing resource. Record the configured period before sign-off; this feature does not request a different one. |
+| Access control | The Azure RBAC already governing that resource. Record the access model and who may query it before sign-off; this feature adds no new reader. |
+| Privacy/security review | Record the review that covered the existing usage event and confirm whether adding a categorical event with no new identifier class requires a delta review. Obtain that determination before sign-off. |
+| Regional and network metadata | Ingestion region follows the existing resource. The client IP is visible to the ingestion service as an unavoidable property of HTTPS and is handled under that service's policy; it is never an application property. |
+| User-facing disablement | Either existing opt-out environment variable, or the applicable installed telemetry configuration, disables the ARM queries and the send before any of them run (AC-007). |
+| Operator-side disablement and rollback | Removing the post-success collection step from the two canonical skills and shipping a package release. Reverting the stacked implementation PRs removes the event entirely. |
+| Absence of a remote kill switch | There is deliberately no server-side or configuration-service switch. Disabling for all users requires a release, so the worst case is bounded by release cadence. Building a remote switch would add a configuration service, a fetch path, and a failure mode to every collection, which is out of proportion to one categorical event. Phase 2 may revisit this if operational experience shows the release path is too slow. |
+
 ### 4.6 Preferences, failures, and transport
 
 Reuse the two existing opt-out environment variables. Resolve the applicable
@@ -340,7 +449,7 @@ Do not introduce another diagnostics subsystem; use PR #235's bounded diagnostic
 if available, otherwise a short local categorical notice.
 
 The existing sender owns delivery timeout and any bounded transport retry.
-There is no contribution-specific retry or persistent queue. A telemetry
+There is no observation-specific retry or persistent queue. A telemetry
 failure cannot reclassify the deployment, prompt a cloud login, elevate Azure
 permissions, or trigger reprovisioning. If ARM read access is absent, skip.
 
@@ -348,7 +457,7 @@ permissions, or trigger reprovisioning. If ARM read access is absent, skip.
 
 | Surface | Planned responsibility |
 | --- | --- |
-| `src/telemetry/contribution.ts` (new) | Stdin input validation, deployment selection policy, normalized event construction |
+| `src/telemetry/deployment-observation.ts` (new) | Stdin input validation, deployment selection policy, normalized event construction |
 | `src/telemetry/arm-deployments.ts` (new) | Injectable bounded structured ARM query/traversal |
 | Existing sender and `src/telemetry/index.ts` | Reuse transport and privacy-safe client; keep raw ARM responses out of the package's telemetry-event API |
 | `bin/azure-functions-skills.js` | Small internal subcommand dispatcher; no deployment orchestration |
@@ -358,8 +467,28 @@ Report event count over time and by skill/deploymentKind. Expand resourceTypes
 only for the breakdown; expanding the array must not inflate the headline count.
 A type's count means "observations containing this type," not resource count.
 Document disabled/unsupported paths and delivery loss. Existing usage counts
-can be displayed alongside contributions, but do not compute an exact funnel
+can be displayed alongside observations, but do not compute an exact funnel
 or attempt denominator from success-only events.
+
+#### Required reporting disclaimer
+
+Any dashboard, report, review slide, or query example that publishes this metric
+must display the following disclaimer next to the number (AC-010). Reproduce it
+verbatim; do not paraphrase it into a weaker claim.
+
+> **Observed successful Azure deployment operations.** Counts azd/Bicep
+> subscription-scope deployments observed after a successful
+> `azure-functions-deploy` or `azure-functions-hosted-skills` command, verified
+> against Azure Resource Manager. It is a best-effort adoption signal, not a
+> deployment inventory, conversion rate, success rate, or proof that Azure
+> Functions Skills created the workload. Resource-group-scope deployments,
+> Terraform, direct Azure CLI, multiple azd provisioning layers, tenant and
+> management-group roots, custom Azure clouds, opted-out users, and cached or
+> update-only redeployments are not counted. Duplicate observations are possible.
+
+Using this metric as the numerator or denominator of a rate requires a written
+coverage statement explaining what the other side of the ratio measures and why
+the two are comparable. Without that statement, publish the count only.
 
 ### Delivery checkpoints
 
@@ -411,6 +540,11 @@ or Azure resource is created by this documentation task.
 | D-012 | Disposition of the independent implementation review | Fix all seven findings in the implementation rather than relax the specification. Six were drifts from contract text this document already stated (fail-closed bounds, fail-closed malformed fields, derived deploymentKind, opt-out that must not be bypassed, subprocess time bound). Only the envelope allowlist needed a specification clarification, because removing four known SDK tags was verified insufficient on Application Insights 1.8.10. Sections 4.4 and 4.5 are clarified accordingly; no acceptance criterion is weakened. | Copilot (revision 5), GPT-5.6 independent review | 2026-09-10 |
 | D-013 | Deployment selection by recency scan versus lookup by name | Switch to direct lookup by deployment name. A live run against a real subscription showed the recency scan is incorrect, not just slow: ARM does not return deployments newest-first (a deployment completed seconds earlier appeared at index 51 of the first page), and `$top` behaves as a per-page hint rather than a global cap (`$top=100` returned 9 entries and excluded that deployment), so a bounded scan silently drops real contributions. Exhaustive pagination measured 58 s over 20 pages for 151 deployments and cannot fit any acceptable bound, whereas lookup by name is one request at 2.4 s and does not degrade as history grows. The cost is that `environmentName` becomes required and resource-group-scope deployments are out of scope; both are acceptable because azd names its subscription-scope deployment after the environment. | Copilot (revision 6), live execution evidence | 2026-09-10 |
 | D-014 | Disposition of defects found only by live execution | Fix in the implementation; keep the specification's intent unchanged. Live execution exposed three defects that injected-dependency tests structurally could not catch: the Azure CLI could not be spawned at all on Windows (`execFile` does not resolve PATHEXT, and Node refuses to spawn `.cmd` without a shell), a successful Application Insights ingestion response was classified as a delivery failure in a helper shared with the pre-existing usage path, and the deployment selection defect recorded in D-013. Section 4.4's time bound moves from 15 s to 20 s and becomes injectable. This is why section 8 now requires live-execution evidence, not only automated tests, before sign-off. | Copilot (revision 6), live execution evidence | 2026-09-10 |
+| D-015 | Reliable per-command correlation versus consistent reframing as observation | Reframe, and rename to match. The reviewer offered either a real per-command correlation mechanism or a consistent non-causal framing, and noted that the document mixed the two. Real correlation is rejected for the structural reason already recorded in D-010: it requires owning the azd process, which the delegating `azure-functions-deploy` skill cannot do, so it would cover one skill while reintroducing a wrapper, temporary files, and exit-code plumbing. Choosing the reframe therefore requires the name to stop claiming what the mechanism cannot prove: the event becomes `azure_deployment_observed`, the document, module, and CLI subcommand are renamed to match, and section 1 adds an explicit table of prohibited interpretations including "proof that a Skills invocation created the observed workload." Renaming is done now because nothing has shipped; after release it would be a breaking analytics change. | User (naming decision), Copilot (revision 7 proposal), independent review by Laveesh | 2026-09-11 |
+| D-016 | Blunt recency window versus caller-supplied start instant | Add an optional `startedAt` lower bound. The 30-minute window alone admits a deployment that completed before the invocation, so a cache-only run could match a user's earlier manual deployment by name and emit an event for work it did not perform. Requiring completion at or after a caller-captured start instant removes that false-positive class and the matching cache-retry duplicate, at the cost of one optional field, one validation rule, and one comparison. It is optional and falls back to the existing window when absent, so an agent that fails to capture it loses precision rather than the observation. This narrows a time window and is explicitly not the per-command correlation rejected in D-015; it does not make the metric causal. | Copilot (revision 7 proposal), independent review by Laveesh | 2026-09-11 |
+| D-017 | Emit update-only deployments with an empty breakdown versus exclude them | Exclude, and correct the contradictory text. Section 4.1 previously implied later updates always count, while section 4.4 only ever included successful `Create` operations; the implementation follows section 4.4. The apparent create-versus-update axis does not exist, because ARM's provisioning-operation enum has no `Update` value and an ARM PUT is a create-or-update, so a redeployment that really provisions is reported as `Create`. The real distinction is whether ARM reports any qualifying operation. Emitting an event with an empty `resourceTypes` array was rejected because it creates a second event class indistinguishable from a collection defect and lets no-op reapplications inflate the headline count. The resulting undercount of maintenance activity is accepted and disclosed. | Copilot (revision 7 proposal), independent review by Laveesh | 2026-09-11 |
+| D-018 | Synchronous bounded collection versus backgrounding | Keep it synchronous and write the execution model down. The collector runs strictly after the deployment has already produced its result, is bounded to 20 s and 50 ARM requests, always exits 0, and sends nothing if the process exits mid-collection. Backgrounding was rejected: it would orphan a process whose lifetime, output, and opt-out behavior outlive the command the user is watching, hide the categorical result from the invoking agent, and complicate opt-out audit, for a saving that the measured 2.4 s lookup does not justify. The review also surfaced that `npx`-based package resolution is unbounded and dominates worst-case wall time; that is now stated as a known cost with a preinstalled-asset mitigation instead of being hidden behind the Azure-side bound. | Copilot (revision 7 proposal), independent review by Laveesh | 2026-09-11 |
+| D-019 | Define new governance versus document the governance that already applies | Document the existing governance and point to it. This event reuses the destination, credential, and transport of the existing `AzureFunctionsSkillsPluginExecuted` usage event (D-002), so owner, retention, access control, privacy review, and regional handling are properties of that existing resource rather than of this feature. Section 4.5 adds a governance table and AC-012 makes recording the concrete values a sign-off gate, so the feature cannot merge with unresolved placeholders. A remote kill switch was rejected as disproportionate: disablement is the existing user opt-out, and operator-side rollback is a skills-template change plus a release, bounded by release cadence. | Copilot (revision 7 proposal), independent review by Laveesh | 2026-09-11 |
 ## 6. Test plan
 
 All entries were planned before implementation. Automated entries now exist and
@@ -422,17 +556,18 @@ CLI fixture, local HTTP capture, and isolated install/update infrastructure.
 | --- | --- | --- |
 | AC-001 | Extend `tests/telemetry.test.ts` and `tests/simplified-cli.test.ts` | New event exact shape; unchanged legacy stdin/event behavior |
 | AC-002, AC-011 | Skill contract fixtures and isolated CLI invocation with a fake ARM query adapter | Only supported explicit entry points collect; external delegation has one owner; no customer `azure.yaml` modifications |
-| AC-003 | New contribution fixtures: missing or invalid `environmentName`, deployment not found, ARM Running/Failed, stale timestamp outside the window, preview, validation-only | Zero contribution sends; a missing or invalid environment name skips before any Azure query is issued |
-| AC-004 | Failed attempt then successful attempt; nested modules; deliberate double collector call | 0 then 1 for normal retry; one event for nested modules; duplicate-call limitation documented, not falsely claimed solved |
-| AC-005 | New ARM fixtures: subscription root, RG root, nested modules/pages, Create/Read/Delete, malformed type, repeated type, unsupported child, empty type set | Complete normalized type set or explicit skip, never wrapper-type counting or partial silent success |
+| AC-003 | New observation fixtures: missing or invalid `environmentName`, deployment not found, ARM Running/Failed, stale timestamp outside the window, completion earlier than `startedAt`, absent and malformed `startedAt`, preview, validation-only | Zero sends for every rejecting case; a missing or invalid environment name skips before any Azure query is issued; an absent or malformed `startedAt` falls back to the recency window instead of failing |
+| AC-004 | Failed attempt then successful attempt; nested modules; deliberate double collector call; deployment whose operations contain no successful `Create` | 0 then 1 for normal retry; one event for nested modules; no-`Create` deployment skips with no event and no empty-array emission; duplicate-call limitation documented, not falsely claimed solved |
+| AC-005 | New ARM fixtures: subscription root, resource-group root, nested modules/pages, Create/Read/Delete, malformed type, repeated type, unsupported child, empty type set | Complete normalized type set or explicit skip, never wrapper-type counting or partial silent success; a resource-group-scope root is skipped as out of scope rather than misattributed |
 | AC-005, AC-008 | Deadline/request/depth/type caps, cycle, denied read, invalid pagination origin | Bounded termination, no arbitrary URL request, no raw diagnostic data |
 | AC-006 | Local HTTP server captures/decompresses the entire serialized SDK request; seed input with sentinel names/secrets | No forbidden sentinel, hostname, environment-derived tag, source, endpoint, or correlation identity anywhere in the envelope |
 | AC-006, AC-009 | Invalid skill/client/version, unknown fields, oversized input/type set | Reject or normalize per contract; no free-text outbound dimensions |
 | AC-007 | Both environment opt-outs; each host's local and plugin config; missing/malformed preference context | No additional ARM read or send when disabled/unresolved; original deployment still runs |
 | AC-008 | Missing Azure CLI, denied or failing ARM query, send failure, malformed stdin | No cloud retry caused by telemetry; the deployment result the agent already observed is never reclassified |
 | AC-009 | Installed version differs from npx sender; missing metadata; rename variant | Correct asset version or unknown; one canonical skill name, no double emission |
-| AC-010 | Documented query examples against a small synthetic dataset | Resource expansion does not change headline event count; no success-rate or full-inventory claim |
+| AC-010 | Documented query examples against a small synthetic dataset; review of every published reporting artifact | Resource expansion does not change headline event count; no success-rate or full-inventory claim; the section 4.7 disclaimer appears verbatim next to the number in each artifact |
 | AC-011 | Canonical payload generation and isolated workspace CLI integration | No durable ledger, global hook interception, Azure tags, or new service introduced |
+| AC-012 | Documentation review against the section 4.5 governance table before sign-off | Owner, retention, access control, privacy-review determination, regional/network handling, and rollback procedure are all recorded with concrete values; no placeholder remains |
 | AC-003, AC-005, AC-006, AC-008 | Live execution against a real Azure subscription and a real Application Insights resource, exercising the published command path rather than injected fakes | Successful send and event arrival with the specified properties; skip and opt-out paths return a single categorical word and exit 0 without querying Azure; the ingested envelope carries no host, user, correlation, or application-version identity. This class of evidence is required because injected-dependency tests cannot exercise process spawning, real ARM response ordering, or ingestion responses (D-014). |
 
 At implementation time, run the targeted tests first, then the repository's
@@ -450,8 +585,9 @@ governance index. Do not otherwise modify the governance files.
 Implementation would update:
 
 - `README.md`, Telemetry: new categorical event, opt-out, local transient ARM
-  identifiers, contribution scope, IP/service metadata caveat, and best-effort limits.
-- `docs/internal/telemetry-release.md`: actual event/property contract and
+  identifiers, observation scope, IP/service metadata caveat, and best-effort limits.
+- `docs/internal/telemetry-release.md`: actual event/property contract, the
+  section 4.5 governance values, the section 4.7 reporting disclaimer, and
   simple reporting examples; preserve the existing release destination model.
 - `docs/cli-reference.md`: clarify internal telemetry behavior and privacy
   without advertising the collector as a supported deployment command.
@@ -473,13 +609,14 @@ applicable skill-authoring instructions; this draft does not execute the skills.
 | Item | Evidence |
 | --- | --- |
 | Independent architecture review | Claude Opus 4.8 read-only review of revision 1 on 2026-09-08; two clarification findings addressed by the author in revision 2 below |
+| Maintainer review | Laveesh Rohra reviewed revision 6 on PR #247. Five findings, dispositioned in revision 7 below. No finding was rejected as invalid; one requested mechanism was declined with a recorded structural rationale (D-015). |
 | Human approval | Pending; prior scope agreement is not approval of this written revision |
 | Approved revision and scope | Pending; record commit SHA or content hash after explicit approval |
 | Approval reference and date | Pending |
 | Governance integration | Follows merged FRD governance (`a430a5b`); index row added in `docs/frds/README.md` |
 | Number allocation | FRD-0003 unused among remote main and all open PRs checked on 2026-09-08; rechecked against the merged governance index on 2026-09-10 |
 | Implementation reference | Phase 1 implemented as stacked draft PRs at the user's direction while this document is still Draft: #259 (telemetry core) and #260 (skill and docs wiring), stacked above this document's PR #247 |
-| Acceptance evidence | Automated coverage from section 6 exists in the implementation PRs and passes locally, plus a live end-to-end run against real Azure Resource Manager and a real Application Insights resource on 2026-09-10. The live run confirmed a `sent` result, arrival of a single `azure_contribution` custom event with the specified properties, and the section 4.5 privacy boundary on the actual ingested envelope. It also exposed three defects invisible to automated tests, recorded as D-013 and D-014. |
+| Acceptance evidence | Automated coverage from section 6 exists in the implementation PRs and passes locally, plus a live end-to-end run against real Azure Resource Manager and a real Application Insights resource on 2026-09-10. The live run confirmed a `sent` result, arrival of a single custom event, then named `azure_contribution` and renamed to `azure_deployment_observed` in revision 7, with the specified properties, and the section 4.5 privacy boundary on the actual ingested envelope. It also exposed three defects invisible to automated tests, recorded as D-013 and D-014. Revision 7's rename, `startedAt` bound, and AC-012 governance record are not yet covered by that evidence and require re-verification. |
 | Live execution authorization | Granted by the user on 2026-09-10 for a dedicated test subscription. Test resources are retained by the user for verification queries. |
 
 ### Independent review disposition
@@ -507,8 +644,31 @@ the telemetry core (D-012). It clarifies the request/time bounds in section 4.4
 and the envelope allowlist and `skillsVersion` validation in section 4.5. It
 weakens no acceptance criterion. It has not been re-reviewed independently.
 
+Revision 6 records the deployment-selection change and the defect class found
+only by live execution (D-013, D-014).
+
+Revision 7 records the disposition of the maintainer review of revision 6:
+
+| Finding | Disposition | Where |
+| --- | --- | --- |
+| Attribution is asserted without establishing causality; either add reliable per-command correlation or reframe consistently | Reframe, and rename the event, document, module, and CLI subcommand to `azure_deployment_observed` so the name cannot outrun the mechanism. Section 1 adds an explicit prohibited-interpretation table, including that the count is not proof a Skills invocation created the workload. Per-command correlation is declined for the structural reason in D-010, restated in section 4.2. | D-015, sections 1, 4.2 |
+| Section 4.1 promises update deployments count, but 4.4 only extracts successful `Create` | Exclude update-only activity and correct section 4.1, which was the incorrect text. There is no create/update axis in ARM's enum; the axis is whether any qualifying `Create` is reported. Emitting an empty `resourceTypes` array is rejected. The resulting undercount is stated and disclosed. | D-017, sections 4.1, 4.4, AC-004 |
+| Synchronicity, acceptable latency, mid-collection exit, and backgrounding are undefined | Add an explicit execution-model table: synchronous, strictly after the deployment result, bounded to 20 s and 50 ARM requests, always exit 0, nothing sent if the process exits. Backgrounding is rejected with rationale. The review also surfaced that `npx` package resolution is unbounded; that cost is now stated rather than implied to be covered by the Azure-side bound. | D-018, section 4.2 |
+| Data governance beyond payload filtering is missing | Add a governance table covering owner, categories, retention, access control, privacy review, regional/network metadata, user opt-out, operator rollback, and the deliberate absence of a remote kill switch. Because the event reuses the existing telemetry resource and credential, this records the governance that already applies rather than defining a new one. AC-012 makes recording concrete values a sign-off gate. | D-019, section 4.5, AC-012 |
+| Phase 1 scope exclusions must travel with every report | Add a verbatim required disclaimer and extend AC-010 so any artifact publishing the metric displays it next to the number. Using the metric in a ratio requires a written coverage statement. | Section 4.7, AC-010 |
+
+Revision 7 also fixes three consistency defects found while applying the above:
+section 1 and AC-002 used pre-rename skill naming, AC-005 promised
+resource-group roots that section 4.3 excludes, and the recency window admitted
+deployments completing before the invocation. It weakens no acceptance
+criterion and adds AC-012. It has not been re-reviewed.
+
+Revision 7 changes the analytics contract. The rename must be applied to the
+stacked implementation PRs before merge, and the live-execution evidence
+recorded above predates it.
+
 This records independent advice and the author's disposition, not reviewer or
-human approval of revision 2. M0 questions and human sign-off remain pending.
+human approval of revision 7. M0 questions and human sign-off remain pending.
 
 Status remains Draft, deliberately: the user chose to keep it Draft because
 review may still change the content. Implementation proceeded in parallel as

--- a/docs/frds/README.md
+++ b/docs/frds/README.md
@@ -23,7 +23,7 @@ prerequisites for development.
 
 | ID | Feature | Status | Depends on |
 | --- | --- | --- | --- |
-| [FRD-0003](0003-azure-contribution-telemetry.md) | Azure contribution telemetry: observed successful Azure deployments | Draft | — |
+| [FRD-0003](0003-azure-deployment-observation-telemetry.md) | Azure deployment observation telemetry: observed successful Azure deployment operations | Draft | — |
 
 FRD numbers 0001 and 0002 are reserved by pull requests that were open when this
 index was written; check the index and open pull requests for collisions before

--- a/docs/frds/README.md
+++ b/docs/frds/README.md
@@ -23,10 +23,11 @@ prerequisites for development.
 
 | ID | Feature | Status | Depends on |
 | --- | --- | --- | --- |
+| [FRD-0003](0003-azure-contribution-telemetry.md) | Azure contribution telemetry: observed successful Azure deployments | Draft | — |
 
-No FRDs have been authored yet. Use `_template.md` to write the first one as
-`0001-kebab-case-title.md`, add a row to the table above, and keep the index and
-the document's status in sync as it moves through the lifecycle below.
+FRD numbers 0001 and 0002 are reserved by pull requests that were open when this
+index was written; check the index and open pull requests for collisions before
+choosing a number.
 
 [Historical F1-F21 specifications](../prd-docs/README.md) remain in `docs/prd-docs/`.
 Do not move, renumber, or silently reinterpret them. Refer to old features as


### PR DESCRIPTION
## What this adds

[FRD-0003](docs/frds/0003-azure-deployment-observation-telemetry.md) proposes **one** new Application Insights event, `azure_deployment_observed`, so we can see how often Azure Functions Skills lead to a real Azure deployment — not just how often a skill is invoked.

**This PR is documentation only.** The implementation is stacked above it.

## The proposal in one table

| Item | Value |
| --- | --- |
| Event | `azure_deployment_observed` |
| When | Once, after `azd up` or `azd provision` succeeds in `azure-functions-deploy` or `azure-functions-hosted-skills` |
| How | A bounded, read-only ARM query that confirms the deployment really provisioned something |
| Data | 7 categorical properties. No customer, subscription, resource, or user identity — not even hashed |
| Transport | The existing Application Insights sender. No new destination, credential, or service |
| Opt-out | The two existing environment variables and `telemetry.config.json`, checked **before** any Azure query |
| Failure | Always exits 0. A telemetry problem is never a deployment problem |

## What a reviewer should check

Section 4 is the external contract and is written to be read on its own:

| Section | Question it answers |
| --- | --- |
| 4.1 Quick reference | What is the command, the input, the bounds, and the output? |
| 4.2 What is sent | Exactly which properties leave the machine, and what never does |
| 4.3 When an event is sent | A condition-to-outcome table, plus the counting rules |
| 4.4 How the deployment is found | Lookup by name, and the scope limits |
| 4.5 ARM traversal and bounds | What is included, excluded, and every limit |
| 4.6 Privacy and governance | Envelope allowlist, owner, retention, access, rollback |
| 4.7 Execution model | Synchronous, bounded, always exit 0 |
| 4.8 Reporting rules | The disclaimer that must travel with the number |

Requirements are `AC-001` through `AC-012`, each with an observable acceptance criterion and a matching row in the section 6 test plan.

## Deliberate limits

This is an **observation** metric, not an attribution metric. Section 1 lists the interpretations that are invalid, and section 4.8 requires a verbatim disclaimer next to any published number.

- Only two skills, azd/Bicep, and subscription-scope roots. Resource-group-scope deployments are skipped, not misattributed.
- Success-only, so there is no attempt denominator and **no funnel or conversion rate**.
- Duplicate observations are possible; there is no exactly-once delivery.
- Cache-only redeployments report nothing, so maintenance work is undercounted.

## Review history

| Review | Outcome |
| --- | --- |
| Claude Opus 4.8, architecture, revision 1 | 2 clarifications → revision 2 (D-009) |
| GPT-5.6, implementation, revision 5 | 7 findings, all fixed in the implementation (D-012) |
| Live execution against real Azure, revision 6 | 3 defects that injected-dependency tests cannot catch (D-013, D-014) |
| @larohra, maintainer, revision 6 | 5 findings → revision 7 (D-015 to D-019) |

The maintainer review found that the document asserted attribution it could not establish. Per-command correlation was declined for the structural reason in D-010 — the delegating deploy skill does not own the `azd` process — so revision 7 takes the reframing branch and **renames the event so the name cannot outrun the mechanism** (`azure_contribution` → `azure_deployment_observed`). It also excluded cache-only redeployments (D-017), defined the execution model (D-018), added a data-governance table and AC-012 (D-019), and added the optional `startedAt` lower bound (D-016).

## Revision 8 (this update)

Restructured for readability at the maintainer's request. The document is now spec-first: tables for the contract, one line per decision, and a revision-history table instead of a per-revision narrative.

**No acceptance criterion, bound, privacy rule, or decision was changed or removed.** Section 5 remains append-only (D-001 to D-020).

## Status: Draft, with a merge gate

Human sign-off is required before **any** layer of this stack merges. Section 8 lists what must happen first, including one item worth flagging here:

> **Revision 7 renamed the event.** The implementation PRs still emit `azure_contribution` and expose `telemetry contribution`. Renaming is only free before release, so this must be applied to #259 and #260 before merge.

`startedAt` (D-016) and the AC-012 governance values are also specified but not yet implemented. The live evidence predates all three, so it needs re-running against the renamed contract.

## Stack

| PR | Layer |
| --- | --- |
| **#247** | FRD (this) |
| #259 | Telemetry core |
| #260 | Skill and docs wiring |

## Verification

Documentation only — relative links resolve, all eight FRD sections are present, and whitespace checks pass. No tests, live experiments, or paid evaluations were run for this layer.
