### PR TITLE
docs: make FRD workflow opt-in and clarify local evaluation safety

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,8 @@ This repository is the **Azure Functions Skills** CLI and plugin system — it e
 ## Security
 
 - No secrets in code.
-- Never run Vally evals on PR code — prompt injection risk. Use GitHub Environment with reviewer gate.
+- Never run Vally evals in PR-triggered CI or on unreviewed, untrusted contributor code. GitHub Actions evaluation runs require a GitHub Environment reviewer gate.
+- Local Vally evals of trusted code are allowed without that gate. Isolate every trial from normal developer configuration and verify skill-off trials inherit no repository, workspace, user, or plugin skills.
 - Never run `doctor --deep` on untrusted workspaces.
 
 ## Full Gate

--- a/.github/skills/frd/SKILL.md
+++ b/.github/skills/frd/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: frd
+description: "Create or revise a Feature Requirement Document (FRD) for this repository. Use only when the user explicitly asks to create, draft, or revise an FRD or Feature Requirement Document, or explicitly invokes this skill. Do not trigger for ordinary feature implementation, new skills, bug fixes, refactoring, general design or planning requests, or incidental FRD mentions. Feature size and public contract changes do not imply opt-in."
+---
+
+# Feature Requirement Documents
+
+This is a repository development skill, not a distributed Azure Functions skill.
+Keep its workflow opt-in so ordinary development does not acquire an unsolicited
+documentation or approval gate.
+
+## Scope
+
+Confirm that the user's request explicitly opts into FRD work. If it does not,
+continue the original task without creating an FRD or imposing FRD approval gates.
+Apply this process only to the feature or document the user selected, not to all
+work in the repository. A request to draft a document does not authorize feature
+implementation.
+
+## Authoring workflow
+
+1. Read the [FRD process and index](../../../docs/frds/README.md), the
+   [template](../../../docs/frds/_template.md), and any related FRD and its status.
+   Inspect the relevant code and documentation before proposing a design.
+2. Update a related FRD where possible. Otherwise, use the next available
+   `docs/frds/NNNN-kebab-case-title.md` and add it to the index. Preserve historical
+   documents and numbering in `docs/prd-docs/`.
+3. Maintain one lifecycle FRD per canonical skill rather than one per enhancement,
+   generated payload copy, or alias. Give cross-skill mechanisms a separate
+   shared-infrastructure FRD when included in the user's selected scope. Do not
+   create placeholder FRDs for unrelated skills.
+4. Complete all eight template sections, including stable requirement IDs,
+   observable acceptance criteria, non-goals, design, decisions, tests,
+   documentation impact, and status/sign-off. For skill designs, cover purpose,
+   triggers, inputs/outputs, tools, transitions, safety boundaries, and evaluations.
+5. Record non-trivial decisions with alternatives, rationale, decision-maker, and
+   date. Preserve earlier decisions and identify agent suggestions as proposals,
+   not human approval. Make unresolved questions explicit.
+6. Keep committed documents in English and explanations in the user's language.
+   Present the draft, open decisions, and review status; stop at the requested
+   authoring scope.
+
+## Review and delivery for the opted-in scope
+
+1. Obtain a separate architecture review and explicit human sign-off on the
+   identified revision before marking the FRD `Finalized`. Record the approver,
+   date, revision (commit SHA or content hash), scope, and approval reference.
+   Task-plan approval is not approval of an unwritten or unreviewed FRD.
+2. Implement the opted-in feature only after its FRD is `Finalized` and the user
+   has requested implementation. Drafting, reviewing, and maintaining the FRD
+   itself can proceed before feature approval.
+3. If an approved contract or scope changes, update the FRD and obtain approval
+   for the changed portion before implementing it. Keep the index and document's
+   status in sync.
+4. Link tasks, PRs, tests, and completion evidence to requirement IDs. Default to
+   one primary implementer working in understandable slices, with a separate
+   review pass at meaningful checkpoints. Report completed requirements,
+   remaining work, and changed decisions.
+5. Mark an FRD `Implemented` only when its acceptance criteria and evidence are
+   complete. Benchmark or evaluation FRDs require approved runs and a report,
+   not just sample code. Keep missing approval, measurements, or cleanup explicit.
+
+FRD approval does not authorize paid or live Azure experiments or bypass
+repository security rules. Confirm the code revision, target, identity, budget,
+repetition count, and owned-resource cleanup policy separately. Follow the
+repository's [evaluation security rules](../../../AGENTS.md#security): no Vally
+evals in PR-triggered CI or on unreviewed, untrusted contributor code; retain the
+GitHub Environment reviewer gate for GitHub Actions evaluations. Trusted local
+evaluations are allowed in isolated trial workspaces without that gate. Never
+run `doctor --deep` on untrusted workspaces.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,46 +40,6 @@
 - `templates/` is the canonical source; generated payloads are derived.
 - Never hand-edit files under `.github/plugins/`, `.plugin/`, or `.claude-plugin/`. Change `templates/`, then regenerate with `npm run build:plugin-payload`.
 
-## Feature Design and Approval
-
-Use the [FRD process](docs/frds/README.md) for changes that add or materially
-change a public CLI or library surface, an authoring format, discovery or routing
-behavior, shared infrastructure, or a canonical skill. Typos, documentation-only
-clarifications, bug fixes with a reproduction test, and small internal changes do
-not need a new FRD; explain their scope in the PR.
-
-1. Read the relevant FRD and its status before starting. New FRDs belong in
-   `docs/frds/`; preserve the historical documents and numbering in `docs/prd-docs/`.
-   Maintain one lifecycle FRD per canonical skill rather than creating an FRD for
-   each skill enhancement. Generated payload copies and aliases do not get their
-   own FRDs. Give cross-skill mechanisms a separate shared-infrastructure FRD.
-   Add a new skill's FRD before implementation; introduce an FRD for an existing
-   skill when its contract next changes materially.
-2. Complete all eight sections of the [template](docs/frds/_template.md), including
-   requirements, non-goals, decisions, tests, and documentation impact.
-3. Obtain a separate architecture review and explicit human sign-off on the
-   identified revision. **Do not implement a feature before its FRD is
-   `Finalized`.** Approval of a task plan is not approval of an unwritten FRD.
-   Drafting/reviewing FRDs and maintaining this documentation process are allowed
-   before feature approval.
-4. Record non-trivial decisions with alternatives, rationale, decision-maker,
-   and date. If an approved contract or scope changes, update the FRD and obtain
-   approval for the changed portion before implementing it.
-5. Link tasks, PRs, tests, and completion evidence to the FRD's requirement IDs.
-   Report what is complete, what remains, and which decisions changed at each
-   agreed checkpoint.
-6. Default to one primary implementer progressing through understandable slices,
-   not a fleet of concurrent implementation agents. Use a separate review pass
-   at meaningful checkpoints; do not expand scope ahead of human understanding.
-7. Mark an FRD `Implemented` only after its acceptance criteria and evidence are
-   complete. A benchmark or evaluation FRD requires actual approved runs and a
-   report, not just sample code. Missing approval, measurements, or cleanup
-   remain explicit blockers.
-
-FRD approval does not authorize live Azure experiments or bypass the security
-rules below. Confirm the target, budget, repetition count, and owned-resource
-cleanup policy separately before paid experiments.
-
 ## Testing
 
 - **TDD**: Write tests first. Every new function or module must have tests before implementation.
@@ -94,8 +54,10 @@ cleanup policy separately before paid experiments.
 - No secrets in code — use environment variables or secret managers.
 - No npm lifecycle scripts except `prepack`. Adding `postinstall`, `preinstall`, etc. is forbidden.
 - Run `npm run lint:security` for supply-chain checks.
-- **Never run Vally evals on PR code.** PR code is unreviewed and may contain prompt injection attacks. Skill content is loaded as LLM instructions and the agent has file-write and shell-execution permissions. Always use a GitHub Environment with a reviewer gate so only reviewed code is evaluated.
+- **Never run Vally evals in PR-triggered CI or on unreviewed, untrusted contributor code.** Skill content can contain prompt injection attacks, and the evaluation agent has file-write and shell-execution permissions. GitHub Actions evaluation runs must use a GitHub Environment with a reviewer gate so only reviewed code is evaluated.
+- Local Vally evaluation of trusted code is allowed and does not require a GitHub Environment reviewer gate. Use a clean Vally trial workspace containing only the eval's required files and target skill; never benchmark against the developer's normal workspace configuration. Verify that skill-off trials do not inherit repository, workspace, user, or plugin skills through discovery.
 - Never run `doctor --deep` on untrusted workspaces.
+- Confirm the target, budget, repetition count, and owned-resource cleanup policy separately before paid experiments.
 
 ## Boundaries
 

--- a/docs/frds/README.md
+++ b/docs/frds/README.md
@@ -6,6 +6,19 @@ and [FRD template](https://github.com/Azure/azure-functions-agents-runtime/blob/
 to this TypeScript CLI and skill repository. It does not introduce a new execution
 framework or a requirement to launch multiple agents.
 
+## Opt-in only
+
+FRDs are optional and used only when the user explicitly requests FRD work.
+Use the repository-local [frd skill](../../.github/skills/frd/SKILL.md) for requests
+such as "Create an FRD for this feature" or "Draft a Feature Requirement Document."
+Ordinary implementation, new skills, bug fixes, refactoring, and general planning
+requests do not opt in, regardless of feature size or public contract impact.
+An incidental FRD mention is not an opt-in request.
+
+The authoring, ownership, review, and delivery gates below apply only to the
+feature or document selected by the user. They are not repository-wide
+prerequisites for development.
+
 ## Index
 
 | ID | Feature | Status | Depends on |
@@ -20,19 +33,17 @@ Do not move, renumber, or silently reinterpret them. Refer to old features as
 `F21`, for example, and new features as `FRD-0001`; these are separate sequences.
 The current CLI contract is documented in [CLI Reference](../cli-reference.md).
 
-## Choose the development lane
+## Choose the development lane after opt-in
 
-| Scope | Examples | Process |
+| User intent | Examples | Process |
 | --- | --- | --- |
-| Nit | Typo, formatting, comment correction | Change, appropriate checks, PR |
-| Bug | Incorrect behavior or regression | Reproduction test, fix, checks, PR |
-| Small internal feature | One module, no public contract change | Short design note in PR, tests, implementation, docs |
-| Medium or larger feature | Public CLI/library surface, new authoring format, discovery behavior, cross-module feature | FRD, independent review, human sign-off, implementation, evidence |
+| No explicit FRD request | Any feature, skill, bug fix, refactoring, or general design task | Follow normal development standards; no FRD gate |
+| Explicit FRD request | Create, draft, or revise an FRD for a selected feature | FRD, independent review, human sign-off; implementation and evidence when requested |
 
 Update a related FRD rather than creating one for every module or test case.
-If a bug fix changes an approved public contract, record and review that contract
-change even if the code patch is small. Pure FRD/process documentation can be
-written before feature approval.
+Within the opted-in scope, if a bug fix changes an approved public contract,
+record and review that contract change even if the code patch is small. Pure
+FRD/process documentation can be written before feature approval.
 
 ## Choose FRD ownership
 
@@ -46,9 +57,10 @@ A canonical skill is the authored source skill, not each generated payload copy,
 target-specific rendering, or alias. Those derived forms are covered by the
 canonical skill's FRD and the relevant shared-infrastructure FRD.
 
-New canonical skills require an FRD before implementation. Existing skills do
-not need placeholder FRDs created in bulk; add one when the skill next receives a
-substantive contract change. Update the skill's FRD when its purpose, triggering,
+When the user opts into an FRD for a new canonical skill, draft it before
+implementing that skill. Do not create placeholder FRDs for existing skills in
+bulk or automatically start FRDs for substantive contract changes.
+Within the opted-in scope, update the skill's FRD when its purpose, triggering,
 inputs or outputs, tool chain, transitions, safety boundary, or acceptance criteria
 change. Typos, reference refreshes, and editorial clarifications do not require an
 FRD revision unless they alter the skill's behavior or contract.
@@ -84,7 +96,8 @@ proposed by an agent. Do not present an agent proposal as human approval.
 | Finalized | Identified revision explicitly approved by a human | Approver, date, revision, scope, approval reference |
 | Implemented | Approved scope delivered, documented, and evidenced | Accepted tests/results and implementation reference |
 
-Implementation starts only after `Finalized`. A general task-plan approval does
+For the opted-in scope, implementation starts only after `Finalized` and a user
+request to implement. A general task-plan approval does
 not finalize a document that the human has not reviewed. The agent may record an
 explicit human approval; it may not approve its own FRD.
 


### PR DESCRIPTION
## Summary
- Remove mandatory FRD governance from the root development instructions and move it to an explicit-opt-in repository-local `frd` skill.
- Align the FRD guide with opt-in scope while preserving review, sign-off, and evidence requirements for selected FRD work.
- Clarify that trusted local Vally evaluations are allowed without a GitHub Environment gate; prohibit PR-triggered evaluation CI and evaluation of unreviewed, untrusted contributor code.
- Require clean trial workspaces and prevent skill-off discovery from inheriting repository, workspace, user, or plugin skills.

## Scope
Documentation/process only. This is the base layer for the forthcoming Vally local benchmark stack; no evaluation runtime or Azure DevOps integration changes are included.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test` (268 passed)
- FRD skill frontmatter validation and `git diff --check`