### PR TITLE
feat: add isolated local benchmark workflow

### DIFF
--- a/.vally.yaml
+++ b/.vally.yaml
@@ -2,6 +2,9 @@
 # Docs: https://aka.ms/vally
 #
 # Suites filter across all evals/**/eval.yaml using stimulus tags.
+# These suites expose all template skills, not an isolated OFF baseline.
+# For the target-only benchmark use npm run eval:run (see experiments/README.md).
+# Never execute agent evaluations in PR-triggered CI or on untrusted code.
 # Run with:  npx vally eval --suite smoke
 #            npx vally eval --suite pr
 #            npx vally eval --suite full
@@ -20,7 +23,7 @@ suites:
       tier: smoke
 
   pr:
-    description: "PR gate — same scope as smoke"
+    description: "Legacy smoke alias — trusted manual/reviewer-gated runs only"
     filter:
       tier: smoke
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 Latest E2E status: [HTML report](https://azure.github.io/azure-functions-skills/)
 
+For contributor skill benchmarks, see the [isolated local Vally workflow](experiments/README.md#local-convenience-commands)
+and [static benchmark report](dashboard/README.md). These are separate from the installation E2E report above.
+
 ## What & why
 
 Azure Functions Skills equips your coding agent with Functions-specific knowledge — trigger/binding patterns, language anti-patterns, runtime versions, deployment best practices — so the agent gives accurate guidance instead of generic advice.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -2,6 +2,8 @@
 
 Generate the supplied Benchmark Explorer design from **existing** Vally 0.16.0
 experiment output. This command never runs an agent, calls a model, or regrades.
+For an approved new evaluation followed by this report, use the
+[isolated local workflow](../experiments/README.md#local-convenience-commands).
 
 ```powershell
 npm run eval:report -- --input C:\private\native-merged --output C:\reports\benchmark-site
@@ -15,8 +17,9 @@ files can later be hosted as a static site.
 
 ## Input contract
 
-Use **one** canonical experiment directory, usually the output of
-`vally experiment merge`. Never combine the merged output with its source shards.
+Use **one** canonical experiment directory: `native/` in the local wrapper's
+private bundle, or the output of `vally experiment merge`. Never combine the
+merged output with its source shards.
 It must contain `experiment-manifest.json`, `plan-snapshot.json` and each
 manifest variant's `results.jsonl` and `run-summary.jsonl`. Standalone `vally eval`
 and raw shard manifests are deliberately not supported.

--- a/evals/README.md
+++ b/evals/README.md
@@ -6,17 +6,24 @@ single skill and contains an `eval.yaml` defining stimuli, graders, and configur
 
 > Source / docs: <https://aka.ms/vally> · npm: [`@microsoft/vally-cli`](https://www.npmjs.com/package/@microsoft/vally-cli)
 
-For the native, target-only local benchmark proof, use the
-[isolated TypeScript HTTP scenario](azure-functions-create/typescript-http/README.md).
-Its isolation protocol replaces the repository-root invocation below; do not use
-the older routing suites as a clean skill-off baseline.
+For the native, target-only local benchmark, use
+[`npm run eval:run`, `eval:report`, or `eval`](../experiments/README.md#local-convenience-commands).
+These commands stage the [TypeScript HTTP scenario](azure-functions-create/typescript-http/README.md)
+with isolated profiles outside the checkout. The older routing suites below are
+**not** a clean skill-off baseline.
 
-## Prerequisites
+Run evaluations only on reviewed, trusted code with approved inference spending.
+Never run them in PR-triggered CI or against untrusted contributor code. GitHub
+Actions evaluations require the existing reviewer-gated Environment.
+
+## Existing suite prerequisites
 
 - **Node.js 22.12+** (required by Vally; the rest of the repo targets Node 18+ but Vally
   itself does not get bundled into the published package — it is dev-only).
 - **GitHub Copilot CLI authentication**:
-  - Local: `gh auth login` (Vally reuses your `gh` session).
+  - Existing local suites: `gh auth login` (Vally reuses your `gh` session).
+    The isolated benchmark instead requires an explicit environment token;
+    it does not reuse credential stores.
   - CI: the workflow uses the existing `functions-skills-live-e2e`
     GitHub Environment and consumes the existing `COPILOT_CLI_TOKEN`
     secret, mapping it onto `COPILOT_GITHUB_TOKEN` (the variable name
@@ -24,15 +31,20 @@ the older routing suites as a clean skill-off baseline.
     on the eval step only, so checkout / install / pre-warm / artifact
     upload do not see it. Protected-branches policy + `azure-functions-bucees-team`
     reviewers on the environment gate every run.
-- Run from the repository root so the relative paths in `.vally.yaml` resolve.
+- These existing suites run from the repository root so `.vally.yaml` resolves.
+  That configuration exposes all template skills and normal discovery; it is
+  deliberately separate from the isolated benchmark commands.
 - For the **live (Tier 3) deploy workflow**, additional Azure setup is required —
   see [CI setup — repository / Azure side](#ci-setup--repository--azure-side) below.
 
-## Running
+## Running existing suites (not the isolated benchmark)
 
 ```bash
-# PR gate / smoke — routing checks only (cheapest)
-npx vally eval --suite smoke
+# Trusted manual smoke run — still uses paid agent inference
+npm run eval:smoke
+
+# Previous npm run eval behavior, with explicitly selected suite
+npm run eval:suites -- --suite triggers
 
 # Single skill, single spec
 npx vally eval --eval-spec evals/azure-functions-create/eval.yaml
@@ -60,7 +72,7 @@ Defined in [`.vally.yaml`](../.vally.yaml) at the repo root:
 | suite | filter | use |
 | --- | --- | --- |
 | `smoke` | `tier: smoke` | quick routing checks |
-| `pr` | `tier: smoke` | PR gate (alias of smoke) |
+| `pr` | `tier: smoke` | legacy alias of smoke; not permission to run in PR-triggered CI |
 | `triggers` | `area: routing` | all skill-invocation/routing checks |
 | `integration` | `type: integration` | LLM-backed behavior tests |
 | `full` | `tier: [smoke, full]` | everything **except** live — nightly |
@@ -252,7 +264,8 @@ az group list --tag vally-eval=true -o table
 
 - Every stimulus running through the `copilot-sdk` executor invokes the GitHub
   Copilot agent at least once, which incurs LLM cost.
-- `tier: smoke` stimuli are intentionally small (1 prompt × N runs) for PRs.
+- `tier: smoke` stimuli are intentionally small (1 prompt × N runs), but still
+  require trusted code and approved inference spending.
 - Nightly `full` runs should be gated behind workflow_dispatch or schedule.
 - `tier: live` stimuli additionally **create real Azure resources**. They run
   only from the separate [Skill Evaluation - Azure Live Deploy](../.github/workflows/skill-evaluation-azure-live-deploy.yml)
@@ -276,11 +289,11 @@ reviewer can iterate on one skill at a time:
 
 Eval specs default to `claude-sonnet-4.6` (matches the convention used by
 [`microsoft/GitHub-Copilot-for-Azure`](https://github.com/microsoft/GitHub-Copilot-for-Azure)
-and keeps PR / nightly cost and runtime stable). Override per run:
+and keeps suite cost and runtime stable). Override per run:
 
 | Layer | Model | When |
 | --- | --- | --- |
-| PR gate (`smoke`) | `claude-sonnet-4.6` | every push |
+| Trusted smoke (`smoke`) | `claude-sonnet-4.6` | manual / reviewer-gated workflow |
 | Nightly (`full`) | `claude-sonnet-4.6` | scheduled |
 | Reality check | `claude-opus-4.7` | manual via `--model claude-opus-4.7`, e.g. before a release, to mirror what GitHub Copilot CLI users typically run |
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -43,14 +43,45 @@ $env:VALLY_RUN_ROOT = 'Q:\'
 $env:VALLY_OUTPUT_ROOT = 'C:\private\benchmarks'
 # Explicit acknowledgment of reviewed local code, not spending approval.
 $env:VALLY_TRUSTED = '1'
-# Supply COPILOT_GITHUB_TOKEN, GH_TOKEN or GITHUB_TOKEN through your approved environment.
 
 # Free: stage isolated inputs and resolve the native four-cell plan.
 npm run eval -- --all --dry-run
+```
 
+Before a paid run, supply `COPILOT_GITHUB_TOKEN`, `GH_TOKEN` or `GITHUB_TOKEN`
+through your approved environment. With GitHub CLI installed and authenticated
+to an account with Copilot access, capture its token directly into the current
+PowerShell process's environment without displaying it:
+
+```powershell
+$env:COPILOT_GITHUB_TOKEN = gh auth token --hostname github.com
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($env:COPILOT_GITHUB_TOKEN)) {
+    $env:COPILOT_GITHUB_TOKEN = $null
+    throw 'Could not obtain a GitHub token. Run gh auth login --hostname github.com for an account with Copilot access, then retry.'
+}
+
+# Acquiring a token does not authorize inference spending.
 # Paid: ONLY after approving the models, four trials, budget and cleanup policy.
 npm run eval -- --all
 ```
+
+For multiple authenticated accounts, replace the assignment with the following,
+substituting the intended account for `<github-user>`, and retain the failure
+check before running an evaluation:
+
+```powershell
+$env:COPILOT_GITHUB_TOKEN = gh auth token --hostname github.com --user '<github-user>'
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($env:COPILOT_GITHUB_TOKEN)) {
+    $env:COPILOT_GITHUB_TOKEN = $null
+    throw 'Could not obtain the selected account token. Run gh auth login --hostname github.com for that account, then retry with its --user value.'
+}
+```
+
+Do **not** run `gh auth token` by itself: it prints the token to the terminal.
+Keep the assignment above, do not echo the environment variable, and never put
+the token in configuration files, logs or command-line arguments. Token
+acquisition is a manual environment-preparation step; the wrapper itself still
+does not read credential stores, and dry-runs do not need a token.
 
 Choose `--all` **or** `--skill <registered-id>`. Omitting the selection is an
 error, not implicit permission to run everything. Repeat `--models` to select

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -3,7 +3,9 @@
 These Vally **0.16.0** experiments reuse the
 [TypeScript HTTP scenario](../evals/azure-functions-create/typescript-http/README.md).
 They compare the same objective task, not whether the agent invoked a skill.
-No dashboard, custom runner, LLM judge, Azure resources, or CI is involved.
+Vally owns execution, grading and measurement; the existing static dashboard
+consumes its canonical results. No custom agent runner, LLM judge, Azure
+resources, or CI is involved.
 Run only reviewed, trusted local code with an approved inference budget.
 Never run these from PR-triggered CI or on untrusted contributor content.
 
@@ -11,6 +13,11 @@ Never run these from PR-triggered CI or on untrusted contributor content.
 | --- | --- | --- |
 | `typescript-http-pair.experiment.yaml` | Sonnet 5, skill OFF/ON | 2 |
 | `typescript-http-matrix.experiment.yaml` | Sonnet 5 and GPT-6 Astra, each OFF/ON | 4 |
+
+These two YAML files preserve the manual definitions used for the observations
+below. The convenience workflow's skill/model registration is now solely
+[`local-benchmark.json`](local-benchmark.json); it does not read either proof
+YAML or the repository's suite configuration.
 
 Each cell has `runs: 1`, one worker, a ten-minute native timeout and
 `max_duration`, and the same three native graders. OFF replaces the skill array
@@ -26,9 +33,139 @@ version, `experiment-runner.js` does not supply a retry override and native
 Do not add the unsupported eval-only flag. These limits are not token or money
 caps; `max_turns` and `max_tokens` are not execution limits in 0.16.0.
 
-## Prepare an isolated execution
+## Local convenience commands
 
-Do not execute these commands from a developer checkout or normal profile.
+Configure the environment once, then run one noninteractive npm command from
+this checkout. The output parent must already exist:
+
+```powershell
+$env:VALLY_RUN_ROOT = 'Q:\'
+$env:VALLY_OUTPUT_ROOT = 'C:\private\benchmarks'
+# Explicit acknowledgment of reviewed local code, not spending approval.
+$env:VALLY_TRUSTED = '1'
+# Supply COPILOT_GITHUB_TOKEN, GH_TOKEN or GITHUB_TOKEN through your approved environment.
+
+# Free: stage isolated inputs and resolve the native four-cell plan.
+npm run eval -- --all --dry-run
+
+# Paid: ONLY after approving the models, four trials, budget and cleanup policy.
+npm run eval -- --all
+```
+
+Choose `--all` **or** `--skill <registered-id>`. Omitting the selection is an
+error, not implicit permission to run everything. Repeat `--models` to select
+a registered subset; do not supply a comma-separated model list:
+
+```powershell
+# Alternative to --all: one skill, both configured models (four trials).
+npm run eval -- --skill azure-functions-create --models claude-sonnet-5 --models gpt-6-astra
+
+# Run without HTML: this subset has only two trials, Astra OFF/ON.
+npm run eval:run -- --skill azure-functions-create --models gpt-6-astra
+
+# Later render the printed canonical path without inference.
+npm run eval:report -- --input C:\private\benchmarks\<printed-bundle>\native --output C:\reports\benchmark-site
+```
+
+Unknown/empty selections, repeated model IDs, or combining `--all` and `--skill`
+are rejected before native launch. No model flags means all **registered**
+models for the explicitly selected skill set. Selection preserves configuration
+order; the first selected model's OFF arm is the native baseline. The initial
+registration has exactly one skill/scenario and two models: `--all` means four
+trials, not the legacy full/live suites.
+
+`--run-root` (or `VALLY_RUN_ROOT`) is an **existing, clean external parent** for a fresh temporary
+directory, not a previously staged trial. Choose a writable parent outside the
+checkout with no discovery configuration in its ancestors (for example `/tmp`
+on Linux, when clean). `VALLY_OUTPUT_ROOT` is an existing private parent for
+automatically named, fresh `benchmark-<uuid>` bundles. Alternatively, `--output`
+specifies one **new private bundle**, with an existing parent, outside the
+checkout. Explicit flags override environment defaults. Paths are resolved
+through existing links before checks; an existing bundle is never reused.
+Node 24+, PowerShell 7,
+npm and Functions Core Tools v4 must already be on PATH. The wrapper is Node/ESM
+and cross-platform; the scenario's existing grader requires `pwsh`.
+
+`--trusted` (or exactly `VALLY_TRUSTED=1`) acknowledges review of the checked-out configuration, eval, target
+skill and executable tools. It is **not a sandbox or a budget authorization**.
+Agents retain local file/shell access: use only trusted content and approve
+inference spending separately. PR-triggered execution is refused. The wrapper
+does not acquire tokens, copy credential stores, log tokens, provision Azure,
+or configure CI. It normalizes the first available token in the order above to
+`COPILOT_GITHUB_TOKEN`; a dry-run receives no token at all.
+
+The central JSON registers model IDs, eval paths and the required files for each
+skill. Its initial file list is target `SKILL.md` plus two own references
+(`go-project.md`, `language-snippets.md`); no fixture is needed for this empty-app
+scenario. Selected evals must follow `evals/<skill>/<scenario>/eval.yaml`.
+Explicit file entries are restricted to that target's skill/references and the
+declared scenarios' fixture directories; path traversal and links leaving the
+repository are rejected. Registration is reviewed code, not arbitrary ingestion.
+
+The wrapper stages only the selected evals/files and creates one temporary
+native experiment definition, encoded as JSON (valid YAML). Its native model
+matrix contains only selected models. The ON path uses Vally's
+`${eval.grandparent}` interpolation to resolve each eval's own target skill;
+OFF remains `[]`. This supports multiple registered skills without adding a
+target axis or executing a custom model/skill loop. No new skill scenarios are
+registered automatically when templates or legacy suites change.
+
+The wrapper checks discovery ancestors, creates
+separate empty cwd/home/config/appdata/cache/temp directories, and constructs an
+OS/executable environment allowlist. It excludes inherited SSH agents, Azure
+credentials, Copilot overrides, plugins/MCP settings and npm configuration.
+Both arms disable the two builtin skills using the scenario's native settings;
+Vally supplies fresh per-trial workspaces/config and the OFF/ON skill arrays.
+These controls prevent ambient discovery, not malicious code from escaping.
+
+Dependency installation inside trials defaults to the public HTTPS npm registry
+with empty user/global npm config and a fresh cache. If an approved registry is
+required, explicitly set `VALLY_NPM_REGISTRY` or add
+`--registry https://your-approved-registry/` to either run command;
+credential-bearing URLs are rejected. Normal `.npmrc` files and
+registry credentials are not inherited.
+
+The wrapper executes the **selected native matrix once** as shard `1/1` with a
+fresh UUID, one worker and `--require-pass`. Native `experiment merge` then
+converts that single complete shard into the canonical experiment output used
+by `eval:report`. This is necessary because even an unsharded 0.16.0 run writes
+`shard-manifest.json`, not `experiment-manifest.json`. There is no model loop,
+custom merge, retry, comparison judge or additional inference in reporting.
+
+```text
+<private-bundle>/
+  raw/<run-id>/shard-1-of-1/   Native originals, including session logs/patches
+  native/                    Native merged canonical results
+  site/                      index.html + logo (only with npm run eval)
+```
+
+**Only `site/` is a publication candidate**, after review. Never publish the
+bundle, `raw/`, `native/` or native `report.md`: these contain private prompts,
+paths and logs. `eval:run` prints the canonical path for later `eval:report`.
+Completed native grader failures can still produce a dashboard, but the
+command preserves the nonzero run/merge exit. Missing manifests, launch errors
+or invalid report input fail explicitly and retain the native partial files;
+they never produce an empty success dashboard.
+
+The wrapper removes only its freshly owned staging/profile/trial directory in
+`finally` after native return, not the private bundle or the parent directory.
+Vally and the existing grader own agent/host cleanup; no shared processes are
+stopped. A filesystem cleanup failure is reported with the abandoned directory
+and private output paths; it makes the workflow nonzero without replacing a
+primary native error or discarding valid results. Native run/merge exits remain
+separate from the overall workflow exit. A forced process/OS termination can bypass `finally`: inspect owned
+process identities before manually removing the abandoned `vally-local-*`
+directory. Never delete other sessions' roots or stop hosts by name.
+
+A dry-run generates **no bundle, trial measurement or dashboard**. It validates
+native resolution and wrapper wiring, not inference, model access or grading.
+The four real observations below predate this wrapper; they were not rerun to
+validate these convenience commands.
+
+## Manual native isolation protocol
+
+The commands in this section are advanced manual operations, not replacements
+for the wrapper's isolation. Do not execute them from a developer checkout or normal profile.
 Follow the scenario's **Isolation protocol**, including its environment
 allowlist, empty HOME/USERPROFILE/config/temp directories, ancestry checks,
 bundled runtime, and native ON/OFF discovery checks. Both conditions must show
@@ -214,3 +351,21 @@ was then checked with a temporary, read-only call to the already-installed SDK's
 Native originals, including the merged report, remain private because they
 contain prompts, local paths, and command output. Only the native metric values
 above are reproduced here.
+
+## Evaluation asset classification
+
+Inspection found no obsolete custom evaluation framework to delete.
+
+| Classification | Assets | Reason |
+| --- | --- | --- |
+| REUSE | `local-benchmark.json`, TypeScript HTTP eval/grader | Central registration plus native objective local grading; no independent runner. |
+| REUSE | Matrix/pair YAML | Historical manual proof definitions, not configuration read by the convenience workflow. |
+| REUSE | `src/evaluation/report.ts`, `dashboard/`, report tests | Small deterministic native-result adapter and static UI; no backend or database. |
+| REUSE | Other `evals/` YAML, fixtures and `_base/common-graders.yaml` | Existing routing/behavior/live coverage and reference graders, distinct from this target-only benchmark. |
+| REUSE | `.vally.yaml`, `eval:suites`, `eval:smoke`, `eval:full`, existing evaluation/cleanup workflows | Preserve existing suite scope and reviewer-gated live behavior; not an isolated OFF baseline. |
+| REUSE | `src/telemetry/` and generated hook assets | Product telemetry, not a custom evaluation measurement system. |
+| DELETE | None | No custom SDK runner, model loop, trajectory parser, result DB or dashboard service was found. |
+| UNKNOWN | None in the inspected evaluation assets | No speculative removal or compatibility layer is needed. |
+
+The old `npm run eval` root-suite alias is now named `npm run eval:suites`.
+Existing smoke/full commands and workflow invocations are unchanged.

--- a/experiments/local-benchmark.json
+++ b/experiments/local-benchmark.json
@@ -1,0 +1,13 @@
+{
+  "models": ["claude-sonnet-5", "gpt-6-astra"],
+  "skills": {
+    "azure-functions-create": {
+      "evals": ["evals/azure-functions-create/typescript-http/eval.yaml"],
+      "files": [
+        "templates/skills/azure-functions-create/SKILL.md",
+        "templates/skills/azure-functions-create/references/go-project.md",
+        "templates/skills/azure-functions-create/references/language-snippets.md"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,9 +53,11 @@
     "release:local": "node scripts/release-local.mjs",
     "eval:lint": "vally lint --eval-spec evals",
     "eval:report": "npm run compile && node lib/evaluation/report.js",
+    "eval:run": "npm run compile && node lib/evaluation/run.js",
     "eval:smoke": "vally eval --suite smoke",
     "eval:full": "vally eval --suite full",
-    "eval": "vally eval"
+    "eval:suites": "vally eval",
+    "eval": "npm run compile && node lib/evaluation/run.js --report"
   },
   "engines": {
     "node": ">=18"

--- a/src/evaluation/run.ts
+++ b/src/evaluation/run.ts
@@ -1,0 +1,250 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { copyFileSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import { generateReport } from './report.js';
+
+const repository = fileURLToPath(new URL('../../', import.meta.url));
+const experiment = join('experiments', 'local.experiment.yaml');
+const settings = '{"disabledSkills":["customize-cloud-agent","github-pr-media"]}';
+const osVariables = new Set(['PATH', 'PATHEXT', 'SYSTEMROOT', 'WINDIR', 'SYSTEMDRIVE', 'COMSPEC',
+  'PROGRAMFILES', 'PROGRAMFILES(X86)', 'PROGRAMW6432', 'PROCESSOR_ARCHITECTURE', 'NUMBER_OF_PROCESSORS', 'OS']);
+
+interface Selection {
+  all?: boolean;
+  skill?: string;
+  models?: string[];
+}
+
+interface RunOptions extends Selection {
+  runRoot?: string;
+  output?: string;
+  trusted?: boolean;
+  dryRun?: boolean;
+  report?: boolean;
+  registry?: string;
+}
+
+interface RunResult {
+  exitCode: number;
+  dryRun: boolean;
+  native?: string;
+  site?: string;
+  runExit?: number;
+  mergeExit?: number;
+}
+
+function check(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Local benchmark: ${message}`);
+}
+
+function object(value: unknown): Record<string, unknown> {
+  check(value !== null && typeof value === 'object' && !Array.isArray(value), 'invalid benchmark configuration object.');
+  return value as Record<string, unknown>;
+}
+
+function strings(value: unknown): string[] {
+  check(Array.isArray(value) && value.length > 0 && value.every(v => typeof v === 'string' && v.length > 0)
+    && new Set(value).size === value.length, 'configuration lists must contain unique nonempty strings.');
+  return value as string[];
+}
+
+export function selectBenchmark(value: unknown, selection: Selection) {
+  const config = object(value);
+  const models = strings(config.models);
+  const skills = object(config.skills);
+  const identifier = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,159}$/;
+  check(models.every(model => identifier.test(model)) && Object.keys(skills).length > 0,
+    'invalid models/skills in benchmark configuration.');
+  check(Boolean(selection.all) !== (selection.skill !== undefined), 'specify exactly one of --all or --skill <registered-id>.');
+  check(selection.skill === undefined || Object.hasOwn(skills, selection.skill), 'unknown --skill; use a registered skill.');
+  const selectedModels = selection.models ?? models;
+  check(selectedModels.length > 0 && new Set(selectedModels).size === selectedModels.length
+    && selectedModels.every(model => models.includes(model)), '--models must be a nonempty, unique subset of registered models.');
+  const evals: string[] = [];
+  const files: string[] = [];
+  for (const [id, entry] of Object.entries(skills)) {
+    check(identifier.test(id), 'invalid skill identifier in configuration.');
+    const definition = object(entry);
+    const declaredEvals = strings(definition.evals);
+    const declaredFiles = strings(definition.files);
+    const safePath = (file: string) => file.split('/').every(part => identifier.test(part) && part !== '.' && part !== '..');
+    const target = `templates/skills/${id}`;
+    check(declaredEvals.every(file => {
+      const parts = file.split('/');
+      return safePath(file) && parts.length === 4 && parts[0] === 'evals' && parts[1] === id && parts[3] === 'eval.yaml';
+    }), 'configuration evals must use evals/<skill>/<scenario>/eval.yaml.');
+    check(declaredFiles.includes(`${target}/SKILL.md`) && declaredFiles.every(file =>
+      safePath(file) && (file === `${target}/SKILL.md` || file.startsWith(`${target}/references/`)
+        || declaredEvals.some(evalFile => file.startsWith(`${evalFile.slice(0, -'eval.yaml'.length)}fixtures/`)))),
+    'configuration files must be target SKILL.md, own references or declared scenario fixtures.');
+    if (selection.all || id === selection.skill) {
+      evals.push(...declaredEvals);
+      files.push(...declaredFiles);
+    }
+  }
+  return { models: models.filter(model => selectedModels.includes(model)), evals, files: [...new Set(files)] };
+}
+
+function inside(parent: string, child: string): boolean {
+  const path = relative(parent, child);
+  return path === '' || (path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path));
+}
+
+function cleanAncestors(directory: string): void {
+  for (let current = directory; ; current = dirname(current)) {
+    for (const marker of ['.git', 'AGENTS.md', 'CLAUDE.md', '.github', '.agents', '.claude', '.copilot', '.vally.yaml', '.vally.yml']) {
+      check(!lstatSync(join(current, marker), { throwIfNoEntry: false }),
+        `discovery configuration at ${join(current, marker)}; choose a clean external --run-root.`);
+    }
+    if (dirname(current) === current) break;
+  }
+}
+
+export function benchmarkEnvironment(root: string, source: NodeJS.ProcessEnv, dryRun: boolean,
+  registry = 'https://registry.npmjs.org/'): NodeJS.ProcessEnv {
+  const url = new URL(registry);
+  check(url.protocol === 'https:' && !url.username && !url.password && !url.search && !url.hash,
+    '--registry must be an HTTPS registry URL without credentials, query or fragment.');
+  const env: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(source)) {
+    if (osVariables.has(name.toUpperCase())) env[name.toUpperCase()] = value;
+  }
+  const home = join(root, 'home');
+  Object.assign(env, {
+    HOME: home, USERPROFILE: home, HOMEDRIVE: parse(home).root.replace(/[\\/]$/, ''),
+    HOMEPATH: home.slice(parse(home).root.replace(/[\\/]$/, '').length),
+    TEMP: join(root, 'temp'), TMP: join(root, 'temp'), TMPDIR: join(root, 'temp'),
+    APPDATA: join(root, 'appdata'), LOCALAPPDATA: join(root, 'localappdata'),
+    XDG_CONFIG_HOME: join(root, 'config'), XDG_CACHE_HOME: join(root, 'cache'),
+    XDG_DATA_HOME: join(root, 'data'), XDG_STATE_HOME: join(root, 'state'),
+    COPILOT_HOME: join(root, 'config'), GH_CONFIG_DIR: join(root, 'config', 'gh'),
+    GIT_CONFIG_GLOBAL: process.platform === 'win32' ? 'NUL' : '/dev/null', GIT_CONFIG_NOSYSTEM: '1',
+    npm_config_userconfig: join(home, '.npmrc'), npm_config_globalconfig: join(home, 'global.npmrc'),
+    npm_config_cache: join(root, 'cache', 'npm'), npm_config_registry: url.href,
+    FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT: '1', VALLY_TELEMETRY_OPTOUT: '1',
+    COPILOT_AUTO_UPDATE: 'false', COPILOT_HOME_SETTINGS_JSON: settings,
+  });
+  if (!dryRun) {
+    const token = source.COPILOT_GITHUB_TOKEN || source.GH_TOKEN || source.GITHUB_TOKEN;
+    check(token, 'set COPILOT_GITHUB_TOKEN (or GH_TOKEN / GITHUB_TOKEN); normal credential stores are not copied.');
+    env.COPILOT_GITHUB_TOKEN = token;
+  }
+  return env;
+}
+
+export function runBenchmark(options: RunOptions, sourceEnv = process.env) {
+  const selection = selectBenchmark(JSON.parse(readFileSync(join(repository, 'experiments', 'local-benchmark.json'), 'utf8')), options);
+  check(options.trusted ?? sourceEnv.VALLY_TRUSTED === '1',
+    'review the code and acknowledge --trusted (or VALLY_TRUSTED=1); this is not a sandbox or spending approval.');
+  check(options.dryRun || !sourceEnv.GITHUB_EVENT_NAME?.startsWith('pull_request'),
+    'paid evaluations must not run in PR-triggered CI.');
+  const runRoot = options.runRoot ?? sourceEnv.VALLY_RUN_ROOT;
+  check(runRoot, 'set --run-root or VALLY_RUN_ROOT to an existing clean external parent.');
+  check(options.output || sourceEnv.VALLY_OUTPUT_ROOT, 'set --output or VALLY_OUTPUT_ROOT to an existing private output parent.');
+  const parent = realpathSync(runRoot);
+  const requestedOutput = options.output ?? join(realpathSync(sourceEnv.VALLY_OUTPUT_ROOT ?? ''), `benchmark-${randomUUID()}`);
+  const output = join(realpathSync(dirname(resolve(requestedOutput))), parse(resolve(requestedOutput)).base);
+  const registry = options.registry ?? sourceEnv.VALLY_NPM_REGISTRY;
+  const repo = realpathSync(repository);
+  check(!inside(repo, parent) && !inside(repo, output), '--run-root and --output must be outside the repository.');
+  cleanAncestors(parent);
+  check(!lstatSync(output, { throwIfNoEntry: false }), 'choose a new --output private bundle; existing paths are never reused.');
+  // Validate authentication and registry before creating any owned files.
+  benchmarkEnvironment(parent, sourceEnv, options.dryRun === true, registry);
+  const root = mkdtempSync(join(parent, 'vally-local-'));
+  let outcome: RunResult | undefined;
+  try {
+    const env = benchmarkEnvironment(root, sourceEnv, options.dryRun === true, registry);
+    for (const directory of ['home', 'temp', 'appdata', 'localappdata', 'config', 'cache', 'data', 'state', 'empty']) {
+      mkdirSync(join(root, directory));
+    }
+    writeFileSync(join(root, 'config', 'settings.json'), settings);
+    for (const file of [...selection.evals, ...selection.files]) {
+      const source = realpathSync(join(repo, ...file.split('/')));
+      check(inside(repo, source), 'input links must not leave the trusted repository.');
+      const target = join(root, 'inputs', file);
+      mkdirSync(dirname(target), { recursive: true });
+      copyFileSync(source, target);
+    }
+    const definition = {
+      name: 'local-skill-benchmark',
+      evals: selection.evals.map(file => `../${file}`),
+      overrides: { runs: 1, timeout: '10m' }, execution: { workers: 1 },
+      baseline: { skill: 'off', model: selection.models[0] },
+      matrix: {
+        skill: { path: '/environment/skills', values: [{ off: [] }, { on: ['../templates/skills/${eval.grandparent}'] }] },
+        model: { path: '/defaults/model', values: selection.models },
+      },
+    };
+    mkdirSync(join(root, 'inputs', 'experiments'));
+    // JSON is valid YAML; Vally validates and expands this native matrix.
+    writeFileSync(join(root, 'inputs', experiment), JSON.stringify(definition, null, 2));
+    const vally = join(repo, 'node_modules', '@microsoft', 'vally-cli', 'dist', 'index.js');
+    const invoke = (args: string[]) => {
+      const child = spawnSync(process.execPath, [vally, ...args], {
+        cwd: join(root, 'empty'), env, shell: false, stdio: ['ignore', 'inherit', 'inherit'],
+      });
+      check(!child.error, 'could not launch native Vally; restore the pinned dependencies and check Node.js.');
+      check(child.signal === null, `native Vally terminated by ${child.signal}; private output: ${output}`);
+      check(child.status !== null, `native Vally has no exit status; private output: ${output}`);
+      return child.status;
+    };
+    const runId = randomUUID();
+    const raw = join(output, 'raw');
+    const shard = join(raw, runId, 'shard-1-of-1');
+    const native = join(output, 'native');
+    const args = ['experiment', 'run', join(root, 'inputs', experiment),
+      '--shard', '1/1', '--run-id', runId, '--workspace', join(root, 'trials'),
+      '--output-dir', raw, '--workers', '1', '--require-pass'];
+    if (options.dryRun) {
+      const exitCode = invoke([...args, '--dry-run']);
+      check(exitCode === 0, `native dry-run failed (exit ${exitCode}); no measurements or dashboard were generated.`);
+      outcome = { exitCode, dryRun: true };
+      return outcome;
+    }
+    mkdirSync(output, { mode: 0o700 });
+    const runExit = invoke(args);
+    check(lstatSync(join(shard, 'shard-manifest.json'), { throwIfNoEntry: false }),
+      `native run exit ${runExit}, missing shard manifest; partial results retained privately at ${output}.`);
+    // Even an unsharded native run writes a shard manifest. Native merge alone
+    // produces the canonical experiment manifest consumed by the existing report.
+    const mergeExit = invoke(['experiment', 'merge', shard, '--output-dir', native, '--require-pass']);
+    check(lstatSync(join(native, 'experiment-manifest.json'), { throwIfNoEntry: false }),
+      `native run exit ${runExit}, merge exit ${mergeExit}, missing experiment manifest; private results: ${output}.`);
+    const site = options.report ? generateReport(native, join(output, 'site')) : undefined;
+    outcome = { exitCode: runExit || mergeExit, dryRun: false, native, site, runExit, mergeExit };
+    return outcome;
+  } finally {
+    try {
+      rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    } catch (error) {
+      const code = error instanceof Error && 'code' in error && typeof error.code === 'string' ? error.code : 'unknown';
+      console.error(`Local benchmark: cleanup failed (${code}) for ${root}; inspect owned processes before removal. Private output: ${output}`);
+      if (outcome) outcome.exitCode ||= 1;
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    const { values } = parseArgs({ options: {
+      'run-root': { type: 'string' }, output: { type: 'string' }, registry: { type: 'string' },
+      trusted: { type: 'boolean' }, 'dry-run': { type: 'boolean' }, report: { type: 'boolean' },
+      all: { type: 'boolean' }, skill: { type: 'string' }, models: { type: 'string', multiple: true },
+    }, strict: true });
+    const result = runBenchmark({
+      runRoot: values['run-root'], output: values.output, trusted: values.trusted,
+      dryRun: values['dry-run'], report: values.report, registry: values.registry,
+      all: values.all, skill: values.skill, models: values.models,
+    });
+    console.log(result.dryRun ? 'Dry-run only: no measured trials or dashboard generated.'
+      : `Native results: ${result.native}${result.site ? `\nStatic site: ${result.site}` : ''}\nNative run/merge exits: ${result.runExit}/${result.mergeExit}\nWorkflow exit: ${result.exitCode}`);
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tests/evaluation-report.test.ts
+++ b/tests/evaluation-report.test.ts
@@ -143,6 +143,46 @@ describe('native benchmark report', () => {
     expect(arm?.metrics.totalTokens).toBeNull();
   });
 
+  it('keeps multiple skills with the same scenario separate when only Astra is selected', () => {
+    const f = fixture();
+    f.experiment.variantNames.splice(0, 2);
+    f.experiment.baseline = f.experiment.variantNames[0];
+    f.cells.splice(0, 2);
+    f.snapshot.evals.splice(0, 2);
+    f.save();
+    for (const cell of f.cells) {
+      const other = structuredClone(cell);
+      const evalFile = cell.plan.evalFile.replace('azure-functions-create', 'another-skill');
+      const replaceSkill = (value: string) => value.replace('azure-functions-create', 'another-skill');
+      other.plan.evalFile = evalFile;
+      other.plan.environment.skills = other.plan.environment.skills.map(replaceSkill);
+      other.plan.stimuli[0].environment.skills = other.plan.environment.skills;
+      other.summary.evalFile = evalFile;
+      other.summary.resolvedEnvironment = other.plan.environment;
+      other.trial.experiment.evalFile = evalFile;
+      other.trial.shardKey = other.trial.shardKey.replace(cell.plan.evalFile, evalFile);
+      f.snapshot.evals.push(other.plan);
+      const dir = join(f.input, cell.plan.variant);
+      writeFileSync(join(dir, 'run-summary.jsonl'), [cell.summary, other.summary].map(v => JSON.stringify(v)).join('\n'));
+      writeFileSync(join(dir, 'results.jsonl'), [cell.trial, other.trial].map(v => JSON.stringify(v)).join('\n'));
+    }
+    writeFileSync(join(f.input, 'plan-snapshot.json'), JSON.stringify(f.snapshot));
+    const comparisons = readBenchmark(f.input).comparisons;
+    expect(comparisons.map(c => c.skill).sort()).toEqual(['another-skill', 'azure-functions-create']);
+    expect(new Set(comparisons.map(c => c.id)).size).toBe(2);
+    for (const c of comparisons) {
+      expect(c.model).toBe('gpt-6-astra');
+      expect(c.on?.samples).toBe(1);
+      expect(c.off?.samples).toBe(1);
+    }
+    const html = readFileSync(generateReport(f.input, join(f.root, 'subset-site')), 'utf8');
+    for (const c of comparisons) {
+      const view = render(html, `?skill=${c.id}`);
+      expect(view.node('#app').innerHTML).toContain(c.skill);
+      expect(view.node('#app').innerHTML).toContain('281,764');
+    }
+  });
+
   it('separates execution errors, grader failures, and actual grader score', () => {
     const f = fixture();
     f.cells[0].trial.status = 'error';

--- a/tests/evaluation-run.test.ts
+++ b/tests/evaluation-run.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join, relative, resolve } from 'node:path';
+import { createTempDir, removeDir } from './helpers/fs.js';
+import { generateReport } from '../src/evaluation/report.js';
+import { benchmarkEnvironment, runBenchmark, selectBenchmark } from '../src/evaluation/run.js';
+
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }));
+vi.mock('../src/evaluation/report.js', () => ({ generateReport: vi.fn() }));
+vi.mock('node:fs', async importOriginal => {
+  const fs = await importOriginal<typeof import('node:fs')>();
+  return { ...fs, lstatSync: vi.fn(fs.lstatSync), rmSync: vi.fn(fs.rmSync) };
+});
+
+let root: string;
+const secret = 'private-token-canary';
+const env = { PATH: process.env.PATH, GH_TOKEN: secret };
+const result = (status = 0) => ({ status, signal: null, error: undefined, pid: 1, output: [], stdout: '', stderr: '' });
+const options = () => ({ runRoot: root, output: join(root, 'private'), trusted: true, all: true });
+const config = {
+  models: ['claude-sonnet-5', 'gpt-6-astra'],
+  skills: {
+    'azure-functions-create': {
+      evals: ['evals/azure-functions-create/typescript-http/eval.yaml'],
+      files: ['templates/skills/azure-functions-create/SKILL.md'],
+    },
+    'another-skill': {
+      evals: ['evals/another-skill/typescript-http/eval.yaml'],
+      files: ['templates/skills/another-skill/SKILL.md'],
+    },
+  },
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  root = createTempDir('af-local-eval-');
+  // Unit tests may live below the developer home; only their own discovery fixtures apply.
+  const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+  vi.mocked(lstatSync).mockImplementation((path, opts) =>
+    resolve(String(path)).startsWith(root) ? fs.lstatSync(path, opts) : undefined);
+  vi.mocked(spawnSync).mockImplementation((_command, argv) => {
+    const args = [...(argv ?? [])];
+    const output = args[args.indexOf('--output-dir') + 1];
+    if (args.includes('--dry-run')) return result();
+    if (args[1] === 'experiment' && args[2] === 'run') {
+      const runId = args[args.indexOf('--run-id') + 1];
+      mkdirSync(join(output, runId, 'shard-1-of-1'), { recursive: true });
+      writeFileSync(join(output, runId, 'shard-1-of-1', 'shard-manifest.json'), '{}');
+    } else {
+      mkdirSync(output, { recursive: true });
+      writeFileSync(join(output, 'experiment-manifest.json'), '{}');
+    }
+    return result();
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  removeDir(root);
+});
+
+describe('benchmarkEnvironment', () => {
+  it('allowlists OS/executables and one supported token, replacing every discovery profile', () => {
+    const isolated = benchmarkEnvironment(root, {
+      Path: 'executables', SystemRoot: 'system', GH_TOKEN: secret,
+      HOME: 'developer', USERPROFILE: 'developer', APPDATA: 'developer',
+      SSH_AUTH_SOCK: 'signing-agent', AZURE_CLIENT_SECRET: 'azure-secret',
+      COPILOT_CLI_BINARY_VERSION: 'ambient', COPILOT_SKILLS_DIRS: 'unwanted',
+      COPILOT_CLI_PATH: 'unwanted', NODE_OPTIONS: 'unwanted', NODE_PATH: 'unwanted',
+      EVALUATE_USE_HOST_COPILOT_HOME: 'true', npm_config_userconfig: 'credentials',
+    }, false);
+    expect(isolated.PATH).toBe('executables');
+    expect(isolated.COPILOT_GITHUB_TOKEN).toBe(secret);
+    for (const key of ['GH_TOKEN', 'SSH_AUTH_SOCK', 'AZURE_CLIENT_SECRET', 'NODE_OPTIONS',
+      'NODE_PATH', 'COPILOT_CLI_PATH', 'COPILOT_CLI_BINARY_VERSION', 'COPILOT_SKILLS_DIRS',
+      'EVALUATE_USE_HOST_COPILOT_HOME']) expect(isolated[key]).toBeUndefined();
+    for (const key of ['HOME', 'USERPROFILE', 'APPDATA', 'LOCALAPPDATA', 'TEMP', 'TMP',
+      'COPILOT_HOME', 'GH_CONFIG_DIR', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME',
+      'npm_config_userconfig', 'npm_config_globalconfig']) {
+      expect(relative(root, isolated[key] ?? '').startsWith('..')).toBe(false);
+    }
+    expect(JSON.parse(isolated.COPILOT_HOME_SETTINGS_JSON ?? '')).toEqual({
+      disabledSkills: ['customize-cloud-agent', 'github-pr-media'],
+    });
+    expect(isolated.npm_config_registry).toBe('https://registry.npmjs.org/');
+  });
+
+  it('does not pass authentication to a free dry-run or silently use a credential store', () => {
+    expect(benchmarkEnvironment(root, env, true).COPILOT_GITHUB_TOKEN).toBeUndefined();
+    expect(() => benchmarkEnvironment(root, {}, false)).toThrow(/COPILOT_GITHUB_TOKEN.*GH_TOKEN/);
+    expect(benchmarkEnvironment(root, { COPILOT_GITHUB_TOKEN: secret, GH_TOKEN: 'other' }, false)
+      .COPILOT_GITHUB_TOKEN).toBe(secret);
+    expect(benchmarkEnvironment(root, { GITHUB_TOKEN: secret }, false).COPILOT_GITHUB_TOKEN).toBe(secret);
+  });
+});
+
+describe('selectBenchmark', () => {
+  it('requires an explicit all or single-skill selection, even for dry-runs', () => {
+    expect(() => selectBenchmark(config, {})).toThrow(/--all.*--skill/);
+    expect(() => selectBenchmark(config, { all: true, skill: 'azure-functions-create' })).toThrow(/--all.*--skill/);
+    expect(() => selectBenchmark(config, { skill: '' })).toThrow(/skill/);
+    expect(() => selectBenchmark(config, { skill: 'unregistered' })).toThrow(/skill/);
+  });
+
+  it('selects registered evals/files and model subsets in central configuration order', () => {
+    expect(selectBenchmark(config, { skill: 'another-skill', models: ['gpt-6-astra'] })).toEqual({
+      models: ['gpt-6-astra'],
+      evals: config.skills['another-skill'].evals,
+      files: config.skills['another-skill'].files,
+    });
+    const all = selectBenchmark(config, { all: true, models: ['gpt-6-astra', 'claude-sonnet-5'] });
+    expect(all.models).toEqual(config.models);
+    expect(all.evals).toHaveLength(2);
+    expect(all.files).toHaveLength(2);
+    for (const models of [[], [''], ['unknown'], ['gpt-6-astra', 'gpt-6-astra']])
+      expect(() => selectBenchmark(config, { all: true, models })).toThrow(/model/);
+  });
+
+  it('rejects malformed configuration, path escapes and discovery/other-skill inputs', () => {
+    for (const invalid of [null, {}, { ...config, models: [] }, { ...config, models: ['bad/id'] }])
+      expect(() => selectBenchmark(invalid, { all: true })).toThrow(/config/i);
+    for (const file of ['../secret', '/absolute', 'templates/skills/another-skill/SKILL.md',
+      'templates/skills/azure-functions-create/../../.github/copilot-instructions.md',
+      'evals/azure-functions-create/typescript-http/AGENTS.md']) {
+      const invalid = structuredClone(config);
+      invalid.skills['azure-functions-create'].files.push(file);
+      expect(() => selectBenchmark(invalid, { all: true })).toThrow(/config/i);
+    }
+  });
+});
+
+describe('runBenchmark', () => {
+  it('stages only the fixed native inputs into an external owned root and cleans them after dry-run', () => {
+    let temporary = '';
+    vi.mocked(spawnSync).mockImplementation((_command, argv, opts) => {
+      const args = [...(argv ?? [])];
+      const cwd = String(opts?.cwd);
+      temporary = dirname(cwd);
+      expect(cwd).toBe(join(temporary, 'empty'));
+      expect(readdirSync(cwd)).toEqual([]);
+      expect(args[0]).toBe(resolve('node_modules', '@microsoft', 'vally-cli', 'dist', 'index.js'));
+      expect(args.slice(1, 3)).toEqual(['experiment', 'run']);
+      const experiment = args[3];
+      expect(experiment).toBe(join(temporary, 'inputs', 'experiments', 'local.experiment.yaml'));
+      const definition = JSON.parse(readFileSync(experiment, 'utf8'));
+      expect(definition.matrix.skill.values).toEqual([
+        { off: [] }, { on: ['../templates/skills/${eval.grandparent}'] },
+      ]);
+      expect(definition.matrix.model.values).toEqual(config.models);
+      expect(definition.overrides).toEqual({ runs: 1, timeout: '10m' });
+      const skills = join(temporary, 'inputs', 'templates', 'skills');
+      expect(readdirSync(skills)).toEqual(['azure-functions-create']);
+      expect(readdirSync(join(skills, 'azure-functions-create')).sort()).toEqual(['SKILL.md', 'references']);
+      expect(readdirSync(join(skills, 'azure-functions-create', 'references')).sort())
+        .toEqual(['go-project.md', 'language-snippets.md']);
+      expect(existsSync(join(temporary, 'inputs', '.vally.yaml'))).toBe(false);
+      expect(opts?.env?.HOME).toBe(join(temporary, 'home'));
+      expect(opts?.env?.COPILOT_GITHUB_TOKEN).toBeUndefined();
+      expect(args).toContain('--dry-run');
+      expect(opts?.shell).toBe(false);
+      return result();
+    });
+    expect(runBenchmark({ ...options(), dryRun: true, report: true }, env).dryRun).toBe(true);
+    expect(existsSync(temporary)).toBe(false);
+    expect(existsSync(options().output)).toBe(false);
+    expect(generateReport).not.toHaveBeenCalled();
+  });
+
+  it('uses a selected model as the baseline without running extra model-specific commands', () => {
+    const normal = vi.mocked(spawnSync).getMockImplementation();
+    vi.mocked(spawnSync).mockImplementation((...args) => {
+      if (args[1]?.[2] === 'run') {
+        const definition = JSON.parse(readFileSync(args[1][3], 'utf8'));
+        expect(definition.baseline).toEqual({ skill: 'off', model: 'gpt-6-astra' });
+        expect(definition.matrix.model.values).toEqual(['gpt-6-astra']);
+        expect(definition.evals).toEqual(['../evals/azure-functions-create/typescript-http/eval.yaml']);
+      }
+      return normal?.(...args) ?? result();
+    });
+    runBenchmark({ ...options(), all: false, skill: 'azure-functions-create', models: ['gpt-6-astra'] }, env);
+    expect(spawnSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports explicit environment defaults and creates a fresh private bundle on every invocation', () => {
+    const source = { ...env, VALLY_RUN_ROOT: root, VALLY_OUTPUT_ROOT: root, VALLY_TRUSTED: '1',
+      VALLY_NPM_REGISTRY: 'https://registry.example.test/' };
+    const first = runBenchmark({ all: true }, source);
+    const second = runBenchmark({ skill: 'azure-functions-create' }, source);
+    expect(first.native).not.toBe(second.native);
+    expect(readdirSync(root)).toHaveLength(2);
+    expect(vi.mocked(spawnSync).mock.calls[0][2]?.env?.npm_config_registry).toBe(source.VALLY_NPM_REGISTRY);
+    expect(vi.mocked(spawnSync).mock.calls[0][2]?.env?.VALLY_TRUSTED).toBeUndefined();
+    expect(() => runBenchmark({ ...options(), trusted: false }, source)).toThrow(/--trusted/);
+    expect(() => runBenchmark({ all: true, trusted: true }, env)).toThrow(/run-root/i);
+  });
+
+  it('rejects omitted selectors before native launch and never creates a bundle', () => {
+    expect(() => runBenchmark({ ...options(), all: false }, env)).toThrow(/--all.*--skill/);
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(readdirSync(root)).toEqual([]);
+  });
+
+  it('runs the full native matrix once, merges its one shard and delegates to the existing report', () => {
+    const outcome = runBenchmark({ ...options(), report: true }, env);
+    const calls = vi.mocked(spawnSync).mock.calls;
+    expect(calls).toHaveLength(2);
+    const args = calls[0][1] ?? [];
+    expect(args).toContain('--shard');
+    expect(args[args.indexOf('--shard') + 1]).toBe('1/1');
+    expect(args[args.indexOf('--workers') + 1]).toBe('1');
+    expect(args).toContain('--require-pass');
+    for (const flag of ['--compare', '--work-dir', '--max-retries', '--model', '--variant', '--verbose'])
+      expect(args).not.toContain(flag);
+    expect(JSON.stringify(args)).not.toContain(secret);
+    expect(calls[1][1]?.slice(1, 3)).toEqual(['experiment', 'merge']);
+    expect(generateReport).toHaveBeenCalledWith(join(options().output, 'native'), join(options().output, 'site'));
+    expect(outcome.exitCode).toBe(0);
+    expect(readdirSync(root)).toEqual(['private']);
+  });
+
+  it('keeps measured failures nonzero while reporting valid native results', () => {
+    const normal = vi.mocked(spawnSync).getMockImplementation();
+    vi.mocked(spawnSync).mockImplementation((...args) => {
+      normal?.(...args);
+      return result(1);
+    });
+    expect(runBenchmark({ ...options(), report: true }, env).exitCode).toBe(1);
+    expect(generateReport).toHaveBeenCalledOnce();
+    expect(existsSync(join(options().output, 'native', 'experiment-manifest.json'))).toBe(true);
+    expect(readdirSync(root)).toEqual(['private']);
+  });
+
+  it('preserves partial outputs without inventing a report when native fails before its manifest', () => {
+    vi.mocked(spawnSync).mockImplementation(() => result(2));
+    expect(() => runBenchmark({ ...options(), report: true }, env)).toThrow(/exit 2.*private/i);
+    expect(generateReport).not.toHaveBeenCalled();
+    expect(readdirSync(root)).toEqual(['private']);
+  });
+
+  it('surfaces launch, signal and missing-result errors and still cleans owned staging', () => {
+    vi.mocked(spawnSync).mockImplementation(() => ({ ...result(), error: new Error('spawn failed') }));
+    expect(() => runBenchmark({ ...options(), dryRun: true }, env)).toThrow(/launch/i);
+    vi.mocked(spawnSync).mockImplementation(() => ({ ...result(), status: null, signal: 'SIGTERM' }));
+    expect(() => runBenchmark({ ...options(), dryRun: true }, env)).toThrow(/SIGTERM/);
+    vi.mocked(spawnSync).mockImplementation(() => result());
+    expect(() => runBenchmark(options(), env)).toThrow(/manifest/i);
+    expect(readdirSync(root)).toEqual(['private']);
+  });
+
+  it('surfaces report errors without discarding real native artifacts', () => {
+    vi.mocked(generateReport).mockImplementationOnce(() => { throw new Error('report invalid'); });
+    expect(() => runBenchmark({ ...options(), report: true }, env)).toThrow('report invalid');
+    expect(existsSync(join(options().output, 'native', 'experiment-manifest.json'))).toBe(true);
+    expect(readdirSync(root)).toEqual(['private']);
+  });
+
+  it.each([0, 2])('preserves native exit %s and artifact paths while making cleanup failures nonzero', nativeExit => {
+    const normal = vi.mocked(spawnSync).getMockImplementation();
+    vi.mocked(spawnSync).mockImplementation((...args) => {
+      normal?.(...args);
+      return result(nativeExit);
+    });
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(rmSync).mockImplementationOnce(() => { throw Object.assign(new Error('locked'), { code: 'EBUSY' }); });
+    const outcome = runBenchmark({ ...options(), report: true }, env);
+    expect(outcome.exitCode).toBe(nativeExit || 1);
+    expect(outcome.runExit).toBe(nativeExit);
+    expect(outcome.mergeExit).toBe(nativeExit);
+    expect(outcome.native).toBe(join(options().output, 'native'));
+    expect(generateReport).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/cleanup.*EBUSY.*vally-local-.*private/i));
+  });
+
+  it('does not replace the primary native failure with a filesystem cleanup error', () => {
+    vi.mocked(spawnSync).mockImplementation(() => result(2));
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(rmSync).mockImplementationOnce(() => { throw Object.assign(new Error('locked'), { code: 'EPERM' }); });
+    expect(() => runBenchmark(options(), env)).toThrow(/native run exit 2.*missing shard manifest/);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/cleanup.*EPERM/));
+    expect(generateReport).not.toHaveBeenCalled();
+  });
+
+  it('does not turn a native merge failure into successful completion', () => {
+    const normal = vi.mocked(spawnSync).getMockImplementation();
+    vi.mocked(spawnSync).mockImplementation((...args) => {
+      if (args[1]?.includes('merge')) return result(2);
+      return normal?.(...args) ?? result();
+    });
+    expect(() => runBenchmark({ ...options(), report: true }, env)).toThrow(/merge exit 2/);
+    expect(generateReport).not.toHaveBeenCalled();
+    expect(readdirSync(root)).toEqual(['private']);
+  });
+
+  it('rejects unacknowledged trust, reused output, unsafe registry and discovery ancestors before native launch', () => {
+    expect(() => runBenchmark({ ...options(), trusted: false }, env)).toThrow(/--trusted/);
+    expect(() => runBenchmark({ ...options(), registry: `https://user:${secret}@example.com` }, env))
+      .toThrow(/registry/i);
+    mkdirSync(options().output);
+    expect(() => runBenchmark(options(), env)).toThrow(/new.*output/i);
+    removeDir(options().output);
+    mkdirSync(join(root, '.copilot'));
+    expect(() => runBenchmark(options(), env)).toThrow(/discovery/i);
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('refuses paid PR-triggered execution even when trust is acknowledged', () => {
+    expect(() => runBenchmark(options(), { ...env, GITHUB_EVENT_NAME: 'pull_request_target' })).toThrow(/PR-triggered/);
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('refuses the repository as the staging/output location', () => {
+    expect(() => runBenchmark({ ...options(), runRoot: process.cwd() }, env)).toThrow(/repository/i);
+    expect(() => runBenchmark({ ...options(), output: join(process.cwd(), 'never-created') }, env))
+      .toThrow(/repository/i);
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects repository paths reached through an external directory link', () => {
+    const link = join(root, 'repo-link');
+    symlinkSync(process.cwd(), link, 'junction');
+    expect(() => runBenchmark({ ...options(), runRoot: link }, env)).toThrow(/repository/i);
+    expect(() => runBenchmark({ ...options(), output: join(link, 'never-created') }, env)).toThrow(/repository/i);
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

<img width="1272" height="892" alt="image" src="https://github.com/user-attachments/assets/31eb715d-9f44-404d-af5b-883a5854ba05" />
<img width="1264" height="928" alt="image" src="https://github.com/user-attachments/assets/026ad503-8256-4dc2-908d-a894fd586ee2" />
<img width="1256" height="538" alt="image" src="https://github.com/user-attachments/assets/a4179cd6-8aa2-4f3f-aa20-87fd97f55e4c" />
<img width="1209" height="917" alt="image" src="https://github.com/user-attachments/assets/4b551478-cd48-41f1-abd1-1e853519375b" />


Final layer on top of #256 (`tsuyoshiushio-vally-static-dashboard`).

- Add one central `experiments/local-benchmark.json` registration: the existing TypeScript HTTP scenario for `azure-functions-create`, with Claude Sonnet 5 and GPT-6 Astra.
- Require `--all` **or** `--skill`; accept repeated `--models` only as a registered subset. Missing/conflicting/unknown selections fail before execution. Environment defaults enable one noninteractive `npm run eval -- --all` command after trusted-code and budget preparation.
- Stage only selected inputs under a fresh external root, with clean discovery ancestors, isolated profiles, an OS/executable environment allowlist and explicit token authentication. Generate one temporary native matrix using `${eval.grandparent}` for each ON target; execute native shard `1/1`, native merge, the existing static report, then owned-directory cleanup. No agent/model loop, SDK runner, custom merge or new telemetry.
- Keep `raw/` and `native/` private; only reviewed `site/` is a publication candidate. Preserve native/merge failures and valid artifact paths even if cleanup fails. `--trusted` is an acknowledgment, **not a sandbox or inference-spending authorization**.
- Preserve `eval:run` / `eval:report`, move the previous root-suite alias to `eval:suites`, and retain existing smoke/full/live workflows. Asset inspection found no obsolete custom evaluation framework to delete; product telemetry and distinct routing/live coverage remain.

## Validation and provenance

- TDD; 310 tests across 22 files pass, including selector/path isolation, environment/auth handling, native argv, failure/cleanup propagation and multi-skill same-scenario/Astra-only report regressions. Lint, typecheck, static eval lint, supply-chain checks and diff checks pass.
- Real **free** native dry-runs resolve four all-model plans and two Astra-only plans, with the same eval/config hashes as the earlier measurements. Native oracle and bundled CLI discovery show OFF = no enabled skills, ON = only the target, and both builtin skills disabled; staged source hashes match and owned temporary roots are removed.
- Reused the **four actual scenario trials already completed in #255**. Native merge was exercised on unchanged copies of their original two shards; all 32 original files remained unchanged. The final `eval:report` regenerated the actual static HTML, byte-identical to the remerged report (SHA256 `cf5edd8c9c2c34d96dfb7d5137b952cb65ea7748a173331cbef50ce3fcd2c6bc`). Raw artifacts remain private.
- **No additional paid evaluations were run in this layer.** A newly measured wrapper-driven `1/1` end-to-end run has not been performed; that wiring was validated through native implementation/CLI contracts, free dry-runs and unit tests, not represented as new measured completion. Dry-run never generates a fake dashboard.
- Independent read-only Claude Opus 5 review completed; its cleanup-error masking finding was reproduced, fixed and re-reviewed with no remaining findings.

No new skill/grader, UI redesign, adapter rewrite, FRD, CI/AzDO authentication or Pages deployment is included.