### PR TITLE
feat: wire azure_deployment_observed collector into skills and docs

### DIFF
--- a/.github/plugins/azure-functions-skills/skills/azure-functions-deploy/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-deploy/SKILL.md
@@ -162,6 +162,24 @@ Do not kill and restart the `azd up` process based solely on lack of terminal ou
 
 > ✅ Your app is deployed through Azure Skills. Consider running `azure-functions-best-practices` for a production readiness review.
 
+## Report a successful deployment (internal telemetry)
+
+After the delegated Azure Skills deployment (`azure-deploy`) reports success, run the one-time internal contribution collector **exactly once**. It records an anonymous, categorical "observed successful Azure deployment" signal and is best-effort: it independently reads the named Azure Resource Manager deployment (by the environment name) to confirm success and never changes the deployment outcome.
+
+- This skill is the **sole owner** of the collection step for the delegated deployment path. The `azure-functions-hosted-skills` skill must not also emit it for the same work.
+- Run it once, and only after the delegated deployment reports success. Never run it after a failed, cancelled, preview, or validation-only run, and never re-run it to "retry" a telemetry failure.
+- Set `operation` to `deploy` for a full deployment, or `provision` if only a standalone `azd provision` was delegated.
+- Set `agent` to the current host (`copilot-cli`, `claude-code`, `codex`, or `Visual Studio Code`); unrecognized hosts are normalized automatically.
+- `environmentName` is **required**: set it to the azd environment name (the ARM deployment name used for the deployment). The collector looks the deployment up by this name, so if it is genuinely unavailable, skip the collector entirely rather than guessing or inventing a value — an absent or invalid name produces no signal. It is used only locally to select which deployment to inspect and is never transmitted.
+- Pass `--dir <workspace-root>` with the project's workspace root so the workspace telemetry opt-out is resolved correctly. Without it the flag defaults to the current working directory, so running from a subdirectory such as `infra/` could miss a workspace opt-out.
+- Suppress all output and ignore failures. A telemetry error must never trigger a redeploy or change the reported result.
+- Older published versions do not have this subcommand. In that case doing nothing is the correct outcome. Never install, upgrade, reinstall, or work around the package, never try an alternative invocation, and never report a telemetry problem to the user.
+
+```bash
+printf '%s' '{"skill":"azure-functions-deploy","operation":"deploy","agent":"copilot-cli","environmentName":"<azd-env-name>"}' \
+  | npx -y @azure/functions-skills@latest telemetry contribution --dir <workspace-root> >/dev/null 2>&1 || true
+```
+
 ## Next steps
 
 - On missing Azure Skills, suggest `azure-functions-setup` to install or configure the Azure Skills plugin.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-hosted-skills/SKILL.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-hosted-skills/SKILL.md
@@ -387,6 +387,12 @@ user already approved the direction. Run `azd up`, open authorization URLs, run 
 get-values`, test deployed endpoints, and report the results. Stop only for user-only actions such
 as signing in to authorize a connector, selecting an ambiguous option, or entering secrets.
 
+After a supported command **fully succeeds** — a complete `azd up`, or a standalone `azd provision`
+— perform the one-time internal contribution telemetry step described in
+[infra-and-deployment.md](./references/infra-and-deployment.md#report-a-successful-deployment-internal-telemetry).
+Run it exactly once per successful command, only on success, with all output suppressed and every
+failure ignored. This skill is the sole owner of that step for its own `azd` deployments.
+
 When creating backing Azure resources beyond this skill's bundled Bicep, use Azure docs. If the
 agent needs searchable docs context, ask the user to connect the Microsoft Learn MCP server at
 `https://learn.microsoft.com/api/mcp`.

--- a/.github/plugins/azure-functions-skills/skills/azure-functions-hosted-skills/references/infra-and-deployment.md
+++ b/.github/plugins/azure-functions-skills/skills/azure-functions-hosted-skills/references/infra-and-deployment.md
@@ -172,6 +172,53 @@ azd env set TO_EMAIL user@example.com
 azd up
 ```
 
+## Report a successful deployment (internal telemetry)
+
+Only after a supported command has **fully succeeded** — a complete `azd up`, or a
+standalone `azd provision` (including the provision run before local development) —
+run the one-time internal contribution collector, **exactly once** for that
+command. It records an anonymous, categorical "observed successful Azure
+deployment" signal. It is best-effort: it independently reads the named Azure
+Resource Manager deployment (by the environment name) to confirm success and
+never changes the deployment outcome.
+
+Rules:
+
+- Run it once per successful command, and only on success. Never run it after a
+  failed, cancelled, preview, or validation-only command, and never re-run it to
+  "retry" a telemetry failure.
+- Set `operation` to `deploy` after `azd up`, or `provision` after a standalone
+  `azd provision`.
+- Set `agent` to the current host (`copilot-cli`, `claude-code`, `codex`, or
+  `Visual Studio Code`); unrecognized hosts are normalized automatically.
+- `environmentName` is **required**: set it to the azd environment name (the ARM
+  deployment name used for the deployment). The collector looks the deployment
+  up by this name, so if it is genuinely unavailable, skip the collector
+  entirely rather than guessing or inventing a value — an absent or invalid name
+  produces no signal. It is used only locally to select which deployment to
+  inspect and is never transmitted.
+- Pass `--dir <workspace-root>` with the project's workspace root so the
+  workspace telemetry opt-out is resolved correctly. Without it the flag defaults
+  to the current working directory, so running from a subdirectory such as `src/`
+  could miss a workspace opt-out.
+- Suppress all output and ignore every failure. A telemetry error must never
+  trigger a redeploy, re-provision, cloud login, or any change to the result the
+  user already saw.
+- Older published versions do not have this subcommand. In that case doing
+  nothing is the correct outcome. Never install, upgrade, reinstall, or work
+  around the package, never try an alternative invocation, and never report a
+  telemetry problem to the user.
+
+```bash
+printf '%s' '{"skill":"azure-functions-hosted-skills","operation":"deploy","agent":"copilot-cli","environmentName":"<azd-env-name>"}' \
+  | npx -y @azure/functions-skills@latest telemetry contribution --dir <workspace-root> >/dev/null 2>&1 || true
+```
+
+This step is owned **solely by this skill** for its own `azd` deployments. Do not
+also emit it from `azure-functions-deploy`, and do not emit it for connector
+follow-up work such as deploying `trigger-config.bicep` (a separate
+`az deployment`, which is out of scope).
+
 ## Local Development Workflow
 
 Provision Azure resources before running locally:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ The result includes installed agents, files written, planned files, dry-run stat
 
 Azure Functions Skills collects usage telemetry to understand which bundled skills and Azure Functions MCP tools are used. Events include allowlisted skill/tool names, relative allowlisted Azure Functions skill-file paths, client name, session id, and timestamp. Telemetry does **not** include file contents, prompts, raw tool arguments, credentials, or absolute paths. Events are sent by the `@azure/functions-skills` package directly to the Azure Functions team's Application Insights resource; the package does not use Azure MCP as a telemetry destination or transport.
 
+### Contribution event
+
+A second event, `azure_contribution`, records an approximate, categorical view of successful Azure deployment work observed through the `azure-functions-deploy` and `azure-functions-hosted-skills` skills after a supported `azd up` or standalone `azd provision`. It carries only seven categorical properties: `skill`, `operation` (`deploy` or `provision`), `result` (constant `success`), `resourceTypes` (a sorted, de-duplicated list of Microsoft resource-provider types such as `microsoft.web/sites`), `deploymentKind` (`function-app` or `hosted-agent`), `agent` (normalized client, or `unknown`), and `skillsVersion` (or `unknown`).
+
+To confirm success and derive the resource-type breakdown, the collector reads the named Azure Resource Manager deployment's state locally using your existing Azure CLI sign-in. Subscription, resource-group, deployment names, and deployment IDs are used **only locally** for those queries; they are never attached to the event, printed, or transmitted. The event contains no customer names, identifiers, secrets, paths, environment values, or correlation IDs.
+
+The same opt-out mechanisms apply unchanged (see below); when telemetry is disabled the collector performs no ARM queries and sends nothing.
+
+This is an adoption/contribution trend, not exact accounting. Phase 1 limitations are intentional and disclosed:
+
+- The collector looks up the subscription-scope ARM deployment by the required environment name and validates it against a bounded 30-minute recency window. A missing or invalid environment name, a deployment older than the window, or a resource-group-scope deployment records nothing. Selecting by name makes cross-deployment misattribution unlikely, but re-running after another deployment that reuses the same environment name still refers to the newest deployment of that name.
+- Duplicate collector calls are possible; there is no exactly-once delivery, no durable de-duplication, and no exact funnel or conversion rate.
+- Only supported `azd`/Bicep paths for the two canonical skills emit; plain CLI create, Terraform, and unrelated skill use do not.
+
+Application telemetry content is categorical, but HTTPS necessarily exposes the client's network address to the receiving service. This does not promise anonymous transport; the receiving Application Insights service's privacy policy and IP handling apply.
+
 For host-managed plugin installs, opt out by setting either
 `AZURE_FUNCTIONS_SKILLS_COLLECT_TELEMETRY=false` or `AZURE_MCP_COLLECT_TELEMETRY=false`
 in the environment. Workspace-local installs can also use `--no-telemetry`; that preference

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -60,3 +60,12 @@ npm run build:plugin-payload
 ```
 
 The plugin payload always contains skills, MCP configuration, and telemetry hooks. There are no payload profiles.
+
+## Internal telemetry commands
+
+The package exposes two hidden `telemetry` subcommands that are **not** user-facing deployment commands and are not part of the supported CLI surface above. They are invoked internally — by the telemetry hooks and by the deployment skills — never as a way to deploy or provision anything:
+
+- `telemetry` reads one sanitized usage event on stdin and sends it.
+- `telemetry contribution [--dir <workspace-root>]` is called once by `azure-functions-deploy` or `azure-functions-hosted-skills` only after a supported `azd up` / standalone `azd provision` has already succeeded. It reads a bounded JSON object on stdin, independently confirms success against Azure Resource Manager using your existing Azure CLI sign-in, and emits the categorical `azure_contribution` event. It prints one status word and always exits `0`, so it never provisions resources, changes a deployment outcome, or triggers a redeploy. `--dir` selects the workspace whose telemetry opt-out configuration (`telemetry.config.json`) applies and defaults to the current working directory; pass the workspace root explicitly so a workspace opt-out is honored even when the command runs from a subdirectory.
+
+Both honor the same opt-out mechanisms described in the project [README](../README.md#telemetry); when telemetry is disabled they perform no work.

--- a/docs/internal/telemetry-release.md
+++ b/docs/internal/telemetry-release.md
@@ -109,6 +109,51 @@ Users can opt out by setting either
 `AZURE_MCP_COLLECT_TELEMETRY=false`. Workspace-local installs also honor
 `telemetry.config.json` with `"enabled": false`.
 
+## Contribution collector
+
+The two canonical deployment skills invoke a second hidden subcommand exactly
+once after a supported command reports success:
+
+```text
+npx -y @azure/functions-skills@latest telemetry contribution
+```
+
+It reads one bounded JSON object on stdin (16 KiB max) with `skill`,
+`operation`, `agent`, optional `skillsVersion`, and a required `environmentName`
+(see selection below); unknown properties are rejected. It prints exactly one
+categorical word (`sent`, `disabled`, `not-configured`, `skipped`, or `failed`)
+and always exits `0`, so a telemetry-only failure never affects the deployment.
+The original `telemetry` stdin contract is unchanged.
+
+The collector looks up the subscription-scope ARM deployment **by name**, using
+`environmentName` as the deployment name (`az deployment sub show --name
+<environmentName>`), then confirms success and derives the resource-type
+breakdown from that single deployment. Lookup by name is one request and does
+not degrade as deployment history grows; it replaced an earlier recency-scan
+approach because ARM does not return deployments newest-first and `$top` is a
+per-page hint rather than a global cap, so a full scan was both slow and
+unreliable. If `environmentName` is absent or fails ARM deployment-name
+validation, the collector returns `skipped` (reason `no-environment-name`)
+before any Azure query, so nothing is recorded. It honors the same opt-out
+preferences before any ARM query or send. Subscription, resource-group,
+deployment names, and deployment IDs are used only locally for those queries and
+are never sent.
+
+### Rollout ordering
+
+The skill snippets may ship before a published `@azure/functions-skills` CLI
+that supports `telemetry contribution`. During that window the command is a
+verified silent no-op that emits nothing. A published bin without the
+subcommand matches `command === 'telemetry'`, ignores the `contribution`
+argument, and pipes stdin into the old `parseTelemetryEvent`, whose strict
+property allowlist rejects our payload's first key (`skill`) with
+`Unsupported telemetry property: skill` and exit `1`; a version predating the
+`telemetry` command prints `Unknown command` and exits `1`. Either way no
+usage event is sent, `environmentName` is never transmitted, and the snippets'
+`>/dev/null 2>&1 || true` swallows the stderr and non-zero exit. This is
+intended behavior — do not "fix" the snippets or the old parser to make the
+subcommand appear to run on older releases.
+
 ## Events and expected dimensions
 
 | Event type | Trigger | Dimensions |
@@ -116,6 +161,36 @@ Users can opt out by setting either
 | `skill_invocation` | `skill`/`Skill` invokes a bundled Azure Functions skill, or its `SKILL.md` is read from a recognized plugin path. | `timestamp`, `client-name`, `session-id`, `skill-name` |
 | `tool_invocation` | Azure Functions MCP tool names such as `functions_template_get`, `functions_project_get`, or host-prefixed equivalents are called. | `timestamp`, `client-name`, `session-id`, `tool-name` |
 | `reference_file_read` | A non-`SKILL.md` file is read under a bundled Azure Functions skill directory. | `timestamp`, `client-name`, `session-id`, `file-reference` |
+| `azure_contribution` | The `azure-functions-deploy` or `azure-functions-hosted-skills` skill collects once after a supported `azd up` / standalone `azd provision` succeeds and a current ARM deployment confirms it. | `skill`, `operation`, `result`, `resourceTypes`, `deploymentKind`, `agent`, `skillsVersion` |
+
+The `azure_contribution` properties are all categorical strings:
+
+| Property | Value |
+| --- | --- |
+| `skill` | `azure-functions-deploy` or `azure-functions-hosted-skills` |
+| `operation` | `deploy` (from `azd up`) or `provision` (standalone `azd provision`) |
+| `result` | Constant `success`, constructed only after ARM verification |
+| `resourceTypes` | JSON-encoded, sorted, de-duplicated array of Microsoft resource-provider types |
+| `deploymentKind` | `function-app` (deploy skill) or `hosted-agent` (hosted-skills skill) |
+| `agent` | Normalized client (`copilot-cli`, `claude-code`, `codex`, `Visual Studio Code`, …) or `unknown` |
+| `skillsVersion` | Installed Skills asset version, or `unknown` |
+
+Example serialized event:
+
+```json
+{
+  "name": "azure_contribution",
+  "properties": {
+    "skill": "azure-functions-deploy",
+    "operation": "deploy",
+    "result": "success",
+    "resourceTypes": "[\"microsoft.storage/storageaccounts\",\"microsoft.web/sites\"]",
+    "deploymentKind": "function-app",
+    "agent": "copilot-cli",
+    "skillsVersion": "unknown"
+  }
+}
+```
 
 These dimensions should support analysis such as:
 
@@ -126,3 +201,36 @@ These dimensions should support analysis such as:
 - MCP template/scaffold usage (`tool-name` for `functions_*` tools);
 - versioned package rollout correlation by comparing blob package version with
   release timing.
+
+Simple contribution reporting examples (KQL against the custom event):
+
+```kusto
+// Observed successful deployments per day by skill and deploymentKind
+customEvents
+| where name == "azure_contribution"
+| summarize count() by bin(timestamp, 1d),
+    tostring(customDimensions.skill), tostring(customDimensions.deploymentKind)
+```
+
+```kusto
+// Resource-type breakdown. Expanding the array must not inflate the headline
+// count: a type's count means "observations containing this type", not resource
+// count. Do not compute an exact funnel or conversion rate from these
+// success-only events.
+customEvents
+| where name == "azure_contribution"
+| extend types = todynamic(tostring(customDimensions.resourceTypes))
+| mv-expand type = types to typeof(string)
+| summarize observations = count() by type
+```
+
+These counts are an approximate contribution trend, not exact accounting.
+Deployment selection is by name (the required `environmentName`) against
+subscription-scope ARM deployments, validated by a bounded 30-minute recency
+window: a named deployment older than the window, a resource-group-scope
+deployment (`az deployment group create`), or a missing or invalid name is
+skipped and records nothing. Selecting by name makes cross-deployment
+misattribution unlikely, but re-running the collector after a second deployment
+that reuses the same environment name still refers to the newest deployment of
+that name. Duplicate collector calls are possible, and there is no exactly-once
+delivery.

--- a/templates/skills/azure-functions-deploy/SKILL.md
+++ b/templates/skills/azure-functions-deploy/SKILL.md
@@ -163,6 +163,24 @@ Do not kill and restart the `azd up` process based solely on lack of terminal ou
 
 > ✅ Your app is deployed through Azure Skills. Consider running `azure-functions-best-practices` for a production readiness review.
 
+## Report a successful deployment (internal telemetry)
+
+After the delegated Azure Skills deployment (`azure-deploy`) reports success, run the one-time internal contribution collector **exactly once**. It records an anonymous, categorical "observed successful Azure deployment" signal and is best-effort: it independently reads the named Azure Resource Manager deployment (by the environment name) to confirm success and never changes the deployment outcome.
+
+- This skill is the **sole owner** of the collection step for the delegated deployment path. The `azure-functions-hosted-skills` skill must not also emit it for the same work.
+- Run it once, and only after the delegated deployment reports success. Never run it after a failed, cancelled, preview, or validation-only run, and never re-run it to "retry" a telemetry failure.
+- Set `operation` to `deploy` for a full deployment, or `provision` if only a standalone `azd provision` was delegated.
+- Set `agent` to the current host (`copilot-cli`, `claude-code`, `codex`, or `Visual Studio Code`); unrecognized hosts are normalized automatically.
+- `environmentName` is **required**: set it to the azd environment name (the ARM deployment name used for the deployment). The collector looks the deployment up by this name, so if it is genuinely unavailable, skip the collector entirely rather than guessing or inventing a value — an absent or invalid name produces no signal. It is used only locally to select which deployment to inspect and is never transmitted.
+- Pass `--dir <workspace-root>` with the project's workspace root so the workspace telemetry opt-out is resolved correctly. Without it the flag defaults to the current working directory, so running from a subdirectory such as `infra/` could miss a workspace opt-out.
+- Suppress all output and ignore failures. A telemetry error must never trigger a redeploy or change the reported result.
+- Older published versions do not have this subcommand. In that case doing nothing is the correct outcome. Never install, upgrade, reinstall, or work around the package, never try an alternative invocation, and never report a telemetry problem to the user.
+
+```bash
+printf '%s' '{"skill":"azure-functions-deploy","operation":"deploy","agent":"copilot-cli","environmentName":"<azd-env-name>"}' \
+  | npx -y @azure/functions-skills@latest telemetry contribution --dir <workspace-root> >/dev/null 2>&1 || true
+```
+
 ## Next steps
 
 - On missing Azure Skills, suggest `azure-functions-setup` to install or configure the Azure Skills plugin.

--- a/templates/skills/azure-functions-hosted-skills/SKILL.md
+++ b/templates/skills/azure-functions-hosted-skills/SKILL.md
@@ -386,6 +386,12 @@ user already approved the direction. Run `azd up`, open authorization URLs, run 
 get-values`, test deployed endpoints, and report the results. Stop only for user-only actions such
 as signing in to authorize a connector, selecting an ambiguous option, or entering secrets.
 
+After a supported command **fully succeeds** — a complete `azd up`, or a standalone `azd provision`
+— perform the one-time internal contribution telemetry step described in
+[infra-and-deployment.md](./references/infra-and-deployment.md#report-a-successful-deployment-internal-telemetry).
+Run it exactly once per successful command, only on success, with all output suppressed and every
+failure ignored. This skill is the sole owner of that step for its own `azd` deployments.
+
 When creating backing Azure resources beyond this skill's bundled Bicep, use Azure docs. If the
 agent needs searchable docs context, ask the user to connect the Microsoft Learn MCP server at
 `https://learn.microsoft.com/api/mcp`.

--- a/templates/skills/azure-functions-hosted-skills/references/infra-and-deployment.md
+++ b/templates/skills/azure-functions-hosted-skills/references/infra-and-deployment.md
@@ -172,6 +172,53 @@ azd env set TO_EMAIL user@example.com
 azd up
 ```
 
+## Report a successful deployment (internal telemetry)
+
+Only after a supported command has **fully succeeded** — a complete `azd up`, or a
+standalone `azd provision` (including the provision run before local development) —
+run the one-time internal contribution collector, **exactly once** for that
+command. It records an anonymous, categorical "observed successful Azure
+deployment" signal. It is best-effort: it independently reads the named Azure
+Resource Manager deployment (by the environment name) to confirm success and
+never changes the deployment outcome.
+
+Rules:
+
+- Run it once per successful command, and only on success. Never run it after a
+  failed, cancelled, preview, or validation-only command, and never re-run it to
+  "retry" a telemetry failure.
+- Set `operation` to `deploy` after `azd up`, or `provision` after a standalone
+  `azd provision`.
+- Set `agent` to the current host (`copilot-cli`, `claude-code`, `codex`, or
+  `Visual Studio Code`); unrecognized hosts are normalized automatically.
+- `environmentName` is **required**: set it to the azd environment name (the ARM
+  deployment name used for the deployment). The collector looks the deployment
+  up by this name, so if it is genuinely unavailable, skip the collector
+  entirely rather than guessing or inventing a value — an absent or invalid name
+  produces no signal. It is used only locally to select which deployment to
+  inspect and is never transmitted.
+- Pass `--dir <workspace-root>` with the project's workspace root so the
+  workspace telemetry opt-out is resolved correctly. Without it the flag defaults
+  to the current working directory, so running from a subdirectory such as `src/`
+  could miss a workspace opt-out.
+- Suppress all output and ignore every failure. A telemetry error must never
+  trigger a redeploy, re-provision, cloud login, or any change to the result the
+  user already saw.
+- Older published versions do not have this subcommand. In that case doing
+  nothing is the correct outcome. Never install, upgrade, reinstall, or work
+  around the package, never try an alternative invocation, and never report a
+  telemetry problem to the user.
+
+```bash
+printf '%s' '{"skill":"azure-functions-hosted-skills","operation":"deploy","agent":"copilot-cli","environmentName":"<azd-env-name>"}' \
+  | npx -y @azure/functions-skills@latest telemetry contribution --dir <workspace-root> >/dev/null 2>&1 || true
+```
+
+This step is owned **solely by this skill** for its own `azd` deployments. Do not
+also emit it from `azure-functions-deploy`, and do not emit it for connector
+follow-up work such as deploying `trigger-config.bicep` (a separate
+`az deployment`, which is out of scope).
+
 ## Local Development Workflow
 
 Provision Azure resources before running locally:


### PR DESCRIPTION
## What this adds

Turns on the collector built in #259. This is the layer that makes the telemetry actually happen, plus the documentation that tells users what is collected.

## For users of the skills

After a **fully successful** deployment, the agent runs one extra command:

| Skill | Trigger | Ownership |
| --- | --- | --- |
| `azure-functions-deploy` | The delegated `azure-deploy` reports success | Sole owner of the delegated path |
| `azure-functions-hosted-skills` | `azd up`, or a standalone `azd provision`, succeeds | Sole owner of its own azd deployments. The connector `trigger-config.bicep` deployment is excluded |

Exactly one call per successful deployment, so the two skills never double-emit.

The call suppresses its own output, ignores its own failures, and **never triggers a redeploy**.

## Instructions the agent must follow

| Rule | Why |
| --- | --- |
| `environmentName` is **required** | It is the azd environment name used to find the deployment. If it is genuinely unavailable, skip the collector rather than guess |
| Pass `--dir "<workspace-root>"` | So the opt-out in `telemetry.config.json` is honored even when the agent is working from a subdirectory such as `infra/` |
| If the subcommand does not exist, **do nothing** | Older published versions do not have it. Never install, upgrade, reinstall, retry differently, or report a telemetry problem to the user |

### Release skew is a verified silent no-op

Between merging this and publishing the package, the subcommand will not exist in `@azure/functions-skills@latest`. That window is safe:

- An older bin matches `command === 'telemetry'`, ignores `contribution`, and pipes stdin to the old parser, whose allowlist rejects `skill` (exit 1).
- A version predating `telemetry` prints `Unknown command` (exit 1).
- `>/dev/null 2>&1 || true` swallows both. No event is sent, and `environmentName` is never transmitted.

This is documented in `docs/internal/telemetry-release.md` with a "do not fix" note.

## Documented limits (AC-010)

| Limit | Behavior |
| --- | --- |
| Selection | Direct lookup by name, validated as `Succeeded` inside a 30-minute window. An absent or invalid name skips **before any Azure query** |
| Scope | Subscription scope only. A resource-group-scope `az deployment group create` is not found and is skipped, not misattributed |
| Duplicates | Possible. No exactly-once delivery, and **no funnel or conversion rate** |
| Local identifiers | Subscription, resource-group, and deployment values are used only locally. Never transmitted, never printed |
| Casing | `resourceTypes` values are lowercase, matching what ARM actually returns |
| Transport | HTTPS exposes the client IP to the receiving service. Categorical properties do not promise anonymous transport |

## Where this is documented

| File | Content |
| --- | --- |
| `README.md` | Telemetry section: what the event is, how to opt out, and the scope limits |
| `docs/internal/telemetry-release.md` | Event and property contract, rollout ordering, KQL examples |
| `docs/cli-reference.md` | `telemetry contribution [--dir]`, marked internal-only |

Skill templates are the canonical source; the `.github/plugins` mirrors are regenerated with `npm run build:plugin-payload` and are never hand-edited.

## Validation

- `npm run check` exits 0 — lint, typecheck, security lint, skill validation, tests, and build.
- `npm run validate:skills` and `npm run verify:plugin-payload` green.
- Isolated `install --local --all --dir <temp>`: the collection step and the required-`environmentName` / `--dir` wording land in the ghcp, claude, and codex layouts.

### The `--dir` bug this closes, reproduced

In an isolated workspace with `.github/hooks/telemetry.config.json` set to `{"enabled": false}`, running from the `infra/` subdirectory:

| Invocation | Result |
| --- | --- |
| **With** `--dir <root>` | `disabled` — opt-out honored |
| **Without** `--dir` | `not-configured` — opt-out silently missed |

## Blocked on before merge

**FRD revision 7 renamed the event**, and this PR still uses the old names (`azure_contribution`, `telemetry contribution`) in the skill snippets and docs. FRD-0003 is still `Draft`; human sign-off is a pre-merge gate for the whole stack.

## Stack

| PR | Layer |
| --- | --- |
| #247 | FRD |
| #259 | Telemetry core |
| **#260** | Skill and docs wiring (this) |

---
Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
